### PR TITLE
Ip address set decide rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-*.class
-bin
-commons/target
-dist/target
-engine/target
-modules/target
-hq/target

--- a/modules/src/main/java/org/archive/modules/deciderules/IpAddressSetDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/IpAddressSetDecideRule.java
@@ -78,9 +78,13 @@ public class IpAddressSetDecideRule extends PredicatedDecideRule {
         // TODO:FIXME: have fetcher insert exact IP contacted into curi,
         // use that rather than inferred by CrawlHost lookup 
         CrawlHost crlh = getServerCache().getHostFor(curi.getUURI());
-        if (crlh == null) { return null; }
+        if (crlh == null) {
+            return null;
+        }
         InetAddress inetadd = crlh.getIP();
-        if (inetadd == null) { return null; }
+        if (inetadd == null) {
+            return null;
+        }
         return inetadd.getHostAddress();
     }
 }


### PR DESCRIPTION
A webmaster requested we stop crawling three ip addresses. Given no domain information, it has become necessary to write the overdue decide rule to scope based on ip address.
