### PR TITLE
ScriptedDecideRule#getEngine() rewrite for better synchronization and thread local mgmt

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/ScriptedDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/ScriptedDecideRule.java
@@ -141,21 +141,23 @@ implements ApplicationContextAware, InitializingBean {
      * to this thread. 
      * @return ScriptEngine to use
      */
-    protected synchronized ScriptEngine getEngine() {
-        if(sharedEngine==null 
-           && getIsolateThreads()) {
-            // initialize
-            sharedEngine = newEngine();
+    protected ScriptEngine getEngine() {
+        if (getIsolateThreads()) {
+            ScriptEngine engine = threadEngine.get(); 
+            if(engine==null) {
+                engine = newEngine(); 
+                threadEngine.set(engine);
+            }
+            return engine;
         }
-        if(sharedEngine!=null) {
-            return sharedEngine;
+        
+        // sharing the engine
+        synchronized(this) {
+            if (sharedEngine == null)
+                sharedEngine = newEngine();
+            assert sharedEngine != null;
         }
-        ScriptEngine engine = threadEngine.get(); 
-        if(engine==null) {
-            engine = newEngine(); 
-            threadEngine.set(engine);
-        }
-        return engine; 
+        return sharedEngine;
     }
 
     /**


### PR DESCRIPTION
Previously the whole method was synchronized even if threadlocals
were used (which are thread safe). And previously the sharedEngine
was set and returned only when it /was not/ needed ie when
getIsolateThreads() returned true.

Now getEngine does what it says it does.

This bug likely would be difficult to notice, as using thread local threadEngine instead of the sharedEngine would not cause major exceptions, and the class has not seen extensive use inside the Internet Archive to my knowledge anyhow.
