### PR TITLE
have TooManyPathSegmentsDecideRule count path segments only

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/TooManyPathSegmentsDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/TooManyPathSegmentsDecideRule.java
@@ -63,11 +63,11 @@ public class TooManyPathSegmentsDecideRule extends PredicatedDecideRule {
      */
     @Override
     protected boolean evaluate(CrawlURI curi) {
-        String uri = curi.toString();
+        String uriPath = curi.getUURI().getEscapedPath();
         int count = 0;
         int threshold = getMaxPathDepth();
-        for (int i = 0; i < uri.length(); i++) {
-            if (uri.charAt(i) == '/') {
+        for (int i = 0; i < uriPath.length(); i++) {
+            if (uriPath.charAt(i) == '/') {
                 count++;
             }
             if (count > threshold) {


### PR DESCRIPTION
- TooManyPathSegmentsDecideRule
  evaluate(CrawlURI) previously counted slashes in the full URI.
  Now it only counts slashes in the path of the URI, meaning a URI
  with slashes in the query string will not be counted as having more
  path segments than it has in its path.
