### PR TITLE
Fix for HER-2017 XML representation of beans uses root node of type "script"

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
@@ -123,7 +123,7 @@ public class BeanBrowseResource extends JobRelatedResource {
         if (variant.getMediaType() == MediaType.APPLICATION_XML) {
             representation = new WriterRepresentation(MediaType.APPLICATION_XML) {
                 public void write(Writer writer) throws IOException {
-                    XmlMarshaller.marshalDocument(writer, "script", makePresentableMap());
+                    XmlMarshaller.marshalDocument(writer, "beans", makePresentableMap());
                 }
             };
         } else {


### PR DESCRIPTION
- BeanBrowseResource.java  
  replaced "script" string in root node with "beans"
