### PR TITLE
Fix for HER-2018: XML representation for /engine/job/<jobName>/beans returns incorrect url for named beans

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -92,6 +92,9 @@ public abstract class JobRelatedResource extends BaseResource {
         }
 
         Reference baseRef = getRequest().getResourceRef().getBaseRef();
+        
+        if(baseRef.getPath().endsWith("beans"))
+            baseRef.setPath(baseRef.getPath()+"/");
 
         if (getBeanToNameMap().containsKey(obj)) {
             // this object is itself a named bean
@@ -274,7 +277,7 @@ public abstract class JobRelatedResource extends BaseResource {
                 } else if (beanPathPrefix.endsWith("[")) {
                     beanPath += field + "]";
                 }
-                info.put("url", new Reference(baseRef, "../beans/" + beanPath).getTargetRef());
+                info.put("url", new Reference(baseRef, "../beans/" + TextUtils.urlEscape(beanPath)).getTargetRef());
             }
         }
         String key = getBeanToNameMap().get(object);


### PR DESCRIPTION
- JobRelatedResource.java  
  Added encoding to URL generation in makePresentableMapFor()  
  Added check to prevent URL generation from overwriting the job name portion of the path in addPresentableNestedNames()
