### PR TITLE
Fix HER-2023: ARCRecord.readHttpHeader() fails if HTTP response lacks empty line between HTTP headers and HTTP body.

### DIFF
--- a/commons/src/main/java/org/archive/io/arc/ARCRecord.java
+++ b/commons/src/main/java/org/archive/io/arc/ARCRecord.java
@@ -649,8 +649,6 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
         // Read the status line.  Don't let it into the parseHeaders function.
         // It doesn't know what to do with it.
         bais.read(statusBytes, 0, statusBytes.length);
-        this.httpHeaders = HttpParser.parseHeaders(bais,
-            ARCConstants.DEFAULT_ENCODING);
         this.getMetaData().setStatusCode(Integer.toString(getStatusCode()));
         bais.reset();
         return bais;


### PR DESCRIPTION
The fix is to remove the unnecessary call to HttpParser.parseHeaders().  AFAICT, the parsed headers are never used (?).  We still want the HTTP _status_ line parsed of course, but not the rest of the headers.
