### PR TITLE
make http proxy port configurable in cxml, avoiding this: org.springfram...

### DIFF
--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
@@ -318,8 +318,8 @@ public class FetchHTTP extends Processor implements Lifecycle {
     /**
      * Proxy port (set only if needed).
      */
-    public void setHttpProxyPort(int port) {
-        kp.put("httpProxyPort",port);
+    public void setHttpProxyPort(Integer port) {
+        kp.put("httpProxyPort", port);
     }
 
     public String getHttpProxyUser() {


### PR DESCRIPTION
...ework.beans.NotWritablePropertyException: Invalid property 'httpProxyPort' of bean class [org.archive.modules.fetcher.FetchHTTP]: Bean property 'httpProxyPort' is not writable or has an invalid setter method. Did you mean 'httpProxyHost'?
