### PR TITLE
whoops! send escaped path+query on http request line; had been sending r...

### DIFF
--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -167,7 +167,7 @@ class FetchHTTPRequest {
             this.requestConfigBuilder.setProxy(this.proxyHost);
             requestLineUri = curi.getUURI().toString();
         } else {
-            requestLineUri = curi.getUURI().getPathQuery();
+            requestLineUri = curi.getUURI().getEscapedPathQuery();
         }
 
         if (curi.getFetchType() == FetchType.HTTP_POST) {

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -763,6 +763,18 @@ public class FetchHTTPTests extends ProcessorTestBase {
         assertTrue(httpRequestString(curi).startsWith("GET /??blahblah HTTP/1.0\r\n"));
         runDefaultChecks(curi, "requestLine");
     }
+    
+    public void testUrlWithSpaces() throws Exception {
+        CrawlURI curi = makeCrawlURI("http://localhost:7777/url with spaces");
+        fetcher().process(curi);
+        assertTrue(httpRequestString(curi).startsWith("GET /url%20with%20spaces HTTP/1.0\r\n"));
+        runDefaultChecks(curi, "requestLine");
+
+        curi = makeCrawlURI("http://localhost:7777/url%20with%20spaces");
+        fetcher().process(curi);
+        assertTrue(httpRequestString(curi).startsWith("GET /url%20with%20spaces HTTP/1.0\r\n"));
+        runDefaultChecks(curi, "requestLine");
+    }
 
     @Override
     protected FetchHTTP makeModule() throws IOException {


### PR DESCRIPTION
...aw spaces (includes unit test)
