### PR TITLE
Avoid the exception below by handling bad charsets in FetchHTTP. Restore...

### DIFF
--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
@@ -29,7 +29,6 @@ import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_REFERENCE_
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -584,7 +583,8 @@ public class FetchHTTP extends Processor implements Lifecycle {
             if (charset != null) {
                 rec.setCharset(charset);
             }
-        } catch (UnsupportedCharsetException e) {
+        } catch (IllegalArgumentException e) {
+            // exception could be UnsupportedCharsetException or IllegalCharsetNameException
             String unsatisfiableCharset;
             try {
                 unsatisfiableCharset = response.getFirstHeader("content-type").getElements()[0].getParameterByName("charset").getValue();

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
@@ -184,8 +184,15 @@ public class FetchHTTPTest extends ProcessorTestBase {
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.getOutputStream().write(CP1251_PAYLOAD);
                 ((Request)request).setHandled(true);
-            } else if (target.equals("/bad-charset")) {
-                response.setContentType("text/plain;charset=BAD-CHARSET");
+            } else if (target.equals("/unsupported-charset")) {
+                response.setContentType("text/plain;charset=UNSUPPORTED-CHARSET");
+                response.setDateHeader("Last-Modified", 0);
+                response.setHeader("ETag", ETAG_TEST_VALUE);
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.getOutputStream().write(DEFAULT_PAYLOAD_STRING.getBytes("US-ASCII"));
+                ((Request)request).setHandled(true);
+            } else if (target.equals("/invalid-charset")) {
+                response.setContentType("text/plain;charset=%%INVALID-CHARSET%%");
                 response.setDateHeader("Last-Modified", 0);
                 response.setHeader("ETag", ETAG_TEST_VALUE);
                 response.setStatus(HttpServletResponse.SC_OK);

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -806,10 +806,17 @@ public class FetchHTTPTests extends ProcessorTestBase {
                 + "\u0438\u043E\u0432.\n", 
                 curi.getRecorder().getContentReplayCharSequence().toString());
 
-        curi = makeCrawlURI("http://localhost:7777/bad-charset");
+        curi = makeCrawlURI("http://localhost:7777/unsupported-charset");
         fetcher().process(curi);
-        assertEquals("text/plain;charset=BAD-CHARSET", curi.getHttpResponseHeader("content-type"));
-        assertTrue(curi.getAnnotations().contains("unsatisfiableCharsetInHeader:BAD-CHARSET"));
+        assertEquals("text/plain;charset=UNSUPPORTED-CHARSET", curi.getHttpResponseHeader("content-type"));
+        assertTrue(curi.getAnnotations().contains("unsatisfiableCharsetInHeader:UNSUPPORTED-CHARSET"));
+        assertEquals(Charset.forName("latin1"), curi.getRecorder().getCharset()); // default fallback
+        runDefaultChecks(curi, "requestLine", "contentType");
+        
+        curi = makeCrawlURI("http://localhost:7777/invalid-charset");
+        fetcher().process(curi);
+        assertEquals("text/plain;charset=%%INVALID-CHARSET%%", curi.getHttpResponseHeader("content-type"));
+        assertTrue(curi.getAnnotations().contains("unsatisfiableCharsetInHeader:%%INVALID-CHARSET%%"));
         assertEquals(Charset.forName("latin1"), curi.getRecorder().getCharset()); // default fallback
         runDefaultChecks(curi, "requestLine", "contentType");
     }


### PR DESCRIPTION
... annotation "unsatisfiableCharsetInHeader:...". Includes unit tests for good and bad charsets.

SEVERE thread-5973 org.archive.crawler.framework.ToeThread.recoverableProblem() Problem java.nio.charset.UnsupportedCharsetException: binary occured when trying to process 'http://example.com/' at step ABOUT_TO_BEGIN_PROCESSOR in
java.nio.charset.UnsupportedCharsetException: binary
        at java.nio.charset.Charset.forName(Charset.java:543)
        at org.apache.http.entity.ContentType.<init>(ContentType.java:111)
        at org.apache.http.entity.ContentType.create(ContentType.java:210)
        at org.apache.http.entity.ContentType.get(ContentType.java:258)
        at org.apache.http.entity.ContentType.getOrDefault(ContentType.java:277)
        at org.archive.modules.fetcher.FetchHTTP.setCharacterEncoding(FetchHTTP.java:580)
        at org.archive.modules.fetcher.FetchHTTP.innerProcess(FetchHTTP.java:693)
        at org.archive.modules.Processor.innerProcessResult(Processor.java:175)
        at org.archive.modules.Processor.process(Processor.java:142)
        at org.archive.modules.ProcessorChain.process(ProcessorChain.java:131)
        at org.archive.crawler.framework.ToeThread.run(ToeThread.java:148)
