### PR TITLE
fix job.log file handler was left open when jobdir is removed

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
@@ -132,9 +132,9 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
         if(jobLogger == null) {
             jobLogger = Logger.getLogger(getShortName());
             try {
-                Handler h = new FileHandler(getJobLog().getAbsolutePath(),true);
-                h.setFormatter(new JobLogFormatter());
-                jobLogger.addHandler(h);
+                mainJobLogHandler = new FileHandler(getJobLog().getAbsolutePath(),true);
+                mainJobLogHandler.setFormatter(new JobLogFormatter());
+                jobLogger.addHandler(mainJobLogHandler);
             } catch (SecurityException e) {
                 throw new RuntimeException(e);
             } catch (IOException e) {
@@ -145,18 +145,6 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
         return jobLogger;
     }
 
-	/**
-	 * Cleanup when jobdir is removed. closes job.log file
-	 */
-	public void cleanup() {
-		Logger jobLogLogger = getJobLogger();
-		Handler[] handlers = jobLogLogger.getHandlers();
-		for(Handler handler: handlers) {
-			jobLogLogger.removeHandler(handler);
-			handler.close();
-		}
-	}
-    
     public DateTime getLastLaunch() {
         return lastLaunch;
     }
@@ -454,6 +442,7 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
         }
     }
     
+    protected transient Handler mainJobLogHandler;
     protected transient Handler currentLaunchJobLogHandler;
 
     protected boolean needTeardown = false;
@@ -593,7 +582,14 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
                 currentLaunchJobLogHandler = null;
             }
 
-            getJobLogger().log(Level.INFO,"Job instance discarded");
+            getJobLogger().log(Level.INFO, "Job instance discarded");
+            
+            if (mainJobLogHandler != null) {
+                getJobLogger().removeHandler(mainJobLogHandler);
+                mainJobLogHandler.close();
+                mainJobLogHandler = null;
+            }
+            jobLogger = null;
         }
     }
 

--- a/engine/src/main/java/org/archive/crawler/framework/Engine.java
+++ b/engine/src/main/java/org/archive/crawler/framework/Engine.java
@@ -86,8 +86,6 @@ public class Engine {
         for(String jobName: jobConfigs.keySet().toArray(new String[0])) {
             CrawlJob cj = jobConfigs.get(jobName);
             if(!cj.getJobDir().exists()) {
-				CrawlJob job = jobConfigs.get(jobName);
-				job.cleanup();
                 jobConfigs.remove(jobName); 
             }
         }


### PR DESCRIPTION
When a jobdir is removed the job.log file handler is being left open. This will close the job.log when a job re-scan is done. You can test it by deleting a jobdir and then running `sudo lsof -p <pid> | grep job.log`
