### PR TITLE
Implicitly add the ${} around groovyExpression. When cxml contains ${}, ...

### DIFF
--- a/contrib/src/main/java/org/archive/modules/deciderules/ExpressionDecideRule.java
+++ b/contrib/src/main/java/org/archive/modules/deciderules/ExpressionDecideRule.java
@@ -31,7 +31,7 @@ import org.archive.modules.CrawlURI;
 /**
  * Example usage:
  * <pre> &lt;bean class="org.archive.modules.deciderules.ExpressionDecideRule">
- *     &lt;property name="groovyExpression" value='${curi.via == null &amp;&amp; curi ==~ "^https?://(?:www\\.)?(facebook|vimeo|flickr)\\.com/.*"}'/>
+ *     &lt;property name="groovyExpression" value='curi.via == null &amp;amp;&amp;amp; curi ==~ "^https?://(?:www\\.)?(facebook|vimeo|flickr)\\.com/.*"'/>
  * &lt/bean></pre>
  *
  * @contributor nlevitt
@@ -58,7 +58,7 @@ public class ExpressionDecideRule extends PredicatedDecideRule {
 
         if (groovyTemplate == null) {
             try {
-                groovyTemplate = new SimpleTemplateEngine().createTemplate(getGroovyExpression());
+                groovyTemplate = new SimpleTemplateEngine().createTemplate("${" + getGroovyExpression() + "}");
                 groovyTemplates.put(getGroovyExpression(), groovyTemplate);
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "problem with groovy expression " + getGroovyExpression(), e);


### PR DESCRIPTION
...it fights with spring's PropertyPlaceholderConfigurer (if enabled); and since what we're interested in is an expression, not a template for producing a string, it's more appropriate to leave it out anyway.
