### PR TITLE
make ExpressionDecideRule a plain DecideRule that returns ACCEPT when th...

### DIFF
--- a/contrib/src/main/java/org/archive/modules/deciderules/ExpressionDecideRule.java
+++ b/contrib/src/main/java/org/archive/modules/deciderules/ExpressionDecideRule.java
@@ -36,7 +36,7 @@ import org.archive.modules.CrawlURI;
  *
  * @contributor nlevitt
  */
-public class ExpressionDecideRule extends PredicatedDecideRule {
+public class ExpressionDecideRule extends DecideRule {
     private static final long serialVersionUID = 1L;
 
     private static final Logger logger =
@@ -68,10 +68,19 @@ public class ExpressionDecideRule extends PredicatedDecideRule {
         return groovyTemplate;
     }
 
-    @Override
     protected boolean evaluate(CrawlURI curi) {
         HashMap<String, Object> binding = new HashMap<String, Object>();
         binding.put("curi", curi);
-        return String.valueOf(true).equals(groovyTemplate().make(binding).toString());
+        String expressionResult = groovyTemplate().make(binding).toString();
+        return String.valueOf(true).equals(expressionResult);
+    }
+
+    @Override
+    protected DecideResult innerDecide(CrawlURI curi) {
+        if (evaluate(curi)) {
+            return DecideResult.ACCEPT;
+        } else {
+            return DecideResult.REJECT;
+        }
     }
 }


### PR DESCRIPTION
...e expression evaluates true and REJECT if not, which I think is more intuitive and more appropriate in this case

For example, Processor#shouldProcessRule accepts urls if the DecideRule returns ACCEPT or PASS, and only rejects on explicit REJECT. So if ExpressionDecideRule were a PredicatedDecideRule, if you wrote your shouldProcessRule as an ACCEPT rule, it turns out that all urls get processed. Only by inverting the logic of the rule and setting decision=REJECT will it work as expected. That seems undesirable.
