### PR TITLE
avoid calling CheckpointService.hasAvailableCheckpoints() when crawl not...

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
@@ -127,7 +127,7 @@ public class CrawlJobModel extends LinkedHashMap<String, Object> implements Seri
         
         List<String> checkpointFiles = new ArrayList<String>();
         if (crawlJob.getCheckpointService() != null) {
-            if (crawlJob.getCheckpointService().hasAvailableCheckpoints() && crawlJob.isLaunchable()) {
+            if (crawlJob.isLaunchable() && crawlJob.getCheckpointService().hasAvailableCheckpoints()) {
                 for (File f : crawlJob.getCheckpointService().findAvailableCheckpointDirectories()) {
                     checkpointFiles.add(f.getName()); 
                 }


### PR DESCRIPTION
... launchable and therefore the info is not needed, because it calls isRunning() which is synchronized and blocks when checkpoint is in progress
