### PR TITLE
do not require "+" (plus sign) before @OPERATOR_CONTACT_URL@ in user-age...

### DIFF
--- a/modules/src/main/java/org/archive/modules/CrawlMetadata.java
+++ b/modules/src/main/java/org/archive/modules/CrawlMetadata.java
@@ -201,7 +201,7 @@ implements UserAgentProvider,
     protected static Validator VALIDATOR = new BeanFieldsPatternValidator(
             CrawlMetadata.class,
             "userAgentTemplate", 
-            "^.*\\@OPERATOR_CONTACT_URL@.*$", 
+            "^.*@OPERATOR_CONTACT_URL@.*$", 
             "You must supply a userAgentTemplate value that includes " +
             "the string \"@OPERATOR_CONTACT_URL@\" where your crawl" +
             "contact URL will appear.",


### PR DESCRIPTION
...nt -- many bots including googlebot have the +, but some don't, so having it in the default template seems sufficient
