### PR TITLE
FIX corner-case of bean browser failing due to an exception from hashCode()

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -111,8 +111,19 @@ public abstract class JobRelatedResource extends BaseResource {
             namedBeans = new LinkedList<Object>();
             bean.put("children", namedBeans);
         }
-        
-        if (!alreadyWritten.contains(obj)) {
+        // alreadyWritten.contains() can fail on exception from hashCode()
+        // method. For example, ArrayList.hashCode() iterates over elements
+        // to compute hash. It can fail with ConcurrentModificationException.
+        // We need to use a set based on object identity, instead of regular
+        // java.util.Set which is equals-based.  For now, error from contains()
+        // is simply ignored (assuming not written).
+        boolean writtenBefore = false;
+        try {
+        	writtenBefore = alreadyWritten.contains(obj);
+        } catch (Exception ex) {
+        	// pass
+        }
+        if (!writtenBefore) {
             alreadyWritten.add(obj);
 
             BeanWrapperImpl bwrap = new BeanWrapperImpl(obj);


### PR DESCRIPTION
I know this is a corner-case, but when a bean exposes an object as a property whose `hashCode()` method can fail, it kills entire bean browser. For example, with an ArrayList being changed at high frequency, its `hashCode()` can throw `ConcurrentModificationExcpetion`.

Doing object-identity based test for  `alreadyWritten` will fix it, but I don't know the good way to implement it (there's `System.identityHashCode(Object)`, but there's no real guarantee for uniqueness). For now, this patch simply catches exceptions from `hashCode()` and assumes it's never seen before.
