### PR TITLE
avoid deadlock in AMQPUrlReceiver hopefully

### DIFF
--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -107,7 +107,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
         return isRunning;
     }
     
-    private transient Lock lock = new ReentrantLock();
+    private transient Lock lock = new ReentrantLock(true);
 
     private class StarterRestarter extends Thread {
         public StarterRestarter(String name) {
@@ -121,17 +121,15 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                     lock.lockInterruptibly();
                     if (!isRunning) {
                         // start up again
-                        synchronized (AMQPUrlReceiver.this) {
-                            try {
-                                Consumer consumer = new UrlConsumer(channel());
-                                channel().queueDeclare(getQueueName(), false, false, true, null);
-                                channel().queueBind(getQueueName(), getExchange(), getQueueName());
-                                channel().basicConsume(getQueueName(), false, consumer);
-                                isRunning = true;
-                                logger.info("started AMQP consumer uri=" + getAmqpUri() + " exchange=" + getExchange() + " queueName=" + getQueueName());
-                            } catch (IOException e) {
-                                logger.log(Level.SEVERE, "problem starting AMQP consumer (will try again after 30 seconds)", e);
-                            }
+                        try {
+                            Consumer consumer = new UrlConsumer(channel());
+                            channel().queueDeclare(getQueueName(), false, false, true, null);
+                            channel().queueBind(getQueueName(), getExchange(), getQueueName());
+                            channel().basicConsume(getQueueName(), false, consumer);
+                            isRunning = true;
+                            logger.info("started AMQP consumer uri=" + getAmqpUri() + " exchange=" + getExchange() + " queueName=" + getQueueName());
+                        } catch (IOException e) {
+                            logger.log(Level.SEVERE, "problem starting AMQP consumer (will try again after 30 seconds)", e);
                         }
                     }
 


### PR DESCRIPTION
Use interruptible locking in the one spot where it's needed to avoid this deadlock.

```
"AMQPUrlReceiver-starter-restarter" prio=10 tid=0x00007f62bd0dc000 nid=0x27b5 waiting for monitor entry [0x00007f62ec319000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at org.archive.crawler.frontier.AMQPUrlReceiver$StarterRestarter.run(AMQPUrlReceiver.java:119)
        - waiting to lock <0x00000000cbcecb98> (a org.archive.crawler.frontier.AMQPUrlReceiver)

"org.archive.crawler.frontier.BdbFrontier@4c2d0c64.managerThread" prio=10 tid=0x00007f62bd471000 nid=0x27ae in Object.wait() [0x00007f62adbda000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x00000000cc491e00> (a org.archive.crawler.frontier.AMQPUrlReceiver$StarterRestarter)
        at java.lang.Thread.join(Thread.java:1281)
        - locked <0x00000000cc491e00> (a org.archive.crawler.frontier.AMQPUrlReceiver$StarterRestarter)
        at java.lang.Thread.join(Thread.java:1355)
        at org.archive.crawler.frontier.AMQPUrlReceiver.stop(AMQPUrlReceiver.java:164)
        - locked <0x00000000cbcecb98> (a org.archive.crawler.frontier.AMQPUrlReceiver)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStop(DefaultLifecycleProcessor.java:236)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStop(DefaultLifecycleProcessor.java:213)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStop(DefaultLifecycleProcessor.java:213)
        at org.springframework.context.support.DefaultLifecycleProcessor.access$2(DefaultLifecycleProcessor.java:206)
        at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.stop(DefaultLifecycleProcessor.java:352)
        at org.springframework.context.support.DefaultLifecycleProcessor.stopBeans(DefaultLifecycleProcessor.java:195)
        at org.springframework.context.support.DefaultLifecycleProcessor.stop(DefaultLifecycleProcessor.java:103)
        at org.springframework.context.support.AbstractApplicationContext.stop(AbstractApplicationContext.java:1241)
        at org.archive.crawler.framework.CrawlController.completeStop(CrawlController.java:392)
        at org.archive.crawler.framework.CrawlController.noteFrontierState(CrawlController.java:663)
        at org.archive.crawler.frontier.AbstractFrontier.reachedState(AbstractFrontier.java:442)
        at org.archive.crawler.frontier.AbstractFrontier.managementTasks(AbstractFrontier.java:399)
        at org.archive.crawler.frontier.AbstractFrontier$1.run(AbstractFrontier.java:316)
```
