### PR TITLE
CandidatesProcessor.java

### DIFF
--- a/engine/src/main/java/org/archive/crawler/postprocessor/CandidatesProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/postprocessor/CandidatesProcessor.java
@@ -230,7 +230,7 @@ public class CandidatesProcessor extends Processor {
             runCandidateChain(candidate, curi);
 
         }
-        curi.getOutLinks().clear();
+
     }
     
     /**


### PR DESCRIPTION
Fix for HER-2076 - Keep CrawlURI outlinks intact for use in SeedRecord reporting.
