### PR TITLE
Upgrade to HttpClient 4.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.3.3</version>
+				<version>4.3.6</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Upgrade HttpClient library to [4.3.6](https://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.3.x.txt). This resolves an issue with the library [where null cookies could trigger NPEs](https://issues.apache.org/jira/browse/HTTPCLIENT-1544).
The only caveat about this upgrade is the following from the 4.3.6 [release notes](https://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.3.x.txt):

```
SSLv3 protocol is disabled by default
```
