### PR TITLE
Set character set to UTF-8 when passing through files.

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
@@ -107,6 +107,12 @@ public class EnhDirectoryResource extends DirectoryResource {
                     };
                 }
             }
+        } else {
+            ListIterator<Variant> iter = variants.listIterator(); 
+            while(iter.hasNext()) {
+                Variant v = iter.next();
+                v.setCharacterSet(CharacterSet.UTF_8);
+            }
         }
         
         return variants; 


### PR DESCRIPTION
The default character encoding for file in Java is UTF-8. Since Heritrix never overrides this when writing logs and reports those files are encoded in UTF-8.

The restlets, however, assume a default character encoding of iso-8861-1. This means that reports and logs are presented using the wrong character set when viewed through the Heritrix GUI.

Most of the time this isn't an issue as Heritrix mostly uses the basic ASCII character set. It can however be an issue for customized reports/logs.