### PR TITLE
make sure log4j is configured when running unit tests, to avoid log4j er...

### DIFF
--- a/commons/src/test/resources/log4j.xml
+++ b/commons/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.archive.util.OneLineSimpleLayout" />
+	</appender>
+
+	<logger name="org.apache.commons.httpclient">
+		<level value="ERROR" />
+	</logger>
+
+	<root>
+		<level value="WARN" /> 
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/contrib/src/test/resources/log4j.xml
+++ b/contrib/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.archive.util.OneLineSimpleLayout" />
+	</appender>
+
+	<logger name="org.apache.commons.httpclient">
+		<level value="ERROR" />
+	</logger>
+
+	<root>
+		<level value="WARN" /> 
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/dist/src/test/resources/log4j.xml
+++ b/dist/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.archive.util.OneLineSimpleLayout" />
+	</appender>
+
+	<logger name="org.apache.commons.httpclient">
+		<level value="ERROR" />
+	</logger>
+
+	<root>
+		<level value="WARN" /> 
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/engine/src/test/resources/log4j.xml
+++ b/engine/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.archive.util.OneLineSimpleLayout" />
+	</appender>
+
+	<logger name="org.apache.commons.httpclient">
+		<level value="ERROR" />
+	</logger>
+
+	<root>
+		<level value="WARN" /> 
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/modules/src/test/resources/log4j.xml
+++ b/modules/src/test/resources/log4j.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.archive.util.OneLineSimpleLayout" />
+	</appender>
+
+	<logger name="org.apache.commons.httpclient">
+		<level value="ERROR" />
+	</logger>
+
+	<root>
+		<level value="WARN" /> 
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>


### PR DESCRIPTION
...ror messages polluting captured output and causing tests to fail, like so: https://builds.archive.org/job/Heritrix-3/org.archive.heritrix$heritrix-commons/587/testReport/org.archive.io.arc/ARCWriterTest/testLengthTooLongCompressed/