### PR TITLE
Fix for ServerNotModified WARC revisit records incorrectly record WARC-Payload-Digest

### DIFF
--- a/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
+++ b/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
@@ -107,9 +107,13 @@ public class FetchHistoryProcessor extends Processor {
         curi.getData().put(A_FETCH_HISTORY, history);
 
         if (curi.getFetchStatus() == 304) {
+        	// Copy forward the content digest as the current digest is simply of an empty response
+        	latestFetch.put(A_CONTENT_DIGEST, history[1].get(A_CONTENT_DIGEST));
+        	// Create revisit profile
             ServerNotModifiedRevisit revisit = new ServerNotModifiedRevisit();
             revisit.setETag((String) latestFetch.get(A_ETAG_HEADER));
             revisit.setLastModified((String) latestFetch.get(A_LAST_MODIFIED_HEADER));
+            revisit.setPayloadDigest((String)latestFetch.get(A_CONTENT_DIGEST));
             curi.setRevisitProfile(revisit);
         } else if (hasIdenticalDigest(curi)) {
             curi.getAnnotations().add("duplicate:digest");

--- a/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
+++ b/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
@@ -107,9 +107,9 @@ public class FetchHistoryProcessor extends Processor {
         curi.getData().put(A_FETCH_HISTORY, history);
 
         if (curi.getFetchStatus() == 304) {
-        	// Copy forward the content digest as the current digest is simply of an empty response
-        	latestFetch.put(A_CONTENT_DIGEST, history[1].get(A_CONTENT_DIGEST));
-        	// Create revisit profile
+            // Copy forward the content digest as the current digest is simply of an empty response
+            latestFetch.put(A_CONTENT_DIGEST, history[1].get(A_CONTENT_DIGEST));
+            // Create revisit profile
             ServerNotModifiedRevisit revisit = new ServerNotModifiedRevisit();
             revisit.setETag((String) latestFetch.get(A_ETAG_HEADER));
             revisit.setLastModified((String) latestFetch.get(A_LAST_MODIFIED_HEADER));

--- a/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
+++ b/modules/src/main/java/org/archive/modules/recrawl/FetchHistoryProcessor.java
@@ -110,6 +110,7 @@ public class FetchHistoryProcessor extends Processor {
             // Copy forward the content digest as the current digest is simply of an empty response
             latestFetch.put(A_CONTENT_DIGEST, history[1].get(A_CONTENT_DIGEST));
             // Create revisit profile
+            curi.getAnnotations().add("duplicate:server-not-modified");
             ServerNotModifiedRevisit revisit = new ServerNotModifiedRevisit();
             revisit.setETag((String) latestFetch.get(A_ETAG_HEADER));
             revisit.setLastModified((String) latestFetch.get(A_LAST_MODIFIED_HEADER));

--- a/modules/src/main/java/org/archive/modules/revisit/IdenticalPayloadDigestRevisit.java
+++ b/modules/src/main/java/org/archive/modules/revisit/IdenticalPayloadDigestRevisit.java
@@ -1,5 +1,6 @@
 package org.archive.modules.revisit;
 
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_REFERS_TO_TARGET_URI;
 
 import java.util.Map;
@@ -32,8 +33,7 @@ public class IdenticalPayloadDigestRevisit extends AbstractProfile {
 	public Map<String, String> getWarcHeaders() {
 		Map<String, String> headers = super.getWarcHeaders();
 		
-		// Written automatically by WarcWriterProcessor for all HTTP responses
-		// headers.put(HEADER_KEY_PAYLOAD_DIGEST, payloadDigest); 
+		headers.put(HEADER_KEY_PAYLOAD_DIGEST, payloadDigest); 
 		
 		if (refersToTargetURI!=null) {
 			headers.put(HEADER_KEY_REFERS_TO_TARGET_URI, refersToTargetURI);

--- a/modules/src/main/java/org/archive/modules/revisit/ServerNotModifiedRevisit.java
+++ b/modules/src/main/java/org/archive/modules/revisit/ServerNotModifiedRevisit.java
@@ -2,6 +2,7 @@ package org.archive.modules.revisit;
 
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_ETAG;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_LAST_MODIFIED;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
 
 import java.util.Map;
 
@@ -12,6 +13,9 @@ public class ServerNotModifiedRevisit extends AbstractProfile {
 	// From HTTP response
 	protected String eTag;
 	protected String lastModified;
+	
+	// Optional. Digest of original capture
+	protected String payloadDigest;
 	
 	/**
 	 * Minimal constructor.
@@ -28,6 +32,10 @@ public class ServerNotModifiedRevisit extends AbstractProfile {
 	@Override
 	public Map<String, String> getWarcHeaders() {
 		Map<String, String> headers = super.getWarcHeaders();
+		
+		if (payloadDigest!=null) {
+			headers.put(HEADER_KEY_PAYLOAD_DIGEST, payloadDigest);
+		}
 		
 		if (eTag!=null) {
 			headers.put(HEADER_KEY_ETAG, eTag);
@@ -57,6 +65,16 @@ public class ServerNotModifiedRevisit extends AbstractProfile {
 
 	public void setLastModified(String lastModified) {
 		this.lastModified = lastModified;
+	}
+
+
+	public String getPayloadDigest() {
+		return payloadDigest;
+	}
+
+
+	public void setPayloadDigest(String payloadDigest) {
+		this.payloadDigest = payloadDigest;
 	}
 
 	

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
@@ -392,10 +392,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         // TODO: Use other than ANVL (or rename ANVL as NameValue or
         // use RFC822 (commons-httpclient?).
         ANVLRecord headers = new ANVLRecord();
-        if (curi.getContentDigest() != null) {
-            headers.addLabelValue(HEADER_KEY_PAYLOAD_DIGEST,
-                    curi.getContentDigestSchemeString());
-        }
         headers.addLabelValue(HEADER_KEY_IP, getHostAddress(curi));
 
         URI rid;
@@ -403,6 +399,10 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         if (curi.isRevisit()) {
             rid = writeRevisit(w, timestamp, HTTP_RESPONSE_MIMETYPE, baseid, curi, headers);
         } else {
+            if (curi.getContentDigest() != null) {
+                headers.addLabelValue(HEADER_KEY_PAYLOAD_DIGEST,
+                        curi.getContentDigestSchemeString());
+            }
             // Check for truncated annotation
             String value = null;
             Collection<String> anno = curi.getAnnotations();


### PR DESCRIPTION
Fixes issue: https://webarchive.jira.com/browse/HER-2080
Also adds crawl.log annotations for server-not-modified duplicates.

Relates to: https://github.com/iipc/openwayback/issues/224
