### PR TITLE
Amqp declarations fix

### DIFF
--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -124,6 +124,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                             // start up again
                             try {
                                 Consumer consumer = new UrlConsumer(channel());
+                                channel().exchangeDeclare(getExchange(), "direct", true);
                                 channel().queueDeclare(getQueueName(), false, false, true, null);
                                 channel().queueBind(getQueueName(), getExchange(), getQueueName());
                                 channel().basicConsume(getQueueName(), false, consumer);

--- a/contrib/src/main/java/org/archive/modules/AMQPPublishProcessor.java
+++ b/contrib/src/main/java/org/archive/modules/AMQPPublishProcessor.java
@@ -50,7 +50,7 @@ public class AMQPPublishProcessor extends AMQPProducerProcessor implements Seria
         routingKey = "urls";
     }
 
-    protected String clientId = null;
+    protected String clientId = "requests";
     public String getClientId() {
         return clientId;
     }


### PR DESCRIPTION
Gets rid of the error when starting the AMQP receiver before its exchange exists. Sets the default clientId passed with the publisher to be the same as the default queue name set for the receiver.

@nlevitt 