### PR TITLE
AMQPUrlReceiver changes to support RabbitMQ >= 3.3

### DIFF
--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -107,9 +107,31 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
         return isRunning;
     }
     
+    /** Should be queues be marked as durable? */
+    private boolean durable = true;
+    public boolean isDurable() {
+        return durable;
+    }
+    public void setDurable(boolean durable) {
+        this.durable = durable;
+    }
+
+    /** Should be queues be marked as auto-delete? */
+    private boolean autoDelete = false;
+    public boolean isAutoDelete() {
+        return autoDelete;
+    }
+    public void setAutoDelete(boolean autoDelete) {
+        this.autoDelete = autoDelete;
+    }
+
     private transient Lock lock = new ReentrantLock(true);
 
+    private boolean pauseConsumer = true;
+
     private class StarterRestarter extends Thread {
+        private String consumerTag;
+
         public StarterRestarter(String name) {
             super(name);
         }
@@ -120,18 +142,27 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                 try {
                     lock.lockInterruptibly();
                     try {
-                        if (!isRunning) {
+                        if (!isRunning && !pauseConsumer) {
                             // start up again
                             try {
                                 Consumer consumer = new UrlConsumer(channel());
                                 channel().exchangeDeclare(getExchange(), "direct", true);
-                                channel().queueDeclare(getQueueName(), false, false, true, null);
+                                channel().queueDeclare(getQueueName(), durable,
+                                        false, autoDelete, null);
                                 channel().queueBind(getQueueName(), getExchange(), getQueueName());
-                                channel().basicConsume(getQueueName(), false, consumer);
+                                consumerTag = channel().basicConsume(getQueueName(), false, consumer);
                                 isRunning = true;
                                 logger.info("started AMQP consumer uri=" + getAmqpUri() + " exchange=" + getExchange() + " queueName=" + getQueueName());
                             } catch (IOException e) {
                                 logger.log(Level.SEVERE, "problem starting AMQP consumer (will try again after 30 seconds)", e);
+                            }
+                        }
+
+                        if (isRunning && pauseConsumer) {
+                            try {
+                                channel().basicCancel(consumerTag);
+                            } catch (IOException e) {
+                                logger.log(Level.SEVERE, "problem cancelling AMQP consumer (will try again after 30 seconds)", e);
                             }
                         }
 
@@ -140,6 +171,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                         lock.unlock();
                     }
                 } catch (InterruptedException e) {
+
                     return;
                 }
             }
@@ -147,7 +179,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
     }
 
     transient private StarterRestarter starterRestarter;
-    
+
     @Override
     public void start() {
         lock.lock();
@@ -274,9 +306,14 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                     logger.log(Level.SEVERE,
                             "problem creating CrawlURI from json received via AMQP "
                                     + decodedBody, e);
+                } catch (Throwable e) {
+                    logger.log(Level.SEVERE,
+                            "Unanticipated problem creating CrawlURI from json received via AMQP "
+                                    + decodedBody, e);
                 }
             } else {
-                logger.warning("ignoring url with method other than GET - " + decodedBody);
+                logger.info("ignoring url with method other than GET - "
+                        + decodedBody);
             }
 
             this.getChannel().basicAck(envelope.getDeliveryTag(), false);
@@ -361,22 +398,13 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
     public void onApplicationEvent(CrawlStateEvent event) {
         switch(event.getState()) {
         case PAUSING: case PAUSED:
-            if (channel != null && channel.isOpen()) {
-                try {
-                    channel.flow(false);
-                } catch (IOException e) {
-                    logger.log(Level.WARNING, "failed to pause flow on amqp channel", e);
-                }
-            }
+            this.pauseConsumer = true;
             break;
 
         case RUNNING: case EMPTY: case PREPARING:
-            if (channel != null && channel.isOpen()) {
-                try {
-                    channel.flow(true);
-                } catch (IOException e) {
-                    logger.log(Level.SEVERE, "failed to resume flow on amqp channel", e);
-                }
+            this.pauseConsumer = false;
+            if (starterRestarter == null || !starterRestarter.isAlive()) {
+                start();
             }
             break;
 

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -315,7 +315,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                     logger.log(Level.SEVERE,
                             "problem creating CrawlURI from json received via AMQP "
                                     + decodedBody, e);
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     logger.log(Level.SEVERE,
                             "Unanticipated problem creating CrawlURI from json received via AMQP "
                                     + decodedBody, e);


### PR DESCRIPTION
As of version 3.3, [RabbitMQ no longer supports channel.flow{active=false}][1] and so the AMQPUrlReceiver module is lot able to use this method to pause message consumption.  This patch:

* Switches to a consume/cancel model so the UrlConsumer only runs when the crawl is running.
* Separates consumption from the StarterRestarter, making both more robust.
* Prevents unanticipated exceptions from killing the StarterRestarter thread.
* Enables the durability and auto-delete features of the queues to be modified via Spring.

[1]: https://www.rabbitmq.com/blog/2014/04/02/breaking-things-with-rabbitmq-3-3/