### PR TITLE
catch exceptions and log error in StatisticsTracker.run(), to make su…

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
@@ -416,7 +416,11 @@ public class StatisticsTracker
      *
      */
     public void run() {
-        progressStatisticsEvent();
+        try {
+            progressStatisticsEvent();
+        } catch (Throwable e) {
+            logger.log(Level.SEVERE, "unexpected exception from progressStatisticsEvent()", e);
+        }
     }
 
     /**


### PR DESCRIPTION
…re statistics events don't stop happening