### PR TITLE
Disable SNI for a request if that request failed due to an SNI error …

### DIFF
--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
@@ -661,8 +661,24 @@ public class FetchHTTP extends Processor implements Lifecycle {
             failedExecuteCleanup(curi, e);
             return;
         } catch (IOException e) {
-            failedExecuteCleanup(curi, e);
-            return;
+            if ("handshake alert:  unrecognized_name".equals(e.getMessage())) {
+                req.setDisableSNI(true);
+
+                try {
+                    response = req.execute();
+                    addResponseContent(response, curi);
+                } catch (ClientProtocolException ee) {
+                    failedExecuteCleanup(curi, e);
+                    return;
+                } catch (IOException ee) {
+                    failedExecuteCleanup(curi, e);
+                    return;
+                }
+            }
+            else {
+                failedExecuteCleanup(curi, e);
+                return;
+            }
         }
         
         maybeMidfetchAbort(curi, req.request);

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -115,6 +115,16 @@ import org.archive.util.Recorder;
  */
 class FetchHTTPRequest {
     
+    private boolean disableSNI = false;
+    
+    public boolean isDisableSNI() {
+        return disableSNI;
+    }
+
+    public void setDisableSNI(boolean disableSNI) {
+        this.disableSNI = disableSNI;
+    }
+
     /**
      * Implementation of {@link DnsResolver} that uses the server cache which is
      * normally expected to have been populated by FetchDNS.
@@ -463,7 +473,22 @@ class FetchHTTPRequest {
     protected HttpClientConnectionManager buildConnectionManager() {
         Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
                 .register("http", PlainConnectionSocketFactory.INSTANCE)
-                .register("https", new SSLConnectionSocketFactory(fetcher.sslContext(), new AllowAllHostnameVerifier()))
+                .register(
+                        "https",
+                        new SSLConnectionSocketFactory(fetcher.sslContext(),
+                                new AllowAllHostnameVerifier()) {
+
+                            @Override
+                            public Socket createLayeredSocket(
+                                    final Socket socket, final String target,
+                                    final int port, final HttpContext context)
+                                    throws IOException {
+
+                                return super.createLayeredSocket(socket,
+                                        isDisableSNI() ? "" : target, port,
+                                        context);
+                            }
+                        })
                 .build();
 
         DnsResolver dnsResolver = new ServerCacheResolver(fetcher.getServerCache());


### PR DESCRIPTION
…'javax.net.ssl.SSLProtocolException: handshake alert:  unrecognized_name'