### PR TITLE
More fixes for mutlipart form submission

### DIFF
--- a/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
+++ b/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
@@ -65,6 +65,11 @@ public class HTMLForm {
     public void addField(String type, String name, String value, boolean checked) {
         FormInput input = new FormInput();
         input.type = type;
+        
+        if (isMultipleFormSubmitInputs(type)) {
+            return;
+        }
+             
         // default input type is text per html standard
         if (input.type == null) {
             input.type = "text";
@@ -80,6 +85,19 @@ public class HTMLForm {
             candidatePasswordInputs.add(input);
         }
     }
+    
+    public boolean isMultipleFormSubmitInputs(String type) {
+        if (!type.toLowerCase().equals("submit"))
+            return false;
+
+        for (FormInput input : allInputs) {
+            if (input.type.toLowerCase().equals("submit")) {
+                return true;
+            }
+        }
+
+        return false;
+    }    
 
     /**
      * Add a discovered INPUT, tracking it as potential 
@@ -162,11 +180,9 @@ public class HTMLForm {
                 nameVals.add(new NameValue(input.name, username));
             } else if(input == candidatePasswordInputs.get(0)) {
                 nameVals.add(new NameValue(input.name, password));
-            } else if (StringUtils.isNotEmpty(input.name)
-                    && StringUtils.isNotEmpty(input.value)
-                    && (!"radio".equalsIgnoreCase(input.type)
-                            && !"checkbox".equals(input.type) || input.checked)) {
-                nameVals.add(new NameValue(input.name, input.value));
+            } else if(!"radio".equalsIgnoreCase(input.type)
+                            && !"checkbox".equals(input.type) || input.checked) {
+                nameVals.add(new NameValue(StringUtils.isEmpty(input.name) ? "" : input.name, StringUtils.isEmpty(input.value) ? "" : input.value));
             }
         }
         return nameVals;

--- a/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
+++ b/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
@@ -87,7 +87,7 @@ public class HTMLForm {
     }
     
     public boolean isMultipleFormSubmitInputs(String type) {
-        if (!type.toLowerCase().equals("submit"))
+        if (type != null && !type.toLowerCase().equals("submit"))
             return false;
 
         for (FormInput input : allInputs) {

--- a/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
+++ b/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
@@ -178,11 +178,13 @@ public class HTMLForm {
         for (FormInput input : allInputs) {
             if (input == presumedUsernameInput()) {
                 nameVals.add(new NameValue(input.name, username));
-            } else if(input == candidatePasswordInputs.get(0)) {
+            } else if (input == candidatePasswordInputs.get(0)) {
                 nameVals.add(new NameValue(input.name, password));
-            } else if(!"radio".equalsIgnoreCase(input.type)
-                            && !"checkbox".equals(input.type) || input.checked) {
-                nameVals.add(new NameValue(StringUtils.isEmpty(input.name) ? "" : input.name, StringUtils.isEmpty(input.value) ? "" : input.value));
+            } else if (!"radio".equalsIgnoreCase(input.type)
+                    && !"checkbox".equals(input.type) || input.checked) {
+                nameVals.add(new NameValue(StringUtils.isEmpty(input.name) ? ""
+                        : input.name, StringUtils.isEmpty(input.value) ? ""
+                        : input.value));
             }
         }
         return nameVals;


### PR DESCRIPTION
For login to https://ebiz.aacc.nche.edu/EbusPSNFYPROD/Home/Login/tabid/71/Default.aspx?returnurl=http%3a%2f%2fwww.aacc.nche.edu%2f_layouts%2fAACC.Authentication%2fLogin.aspx%3fReturnUrl%3d%252fPublications%252fCCJ%252fsubscribers%252fPages%252fdefault.aspx, the post data field of __VIEWSTATEENCRYPTED is needed or the site returns an error page and doesn't login. These changes allow blank field values to be used. Also, the submission for this page doesn't work (it returns the error page) if there are 2 submit values, Login and Validate, corresponding to the 2 buttons on the login page for Login and Email Validation. So this code change ensures that only 1 submit input is posted.

Example of blank value input needed:

--FKP3sst5b1cnB0GgQWtPpC0GkhWcKkElNs4uE1
Content-Disposition: form-data; name="__VIEWSTATEENCRYPTED"


