### PR TITLE
Switch to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,8 +375,8 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 				<artifactId>maven-compiler-plugin</artifactId>
                                <version>3.3</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The Heritrix codebase does not compile under Java 6 due to using [InetAddress.getLoopbackAddress()](https://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html#getLoopbackAddress%28%29) in a test (org.archive.modules.writer.WARCWriterProcessorTest). There may be other Java 7 features in use - I've only noticed this one.

Assuming this was intentional, the Maven build needs updating to specify a source version of 1.7 or else it breaks the built in e.g. Eclipse.