### PR TITLE
Controlling HopPath and prefetch behaviour for AMQPUrlReceiver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+
+language: java
+
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+  - openjdk7
+
+matrix:
+    allow_failures:
+        - jdk: oraclejdk8
+
+before_install:  
+ - "export JAVA_OPTS=-Xmx1500m"
+ - "echo JAVA_OPTS=$JAVA_OPTS"
+ - "export MAVEN_OPTS=-Xmx1500m"
+ - "echo MAVEN_OPTS=$MAVEN_OPTS"
+ - "export _JAVA_OPTIONS=-Xmx1500m"
+ - "echo _JAVA_OPTIONS=$_JAVA_OPTIONS"
+
+script:
+ - mvn clean install
+ - cd contrib && mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk7
-  - oraclejdk8
-  - openjdk7
+ - oraclejdk7
+ - oraclejdk8
+ - openjdk7
 
-matrix:
-    allow_failures:
-        - jdk: oraclejdk8
-
-before_install:  
+before_install:
  - "export JAVA_OPTS=-Xmx1500m"
  - "echo JAVA_OPTS=$JAVA_OPTS"
  - "export MAVEN_OPTS=-Xmx1500m"
@@ -22,3 +18,7 @@ before_install:
 script:
  - mvn clean install
  - cd contrib && mvn clean install
+ - cd ..
+
+after_failure:
+  - cat */target/surefire-reports/*.txt

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -163,7 +163,7 @@
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
-			<version>1.01</version>
+			<version>1.04</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -161,7 +161,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.esotericsoftware</groupId>
+			<groupId>com.googlecode</groupId>
 			<artifactId>kryo</artifactId>
 			<version>1.04</version>
 			<scope>compile</scope>

--- a/commons/src/main/java/org/archive/spring/KeyedProperties.java
+++ b/commons/src/main/java/org/archive/spring/KeyedProperties.java
@@ -20,10 +20,10 @@
  package org.archive.spring;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Logger;
 
 /**
@@ -35,14 +35,14 @@ import java.util.logging.Logger;
  * to the 'prop' entry in this map.)
  * 
  */
-public class KeyedProperties extends ConcurrentHashMap<String,Object> {
-    private static final long serialVersionUID = 3403222335436162778L;
+public class KeyedProperties extends ConcurrentSkipListMap<String,Object> {
+    private static final long serialVersionUID = 2L;
     
     private static final Logger logger = Logger.getLogger(KeyedProperties.class.getName());
 
     /** the alternate global property-paths leading to this map 
      * TODO: consider if deterministic ordered list is important */
-    protected HashSet<String> externalPaths = new HashSet<String>(); 
+    protected TreeSet<String> externalPaths = new TreeSet<String>(); 
     
     /**
      * Add a path by which the outside world can reach this map

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.10</artifactId>
-			<version>0.8.2-beta</version>
+			<version>0.9.0.0</version>
 		</dependency>
 	</dependencies>
 	<repositories>

--- a/contrib/src/main/java/org/archive/crawler/event/AMQPUrlPublishedEvent.java
+++ b/contrib/src/main/java/org/archive/crawler/event/AMQPUrlPublishedEvent.java
@@ -1,0 +1,47 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.crawler.event;
+
+import org.archive.modules.AMQPPublishProcessor;
+import org.archive.modules.CrawlURI;
+import org.springframework.context.ApplicationEvent;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
+
+/**
+ * ApplicationEvent published when Heritrix sends a URL to AMQP.
+ * Other modules can observe this event to learn when Heritrix sends a URL.
+ *
+ * @contributor galgeek
+ */
+public class AMQPUrlPublishedEvent extends ApplicationEvent {
+    private static final long serialVersionUID = 1L;
+
+    protected CrawlURI curi;
+    public CrawlURI getCuri() {
+        return curi;
+    }
+
+    public AMQPUrlPublishedEvent(AMQPPublishProcessor source, CrawlURI curi) {
+        super(source);
+        this.curi = curi;
+    }
+}

--- a/contrib/src/main/java/org/archive/crawler/event/AMQPUrlReceivedEvent.java
+++ b/contrib/src/main/java/org/archive/crawler/event/AMQPUrlReceivedEvent.java
@@ -1,0 +1,47 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.crawler.event;
+
+import org.archive.crawler.frontier.AMQPUrlReceiver;
+import org.archive.modules.CrawlURI;
+import org.springframework.context.ApplicationEvent;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
+
+/**
+ * ApplicationEvent published when AMQPUrlReceiver receives a URL.
+ * Other modules can observe this event to learn when AMQPUrlReceiver receives a URL.
+ *
+ * @contributor galgeek
+ */
+public class AMQPUrlReceivedEvent extends ApplicationEvent {
+    private static final long serialVersionUID = 1L;
+
+    protected CrawlURI curi;
+    public CrawlURI getCuri() {
+        return curi;
+    }
+
+    public AMQPUrlReceivedEvent(AMQPUrlReceiver source, CrawlURI curi) {
+        super(source);
+        this.curi = curi;
+    }
+}

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -32,6 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.httpclient.URIException;
+import org.archive.crawler.event.AMQPUrlReceivedEvent;
 import org.archive.crawler.event.CrawlStateEvent;
 import org.archive.crawler.postprocessor.CandidatesProcessor;
 import org.archive.modules.CrawlURI;
@@ -45,7 +46,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.beans.BeansException;
 import org.springframework.context.Lifecycle;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -60,7 +65,8 @@ import com.rabbitmq.client.ShutdownSignalException;
 /**
  * @contributor nlevitt
  */
-public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStateEvent> {
+public class AMQPUrlReceiver
+	implements Lifecycle, ApplicationContextAware, ApplicationListener<CrawlStateEvent> {
 
     @SuppressWarnings("unused")
     private static final long serialVersionUID = 2L;
@@ -69,6 +75,11 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
             Logger.getLogger(AMQPUrlReceiver.class.getName());
 
     public static final String A_RECEIVED_FROM_AMQP = "receivedFromAMQP";
+
+    protected ApplicationContext appCtx;
+    public void setApplicationContext(ApplicationContext appCtx) throws BeansException {
+        this.appCtx = appCtx;
+    }
 
     protected CandidatesProcessor candidates;
     public CandidatesProcessor getCandidates() {
@@ -331,6 +342,7 @@ public class AMQPUrlReceiver implements Lifecycle, ApplicationListener<CrawlStat
                     CrawlURI curi = makeCrawlUri(jo);
                     KeyedProperties.clearAllOverrideContexts();
                     candidates.runCandidateChain(curi, null);
+                    appCtx.publishEvent(new AMQPUrlReceivedEvent(AMQPUrlReceiver.this, curi));
                 } catch (URIException e) {
                     logger.log(Level.WARNING,
                             "problem creating CrawlURI from json received via AMQP "

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -45,12 +45,11 @@ import org.archive.spring.KeyedProperties;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.beans.BeansException;
 import org.springframework.context.Lifecycle;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -152,6 +151,28 @@ public class AMQPUrlReceiver
         this.forceFetch = forceFetch;
     }
 
+    /**
+     * The maximum prefetch count to use, meaning the maximum number of messages
+     * to be consumed without being acknowledged. Use 'null' to specify there
+     * should be no upper limit (the default).
+     */
+    private Integer prefetchCount = null;
+
+    /**
+     * @return the prefetchCount
+     */
+    public Integer getPrefetchCount() {
+        return prefetchCount;
+    }
+
+    /**
+     * @param prefetchCount
+     *            the prefetchCount to set
+     */
+    public void setPrefetchCount(Integer prefetchCount) {
+        this.prefetchCount = prefetchCount;
+    }
+
     private transient Lock lock = new ReentrantLock(true);
 
     private transient boolean pauseConsumer = false;
@@ -209,6 +230,8 @@ public class AMQPUrlReceiver
             channel().queueDeclare(getQueueName(), durable,
                     false, autoDelete, null);
             channel().queueBind(getQueueName(), getExchange(), getQueueName());
+            if (prefetchCount != null)
+                channel().basicQos(prefetchCount);
             consumerTag = channel().basicConsume(getQueueName(), false, consumer);
             logger.info("started AMQP consumer uri=" + getAmqpUri() + " exchange=" + getExchange() + " queueName=" + getQueueName() + " consumerTag=" + consumerTag);
         }
@@ -361,6 +384,7 @@ public class AMQPUrlReceiver
                         + decodedBody);
             }
 
+            logger.finest("Now ACKing: " + decodedBody);
             this.getChannel().basicAck(envelope.getDeliveryTag(), false);
         }
 
@@ -393,7 +417,8 @@ public class AMQPUrlReceiver
 
             JSONObject parentUrlMetadata = jo.getJSONObject("parentUrlMetadata");
             String parentHopPath = parentUrlMetadata.getString("pathFromSeed");
-            String hopPath = parentHopPath + Hop.INFERRED.getHopString();
+            String hop = jo.optString("hop", Hop.INFERRED.getHopString());
+            String hopPath = parentHopPath + hop;
 
             CrawlURI curi = new CrawlURI(uuri, hopPath, via, LinkContext.INFERRED_MISC);
 
@@ -415,8 +440,11 @@ public class AMQPUrlReceiver
              * https://webarchive.jira.com/wiki/display/Heritrix/Precedence+
              * Feature+Notes
              */
-            curi.setSchedulingDirective(SchedulingConstants.HIGH);
-            curi.setPrecedence(1);
+            if (Hop.INFERRED.getHopString().equals(curi.getLastHop())
+                    || Hop.EMBED.getHopString().equals(curi.getLastHop())) {
+                curi.setSchedulingDirective(SchedulingConstants.HIGH);
+                curi.setPrecedence(1);
+            }
 
             curi.setForceFetch(forceFetch || jo.optBoolean("forceFetch"));
             curi.setSeed(jo.optBoolean("isSeed"));

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -434,7 +434,8 @@ public class AMQPUrlReceiver
             }
             curi.getData().put("customHttpRequestHeaders", customHttpRequestHeaders);
 
-            /* Crawl job must be configured to use
+            /*
+             * Crawl job must be configured to use
              * HighestUriQueuePrecedencePolicy to ensure these high priority
              * urls really get crawled ahead of others. See
              * https://webarchive.jira.com/wiki/display/Heritrix/Precedence+
@@ -443,6 +444,9 @@ public class AMQPUrlReceiver
             if (Hop.INFERRED.getHopString().equals(curi.getLastHop())
                     || Hop.EMBED.getHopString().equals(curi.getLastHop())) {
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
+                curi.setPrecedence(1);
+            } else {
+                curi.setSchedulingDirective(SchedulingConstants.NORMAL);
                 curi.setPrecedence(1);
             }
 

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -446,7 +446,13 @@ public class AMQPUrlReceiver
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
                 curi.setPrecedence(1);
             } else {
-                curi.setSchedulingDirective(SchedulingConstants.NORMAL);
+                /*
+                 * By default, redirects get set to MEDIUM, so to ensure the
+                 * incoming links are caught promptly, even if the crawler hits
+                 * a lot of redirects (which we have observed for e.g. The
+                 * Guardian), we bump them to MEDIUM so these links can compete.
+                 */
+                curi.setSchedulingDirective(SchedulingConstants.MEDIUM);
                 curi.setPrecedence(1);
             }
 

--- a/contrib/src/main/java/org/archive/modules/AMQPUrlWaiter.java
+++ b/contrib/src/main/java/org/archive/modules/AMQPUrlWaiter.java
@@ -1,0 +1,82 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.modules;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.archive.crawler.event.AMQPUrlReceivedEvent;
+import org.archive.crawler.event.StatSnapshotEvent;
+import org.archive.crawler.framework.CrawlController;
+import org.archive.crawler.framework.CrawlStatus;
+import org.archive.crawler.framework.Frontier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Bean to enforce a wait for Umbra's amqp queue
+ *
+ * @contributor galgeek
+ */
+public class AMQPUrlWaiter implements ApplicationListener<ApplicationEvent> {
+
+    public AMQPUrlWaiter() {}
+
+    static protected final Logger logger = Logger.getLogger(AMQPUrlWaiter.class.getName());
+
+    protected int urlsReceived = 0;
+
+    protected CrawlController controller;
+    public CrawlController getCrawlController() {
+        return this.controller;
+    }
+    @Autowired
+    public void setCrawlController(CrawlController controller) {
+        this.controller = controller;
+    }
+
+    protected Frontier frontier;
+    public Frontier getFrontier() {
+        return this.frontier;
+    }
+    /** Autowired frontier, needed to determine when a url is finished. */
+    @Autowired
+    public void setFrontier(Frontier frontier) {
+        this.frontier = frontier;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (event instanceof AMQPUrlReceivedEvent) {
+            urlsReceived += 1;
+        } else if (event instanceof StatSnapshotEvent) {
+            checkAMQPUrlWait();
+        }
+    }
+
+    protected void checkAMQPUrlWait() {
+        if (frontier.isEmpty() && urlsReceived > 0) {
+            logger.info("frontier is empty and we have received " + urlsReceived +
+                        " urls from AMQP, stopping crawl with status " + CrawlStatus.FINISHED);
+            controller.requestCrawlStop(CrawlStatus.FINISHED);
+        }
+    }
+}

--- a/contrib/src/main/java/org/archive/modules/AMQPUrlWaiter.java
+++ b/contrib/src/main/java/org/archive/modules/AMQPUrlWaiter.java
@@ -22,11 +22,11 @@ package org.archive.modules;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.archive.crawler.event.AMQPUrlPublishedEvent;
 import org.archive.crawler.event.AMQPUrlReceivedEvent;
 import org.archive.crawler.event.StatSnapshotEvent;
 import org.archive.crawler.framework.CrawlController;
 import org.archive.crawler.framework.CrawlStatus;
-import org.archive.crawler.framework.Frontier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -42,6 +42,7 @@ public class AMQPUrlWaiter implements ApplicationListener<ApplicationEvent> {
 
     static protected final Logger logger = Logger.getLogger(AMQPUrlWaiter.class.getName());
 
+    protected int urlsPublished = 0;
     protected int urlsReceived = 0;
 
     protected CrawlController controller;
@@ -53,19 +54,11 @@ public class AMQPUrlWaiter implements ApplicationListener<ApplicationEvent> {
         this.controller = controller;
     }
 
-    protected Frontier frontier;
-    public Frontier getFrontier() {
-        return this.frontier;
-    }
-    /** Autowired frontier, needed to determine when a url is finished. */
-    @Autowired
-    public void setFrontier(Frontier frontier) {
-        this.frontier = frontier;
-    }
-
     @Override
     public void onApplicationEvent(ApplicationEvent event) {
-        if (event instanceof AMQPUrlReceivedEvent) {
+        if (event instanceof AMQPUrlPublishedEvent) {
+            urlsPublished += 1;
+        } else if (event instanceof AMQPUrlReceivedEvent) {
             urlsReceived += 1;
         } else if (event instanceof StatSnapshotEvent) {
             checkAMQPUrlWait();
@@ -73,9 +66,10 @@ public class AMQPUrlWaiter implements ApplicationListener<ApplicationEvent> {
     }
 
     protected void checkAMQPUrlWait() {
-        if (frontier.isEmpty() && urlsReceived > 0) {
-            logger.info("frontier is empty and we have received " + urlsReceived +
-                        " urls from AMQP, stopping crawl with status " + CrawlStatus.FINISHED);
+        if (controller.getState() == CrawlController.State.EMPTY && (urlsPublished == 0 || urlsReceived > 0)) {
+            logger.info("crawl controller state is empty and we have received " + urlsReceived +
+                        " urls from AMQP, and published " + urlsPublished +
+                        ", stopping crawl with status " + CrawlStatus.FINISHED);
             controller.requestCrawlStop(CrawlStatus.FINISHED);
         }
     }

--- a/contrib/src/main/java/org/archive/modules/postprocessor/KafkaCrawlLogFeed.java
+++ b/contrib/src/main/java/org/archive/modules/postprocessor/KafkaCrawlLogFeed.java
@@ -34,6 +34,8 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.archive.crawler.framework.Frontier;
 import org.archive.crawler.frontier.AbstractFrontier;
 import org.archive.crawler.frontier.BdbFrontier;
@@ -176,8 +178,8 @@ public class KafkaCrawlLogFeed extends Processor implements Lifecycle {
 
     private transient ThreadGroup kafkaProducerThreads;
 
-    transient protected KafkaProducer kafkaProducer;
-    protected KafkaProducer kafkaProducer() {
+    transient protected KafkaProducer<String, byte[]> kafkaProducer;
+    protected KafkaProducer<String, byte[]> kafkaProducer() {
         if (kafkaProducer == null) {
             synchronized (this) {
                 if (kafkaProducer == null) {
@@ -185,6 +187,8 @@ public class KafkaCrawlLogFeed extends Processor implements Lifecycle {
                     props.put("bootstrap.servers", getBrokerList());
                     props.put("acks", "1");
                     props.put("producer.type", "async");
+                    props.put("key.serializer", StringSerializer.class.getName());
+                    props.put("value.serializer", ByteArraySerializer.class.getName());
 
                     /*
                      * XXX This mess here exists so that the kafka producer
@@ -198,13 +202,13 @@ public class KafkaCrawlLogFeed extends Processor implements Lifecycle {
                             return new Thread(kafkaProducerThreads, r);
                         }
                     };
-                    Callable<KafkaProducer> task = new Callable<KafkaProducer>() {
-                        public KafkaProducer call() throws InterruptedException {
-                            return new KafkaProducer(props);
+                    Callable<KafkaProducer<String,byte[]>> task = new Callable<KafkaProducer<String,byte[]>>() {
+                        public KafkaProducer<String, byte[]> call() throws InterruptedException {
+                            return new KafkaProducer<String,byte[]>(props);
                         }
                     };
                     ExecutorService executorService = Executors.newFixedThreadPool(1, threadFactory);
-                    Future<KafkaProducer> future = executorService.submit(task);
+                    Future<KafkaProducer<String, byte[]>> future = executorService.submit(task);
                     try {
                         kafkaProducer = future.get();
                     } catch (InterruptedException e) {
@@ -238,7 +242,7 @@ public class KafkaCrawlLogFeed extends Processor implements Lifecycle {
     @Override
     protected void innerProcess(CrawlURI curi) throws InterruptedException {
         byte[] message = buildMessage(curi);
-        ProducerRecord producerRecord = new ProducerRecord(getTopic(), message);
+        ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<String,byte[]>(getTopic(), message);
         kafkaProducer().send(producerRecord, new KafkaResultCallback(curi));
     }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.archive.crawler.framework.CrawlJob;
@@ -54,6 +55,9 @@ import org.springframework.beans.BeansException;
  * @contributor nlevitt
  */
 public abstract class JobRelatedResource extends BaseResource {
+    private final static Logger LOGGER =
+            Logger.getLogger(JobRelatedResource.class.getName());
+
     protected CrawlJob cj; 
 
     protected IdentityHashMap<Object, String> beanToNameMap;
@@ -147,8 +151,12 @@ public abstract class JobRelatedResource extends BaseResource {
                 }
             }
             if (obj instanceof Iterable<?>) {
-                for (Object next : (Iterable<?>) obj) {
-                    addPresentableNestedNames(namedBeans, next, alreadyWritten);
+                try {
+                    for (Object next : (Iterable<?>) obj) {
+                        addPresentableNestedNames(namedBeans, next, alreadyWritten);
+                    }
+                } catch (Exception e) {
+                    LOGGER.warning("problem iterating over " + obj + " - " + e);
                 }
             }
         }
@@ -286,8 +294,12 @@ public abstract class JobRelatedResource extends BaseResource {
                     beanPathPrefix = beanPath + "[";
                 }
                 // TODO: protect against overlong content?
-                propValues.add(makePresentableMapFor(i + "", list.get(i),
-                        alreadyWritten, beanPathPrefix));
+                try {
+                    propValues.add(makePresentableMapFor(i + "", list.get(i),
+                            alreadyWritten, beanPathPrefix));
+                } catch (Exception e) {
+                    LOGGER.warning(list + ".get(" + i + ") -" + e);
+                }
             }
         } else if (object instanceof Iterable<?>) {
             for (Object next : (Iterable<?>) object) {

--- a/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
@@ -48,14 +48,13 @@ public class StatisticsSelfTest extends SelfTestBase {
         StatisticsTracker stats = heritrix.getEngine().getJob("selftest-job").getCrawlController().getStatisticsTracker();
         assertNotNull(stats);
         assertEquals(14, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(12718, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(12669, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
 
         assertEquals(3, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
         assertEquals(2942, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(10, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
         assertEquals(9727, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(1, (long) stats.getServerCache().getHostFor("dns:").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(49, (long) stats.getServerCache().getHostFor("dns:").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
     }
 
     protected void verifySourceStats() throws Exception {
@@ -75,9 +74,9 @@ public class StatisticsSelfTest extends SelfTestBase {
         sourceStats = stats.getSourceStats("http://localhost:7777/b.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(9776l, (long) sourceStats.get("novel"));
+        assertEquals(9727l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
         assertEquals(11l, (long) sourceStats.get("novelCount"));
-        assertEquals(9776l, (long) sourceStats.get("warcNovelContentBytes"));
+        assertEquals(9727l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
         assertEquals(11l, (long) sourceStats.get("warcNovelUrls"));
     }
 

--- a/modules/src/main/java/org/archive/modules/credential/CredentialStore.java
+++ b/modules/src/main/java/org/archive/modules/credential/CredentialStore.java
@@ -23,11 +23,11 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 import javax.management.AttributeNotFoundException;
@@ -70,7 +70,7 @@ public class CredentialStore implements Serializable, HasKeyedProperties {
      * @see http://crawler.archive.org/proposals/auth/
      */
     {
-        setCredentials(new HashMap<String, Credential>());
+        setCredentials(new TreeMap<String, Credential>());
     }
     @SuppressWarnings("unchecked")
     public Map<String,Credential> getCredentials() {

--- a/modules/src/main/java/org/archive/modules/credential/HtmlFormCredential.java
+++ b/modules/src/main/java/org/archive/modules/credential/HtmlFormCredential.java
@@ -19,8 +19,8 @@
 
 package org.archive.modules.credential;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 import org.apache.commons.httpclient.URIException;
@@ -54,12 +54,15 @@ public class HtmlFormCredential extends Credential {
     
     /**
      * Form items.
+     * 
      */
-    protected Map<String,String> formItems = new HashMap<String,String>();
-    public Map<String,String> getFormItems() {
+    protected Map<String, String> formItems = new TreeMap<String, String>();
+
+    public Map<String, String> getFormItems() {
         return this.formItems;
     }
-    public void setFormItems(Map<String,String> formItems) {
+
+    public void setFormItems(Map<String, String> formItems) {
         this.formItems = formItems;
     }
     

--- a/modules/src/main/java/org/archive/modules/extractor/ContentExtractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ContentExtractor.java
@@ -42,7 +42,11 @@ public abstract class ContentExtractor extends Extractor {
 
     /**
      * Determines if links should be extracted from the given URI. This method
-     * performs three checks. The first check runs only if
+     * performs four checks. It first checks if the URI was processed successfully,
+     * i.e. {@link CrawlURI#isSuccess()} returns true. 
+     * 
+     * <p>
+     * The second check runs only if
      * {@link ExtractorParameters#getExtractIndependently()} is false. It checks
      * {@link ExtractorURI#hasBeenLinkExtracted()} result. If that result is
      * true, then this method returns false, as some other extractor has claimed
@@ -63,6 +67,9 @@ public abstract class ContentExtractor extends Extractor {
      * @return true if links should be extracted from the URI, false otherwise
      */
     final protected boolean shouldProcess(CrawlURI uri) {
+    	if (!uri.isSuccess()) {
+    		return false;
+    	}
         if (!getExtractorParameters().getExtractIndependently()
                 && uri.hasBeenLinkExtracted()) {
             return false;

--- a/modules/src/main/java/org/archive/modules/extractor/StringExtractorTestBase.java
+++ b/modules/src/main/java/org/archive/modules/extractor/StringExtractorTestBase.java
@@ -79,7 +79,8 @@ public abstract class StringExtractorTestBase extends ContentExtractorTestBase {
     private void testOne(String text, String expectedURL) throws Exception {
         Collection<TestData> testDataCol = makeData(text, expectedURL);
         for (TestData testData: testDataCol) {
-            extractor.process(testData.uri);
+        	testData.uri.setFetchStatus(200);
+        	extractor.process(testData.uri);
             HashSet<CrawlURI> expected = new HashSet<CrawlURI>();
             if (testData.expectedResult != null) {
                 expected.add(testData.expectedResult);

--- a/modules/src/main/java/org/archive/state/ModuleTestBase.java
+++ b/modules/src/main/java/org/archive/state/ModuleTestBase.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.SerializationUtils;
 import org.archive.modules.CrawlURI;
@@ -33,6 +31,8 @@ import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.util.Recorder;
 import org.archive.util.TmpDirTestCase;
+
+import junit.framework.TestCase;
 
 
 /**
@@ -184,8 +184,17 @@ public abstract class ModuleTestBase extends TestCase {
         byte[] thirdBytes = SerializationUtils.serialize((Serializable)third);
         
         // HashMap serialization reverses order of items in linked buckets 
-        // each roundtrip -- so don't check one roundtrip, check two
-//        verifySerialization(first, firstBytes, second, secondBytes);
+        // each roundtrip -- so don't check one roundtrip, check two.
+        //
+        // NOTE This is JVM-dependent behaviour, and since <= 1.7.0_u51 this
+        // ordering of serialisation cannot be relied upon. However, a TreeMap
+        // can be used instead of a HashMap, and this appears to have
+        // predictable serialisation behaviour.
+        //
+        // @see
+        // http://stackoverflow.com/questions/22392258/serialization-round-trip-of-hash-map-does-not-preserve-order
+        //
+        // verifySerialization(first, firstBytes, second, secondBytes);
         verifySerialization(first, firstBytes, third, thirdBytes);
     }
 

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -752,6 +752,9 @@ public class FetchHTTPTests extends ProcessorTestBase {
     public void testNoResponse() throws Exception {
         NoResponseServer noResponseServer = new NoResponseServer("localhost", 7780);
         noResponseServer.start();
+
+        // Give the server time to start up:
+        Thread.sleep(1000);
         
         // CrawlURI curi = makeCrawlURI("http://stats.bbc.co.uk/robots.txt");
         CrawlURI curi = makeCrawlURI("http://localhost:7780");

--- a/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
+++ b/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
@@ -129,6 +129,9 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
     }
 
     public void testBasics() throws InterruptedException, IOException {
+        historyStore().store.clear();
+        assertTrue(historyStore().store.isEmpty());
+
         CrawlURI curi1 = new CrawlURI(UURIFactory.getInstance("http://example.org/1"));
         // without Recorder, CrawlURI#getContentLength() returns zero, which makes
         // loader().shoudProcess() return false.
@@ -158,7 +161,8 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
         assertTrue(curi1.getContentDigestHistory().isEmpty());
 
         storer().process(curi1);
-        assertTrue(historyStore().store.isEmpty());
+        assertTrue("historyStore().store should be empty, but it is: " + historyStore().store,
+                historyStore().store.isEmpty());
         
         curi1.getContentDigestHistory().put(A_ORIGINAL_URL, "http://example.org/original");
         // curi1.getContentDigestHistory().put(A_WARC_RECORD_ID, "<urn:uuid:f00dface-d00d-d00d-d00d-0beefface0ff>");


### PR DESCRIPTION
This proposal allows the prefetch behaviour to be modified, because had a problem because the AMQP message pre-fetching was too aggressive.

More importantly, this includes changes to allow the message received from AMQP to override the hop path. The default behaviour is unchanged, but if a 'hop' is set then this overrides the default value of 'I'. This also requires us to apply the high prioritisation to URLs if they are embeds or inferred (the later ensuring the original behaviour prior to this proposal is retained).

This means we can push in seeds and discovered links from seeds with the correct hop path, which makes things clearer and allows reliable prioritisation based on hop path.
