### PR TITLE
No link extraction on URI not successfully downloaded

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ContentExtractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ContentExtractor.java
@@ -42,7 +42,11 @@ public abstract class ContentExtractor extends Extractor {
 
     /**
      * Determines if links should be extracted from the given URI. This method
-     * performs three checks. The first check runs only if
+     * performs four checks. It first checks if the URI was processed successfully,
+     * i.e. {@link CrawlURI#isSuccess()} returns true. 
+     * 
+     * <p>
+     * The second check runs only if
      * {@link ExtractorParameters#getExtractIndependently()} is false. It checks
      * {@link ExtractorURI#hasBeenLinkExtracted()} result. If that result is
      * true, then this method returns false, as some other extractor has claimed
@@ -63,6 +67,9 @@ public abstract class ContentExtractor extends Extractor {
      * @return true if links should be extracted from the URI, false otherwise
      */
     final protected boolean shouldProcess(CrawlURI uri) {
+    	if (!uri.isSuccess()) {
+    		return false;
+    	}
         if (!getExtractorParameters().getExtractIndependently()
                 && uri.hasBeenLinkExtracted()) {
             return false;

--- a/modules/src/main/java/org/archive/modules/extractor/StringExtractorTestBase.java
+++ b/modules/src/main/java/org/archive/modules/extractor/StringExtractorTestBase.java
@@ -79,7 +79,8 @@ public abstract class StringExtractorTestBase extends ContentExtractorTestBase {
     private void testOne(String text, String expectedURL) throws Exception {
         Collection<TestData> testDataCol = makeData(text, expectedURL);
         for (TestData testData: testDataCol) {
-            extractor.process(testData.uri);
+        	testData.uri.setFetchStatus(200);
+        	extractor.process(testData.uri);
             HashSet<CrawlURI> expected = new HashSet<CrawlURI>();
             if (testData.expectedResult != null) {
                 expected.add(testData.expectedResult);


### PR DESCRIPTION
During a test crawl I noticed a bunch of alerts like the following:

```
SEVERE: unable to get replay prefix string (in thread 'ToeThread #38: dns:arcland.is'; in processor 'extractorHtml')
java.io.IOException: chunked stream ended unexpectedly
	at org.apache.commons.httpclient.ChunkedInputStream.getChunkSizeFromInputStream(ChunkedInputStream.java:252)
	at org.apache.commons.httpclient.ChunkedInputStream.nextChunk(ChunkedInputStream.java:221)
	at org.apache.commons.httpclient.ChunkedInputStream.read(ChunkedInputStream.java:176)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.Reader.read(Reader.java:140)
	at org.archive.util.Recorder.getContentReplayPrefixString(Recorder.java:513)
	at org.archive.util.Recorder.getContentReplayPrefixString(Recorder.java:500)
	at org.archive.modules.extractor.ExtractorHTML.shouldExtract(ExtractorHTML.java:713)
	at org.archive.modules.extractor.ContentExtractor.shouldProcess(ContentExtractor.java:77)
	at org.archive.modules.Processor.process(Processor.java:140)
	at org.archive.modules.ProcessorChain.process(ProcessorChain.java:131)
	at org.archive.crawler.framework.ToeThread.run(ToeThread.java:148)
```
Turns out they are caused by the `ExtractorHTML.shouldExtract()` method trying to peek at the start of the content stream. 

At first I thought it was just down to this being a DNS entry, but I quickly realized that these all related to non-successful DNS lookups. 

Which got me thinking, why are we even trying to extract links from non-successful CrawlURIs?

So this PR adds a check to the `ContentExtractor.shouldProcess()` to immediately skip any non-successfully downloaded URIs. Avoids these errors and saves a little, otherwise wasted, effort.