### PR TITLE
AMQP fine control

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -161,9 +161,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.googlecode</groupId>
+			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
-			<version>1.04</version>
+			<version>1.01</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -163,7 +163,7 @@
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
-			<version>1.01</version>
+			<version>1.04</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -161,7 +161,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.esotericsoftware</groupId>
+			<groupId>com.googlecode</groupId>
 			<artifactId>kryo</artifactId>
 			<version>1.04</version>
 			<scope>compile</scope>

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -431,12 +431,6 @@ public class AMQPUrlReceiver
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
                 curi.setPrecedence(1);
             } else {
-                /*
-                 * By default, redirects get set to MEDIUM, so to ensure the
-                 * incoming links are caught promptly, even if the crawler hits
-                 * a lot of redirects (which we have observed for e.g. The
-                 * Guardian), we bump them to MEDIUM so these links can compete.
-                 */
                 curi.setSchedulingDirective(SchedulingConstants.MEDIUM);
                 curi.setPrecedence(1);
             }

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -426,12 +426,8 @@ public class AMQPUrlReceiver
              * https://webarchive.jira.com/wiki/display/Heritrix/Precedence+
              * Feature+Notes
              */
-            if (Hop.INFERRED.getHopString().equals(curi.getLastHop())
-                    || Hop.EMBED.getHopString().equals(curi.getLastHop())) {
+            if (Hop.INFERRED.getHopString().equals(curi.getLastHop())) {
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
-                curi.setPrecedence(1);
-            } else {
-                curi.setSchedulingDirective(SchedulingConstants.MEDIUM);
                 curi.setPrecedence(1);
             }
 

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -45,12 +45,11 @@ import org.archive.spring.KeyedProperties;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.beans.BeansException;
 import org.springframework.context.Lifecycle;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -152,6 +151,28 @@ public class AMQPUrlReceiver
         this.forceFetch = forceFetch;
     }
 
+    /**
+     * The maximum prefetch count to use, meaning the maximum number of messages
+     * to be consumed without being acknowledged. Use 'null' to specify there
+     * should be no upper limit (the default).
+     */
+    private Integer prefetchCount = null;
+
+    /**
+     * @return the prefetchCount
+     */
+    public Integer getPrefetchCount() {
+        return prefetchCount;
+    }
+
+    /**
+     * @param prefetchCount
+     *            the prefetchCount to set
+     */
+    public void setPrefetchCount(Integer prefetchCount) {
+        this.prefetchCount = prefetchCount;
+    }
+
     private transient Lock lock = new ReentrantLock(true);
 
     private transient boolean pauseConsumer = false;
@@ -209,6 +230,8 @@ public class AMQPUrlReceiver
             channel().queueDeclare(getQueueName(), durable,
                     false, autoDelete, null);
             channel().queueBind(getQueueName(), getExchange(), getQueueName());
+            if (prefetchCount != null)
+                channel().basicQos(prefetchCount);
             consumerTag = channel().basicConsume(getQueueName(), false, consumer);
             logger.info("started AMQP consumer uri=" + getAmqpUri() + " exchange=" + getExchange() + " queueName=" + getQueueName() + " consumerTag=" + consumerTag);
         }
@@ -361,6 +384,7 @@ public class AMQPUrlReceiver
                         + decodedBody);
             }
 
+            logger.finest("Now ACKing: " + decodedBody);
             this.getChannel().basicAck(envelope.getDeliveryTag(), false);
         }
 
@@ -393,7 +417,8 @@ public class AMQPUrlReceiver
 
             JSONObject parentUrlMetadata = jo.getJSONObject("parentUrlMetadata");
             String parentHopPath = parentUrlMetadata.getString("pathFromSeed");
-            String hopPath = parentHopPath + Hop.INFERRED.getHopString();
+            String hop = jo.optString("hop", Hop.INFERRED.getHopString());
+            String hopPath = parentHopPath + hop;
 
             CrawlURI curi = new CrawlURI(uuri, hopPath, via, LinkContext.INFERRED_MISC);
 
@@ -415,8 +440,11 @@ public class AMQPUrlReceiver
              * https://webarchive.jira.com/wiki/display/Heritrix/Precedence+
              * Feature+Notes
              */
-            curi.setSchedulingDirective(SchedulingConstants.HIGH);
-            curi.setPrecedence(1);
+            if (Hop.INFERRED.getHopString().equals(curi.getLastHop())
+                    || Hop.EMBED.getHopString().equals(curi.getLastHop())) {
+                curi.setSchedulingDirective(SchedulingConstants.HIGH);
+                curi.setPrecedence(1);
+            }
 
             curi.setForceFetch(forceFetch || jo.optBoolean("forceFetch"));
             curi.setSeed(jo.optBoolean("isSeed"));

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -153,25 +153,10 @@ public class AMQPUrlReceiver
 
     /**
      * The maximum prefetch count to use, meaning the maximum number of messages
-     * to be consumed without being acknowledged. Use 'null' to specify there
-     * should be no upper limit (the default).
+     * to be consumed without being acknowledged. Using 'null' would specify
+     * there should be no upper limit (the default).
      */
-    private Integer prefetchCount = null;
-
-    /**
-     * @return the prefetchCount
-     */
-    public Integer getPrefetchCount() {
-        return prefetchCount;
-    }
-
-    /**
-     * @param prefetchCount
-     *            the prefetchCount to set
-     */
-    public void setPrefetchCount(Integer prefetchCount) {
-        this.prefetchCount = prefetchCount;
-    }
+    private Integer prefetchCount = 1000;
 
     private transient Lock lock = new ReentrantLock(true);
 

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -434,7 +434,8 @@ public class AMQPUrlReceiver
             }
             curi.getData().put("customHttpRequestHeaders", customHttpRequestHeaders);
 
-            /* Crawl job must be configured to use
+            /*
+             * Crawl job must be configured to use
              * HighestUriQueuePrecedencePolicy to ensure these high priority
              * urls really get crawled ahead of others. See
              * https://webarchive.jira.com/wiki/display/Heritrix/Precedence+
@@ -443,6 +444,9 @@ public class AMQPUrlReceiver
             if (Hop.INFERRED.getHopString().equals(curi.getLastHop())
                     || Hop.EMBED.getHopString().equals(curi.getLastHop())) {
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
+                curi.setPrecedence(1);
+            } else {
+                curi.setSchedulingDirective(SchedulingConstants.NORMAL);
                 curi.setPrecedence(1);
             }
 

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -446,7 +446,13 @@ public class AMQPUrlReceiver
                 curi.setSchedulingDirective(SchedulingConstants.HIGH);
                 curi.setPrecedence(1);
             } else {
-                curi.setSchedulingDirective(SchedulingConstants.NORMAL);
+                /*
+                 * By default, redirects get set to MEDIUM, so to ensure the
+                 * incoming links are caught promptly, even if the crawler hits
+                 * a lot of redirects (which we have observed for e.g. The
+                 * Guardian), we bump them to MEDIUM so these links can compete.
+                 */
+                curi.setSchedulingDirective(SchedulingConstants.MEDIUM);
                 curi.setPrecedence(1);
             }
 


### PR DESCRIPTION
This change aims to allow two things. Firstly, it allows the received URLs to control the hop path (because classifying everything as I was causing problems for us). Secondly, it allows the QOS field to be set to avoid the message consumer aggressively soaking up messages much faster than it can ACK them (which ends up starving RabbitMQ of memory for us).

I also updated Kryo 1 to latest bug-fix version, but this can probably be taken out if you'd rather.