### PR TITLE
updateRobots deem S_CONNECT_FAILED 404

### DIFF
--- a/modules/src/main/java/org/archive/modules/net/CrawlServer.java
+++ b/modules/src/main/java/org/archive/modules/net/CrawlServer.java
@@ -157,6 +157,12 @@ public class CrawlServer implements Serializable, FetchStats.HasFetchStats, Iden
             gotSomething = true;
         }
        
+        // special deeming for connection-failure
+         if (curi.getFetchStatus() == S_CONNECT_FAILED) {
+             curi.setFetchStatus(S_DEEMED_NOT_FOUND);
+             gotSomething = true;
+         }
+
        if (!gotSomething) {
            // robots.txt fetch failed and exceptions (ignore/deeming) don't apply; no valid robots info yet
            validRobots = false;


### PR DESCRIPTION
seeing many connection failures for twitter's https://pbs.twimg.com/robots.txt—
let's treat this as a 404 (and not S_ROBOTS_PREREQUISITE_FAILURE)