### PR TITLE
Enforce robots.txt character limit per char not per line

### DIFF
--- a/modules/src/main/java/org/archive/modules/net/CrawlServer.java
+++ b/modules/src/main/java/org/archive/modules/net/CrawlServer.java
@@ -174,10 +174,9 @@ public class CrawlServer implements Serializable, FetchStats.HasFetchStats, Iden
 
         InputStream contentBodyStream = null;
         try {
-            BufferedReader reader;
             contentBodyStream = curi.getRecorder().getContentReplayInputStream();
 
-            reader = new BufferedReader(new InputStreamReader(contentBodyStream));
+            InputStreamReader reader = new InputStreamReader(contentBodyStream);
             robotstxt = new Robotstxt(reader);
             validRobots = true;
         } catch (IOException e) {

--- a/modules/src/main/java/org/archive/modules/net/Robotstxt.java
+++ b/modules/src/main/java/org/archive/modules/net/Robotstxt.java
@@ -93,10 +93,14 @@ public class Robotstxt implements Serializable {
 
         String[] lines = LINE_SEPARATOR.split(buffer);
         if (buffer.limit() == buffer.capacity()) {
-            int processed = buffer.capacity() - lines[lines.length - 1].length();
+            int processed = buffer.capacity();
+            if (lines.length != 0) {
+                // discard the partial line at the end so we don't process a truncated path
+                int last = lines.length - 1;
+                processed -= lines[last].length();
+                lines[last] = "";
+            }
             logger.warning("processed " + processed + " characters, ignoring the rest (see HER-1990)");
-            // discard the partial line at the end so we don't process a truncated path
-            lines[lines.length - 1] = "";
         }
 
         // current is the disallowed paths for the preceding User-Agent(s)

--- a/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
+++ b/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
@@ -20,6 +20,7 @@ package org.archive.modules.net;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
 
@@ -29,7 +30,7 @@ import org.archive.bdb.AutoKryo;
 
 public class RobotstxtTest extends TestCase {
     public void testParseRobots() throws IOException {
-        BufferedReader reader = new BufferedReader(new StringReader("BLAH"));
+        Reader reader = new StringReader("BLAH");
         Robotstxt r = new Robotstxt(reader);
         assertFalse(r.hasErrors);
         assertEquals(0,r.getNamedUserAgents().size());
@@ -57,8 +58,7 @@ public class RobotstxtTest extends TestCase {
     }
     
     static Robotstxt sampleRobots1() throws IOException {
-        BufferedReader reader = new BufferedReader(
-            new StringReader(
+        Reader reader = new StringReader(
                 "User-agent: *\n" +
                 "Disallow: /cgi-bin/\n" +
                 "Disallow: /details/software\n" +
@@ -78,13 +78,12 @@ public class RobotstxtTest extends TestCase {
                 "Disallow: /\n" +
                 "Crawl-Delay: 20\n"+
                 "Allow: /images/\n"
-            ));
+            );
         return new Robotstxt(reader); 
     }
     
     Robotstxt whitespaceFlawedRobots() throws IOException {
-        BufferedReader reader = new BufferedReader(
-            new StringReader(
+        Reader reader = new StringReader(
                 "  User-agent: *\n" +
                 " Disallow: /cgi-bin/\n" +
                 "  Disallow: /details/software\n" +
@@ -100,7 +99,7 @@ public class RobotstxtTest extends TestCase {
                 "  Disallow: /\n" +
                 " Crawl-Delay: 20\n"+
                 " Allow: /images/\n"
-            ));
+            );
         return new Robotstxt(reader); 
     }
     
@@ -144,8 +143,7 @@ public class RobotstxtTest extends TestCase {
     }
 
     Robotstxt htmlMarkupRobots() throws IOException {
-        BufferedReader reader = new BufferedReader(
-            new StringReader(
+        Reader reader = new StringReader(
                 "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\"><HTML>\n"
                 +"<HEAD>\n"
                 +"<TITLE>/robots.txt</TITLE>\n"
@@ -157,7 +155,7 @@ public class RobotstxtTest extends TestCase {
                 +"\n"
                 +"</BODY>\n"
                 +"</HTML>\n"
-            ));
+            );
         return new Robotstxt(reader); 
     }
     
@@ -188,7 +186,7 @@ public class RobotstxtTest extends TestCase {
         "Disallow:/service\n";
 
         StringReader sr = new StringReader(TEST_ROBOTS_TXT);
-        Robotstxt rt = new Robotstxt(new BufferedReader(sr));
+        Robotstxt rt = new Robotstxt(sr);
         {
             RobotsDirectives da = rt.getDirectivesFor("a", false);
             RobotsDirectives db = rt.getDirectivesFor("b", false);
@@ -216,7 +214,7 @@ public class RobotstxtTest extends TestCase {
                 + "User-agent: a\n"
                 + "Crawl-delay: 99\n";
         StringReader sr = new StringReader(TEST_ROBOTS_TXT);
-        Robotstxt rt = new Robotstxt(new BufferedReader(sr));
+        Robotstxt rt = new Robotstxt(sr);
 
         assertFalse(rt.getDirectivesFor("a").allows("/foo"));
 
@@ -231,14 +229,18 @@ public class RobotstxtTest extends TestCase {
     public void testSizeLimit() throws IOException {
         StringBuilder builder = new StringBuilder(
                 "User-agent: a\n" +
-                "  Disallow: /\n" +
-                "User-Agent: b\n");
+                        "  Disallow: /\n" +
+                        "User-Agent: b\nDisallow: /");
         for (int i = 0; i < Robotstxt.MAX_SIZE; i++) {
             builder.append(' ');
         }
-        builder.append("Disallow: /\n");
-        Robotstxt rt = new Robotstxt(new BufferedReader(new StringReader(builder.toString())));
-        assertFalse("we should parse the first part", rt.getDirectivesFor("a").allows("/foo"));
-        assertTrue("but ignore anything after the size limit", rt.getDirectivesFor("b").allows("/foo"));
+        builder.append("\nUser-Agent: c\nDisallow: /\n");
+        Robotstxt rt = new Robotstxt(new StringReader(builder.toString()));
+        assertFalse("we should parse the first few lines",
+                rt.getDirectivesFor("a").allows("/foo"));
+        assertTrue("ignore the line that breaks the size limit",
+                rt.getDirectivesFor("b").allows("/foo"));
+        assertTrue("and also ignore any lines after the size limit",
+                rt.getDirectivesFor("c").allows("/foo"));
     }
 }

--- a/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
+++ b/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
@@ -243,4 +243,12 @@ public class RobotstxtTest extends TestCase {
         assertTrue("and also ignore any lines after the size limit",
                 rt.getDirectivesFor("c").allows("/foo"));
     }
+
+    public void testAllBlankLines() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < Robotstxt.MAX_SIZE; i++) {
+            builder.append('\n');
+        }
+        new Robotstxt(new StringReader(builder.toString()));
+    }
 }

--- a/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
+++ b/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
@@ -227,4 +227,18 @@ public class RobotstxtTest extends TestCase {
 
         assertEquals(99f, rt.getDirectivesFor("a").getCrawlDelay());
     }
+
+    public void testSizeLimit() throws IOException {
+        StringBuilder builder = new StringBuilder(
+                "User-agent: a\n" +
+                "  Disallow: /\n" +
+                "User-Agent: b\n");
+        for (int i = 0; i < Robotstxt.MAX_SIZE; i++) {
+            builder.append(' ');
+        }
+        builder.append("Disallow: /\n");
+        Robotstxt rt = new Robotstxt(new BufferedReader(new StringReader(builder.toString())));
+        assertFalse("we should parse the first part", rt.getDirectivesFor("a").allows("/foo"));
+        assertTrue("but ignore anything after the size limit", rt.getDirectivesFor("b").allows("/foo"));
+    }
 }


### PR DESCRIPTION
Since we were only enforcing the size limit after reading each
line a single very long line could cause us to to run out of
memory.

This change enforces the character limit on each read character
not just on line boundaries.

We also correct the count of processed characters in the warning
message, which was not counting newline and linefeed characters.