### PR TITLE
fix for test failures in a workspace on NFS-mounted filesystem

### DIFF
--- a/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
+++ b/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
@@ -128,6 +128,14 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
         return bdb;
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+    	if (bdb != null) {
+    		bdb.close();
+    	}
+    	super.tearDown();
+    }
+
     public void testBasics() throws InterruptedException, IOException {
         historyStore().store.clear();
         assertTrue(historyStore().store.isEmpty());


### PR DESCRIPTION
I ran `mvn package` in a workspace on NFS-mounted filesystem, and build consistently failed with following output:
```
Tests in error: 
  testWarcDedupe(org.archive.modules.recrawl.ContentDigestHistoryTest): Unable to delete directory /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb.
  testDomains(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testSimpleReplace(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testMaxCookieDomain(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testPaths(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testSaveLoadCookies(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testConcurrentLoadNoDomainCookieLimitBreach(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testConcurrentLoad(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
  testBasics(org.archive.modules.fetcher.CookieStoreTest): Unable to delete file: /home/kenji/heritrix3-hq/modules/target/heritrix-junit-tests/bdb/.nfs000000001c56045f0000056b
```
I tracked the failure down to `FileUtils.deleteDirectory` in `CookiesStoreTest.bdb` method. I suspect `ContentDigestHistoryTest` is leaving `BdbModule` open and preventing following tests from deleting bdb directory in following tests. This is fixed by adding `tearDown` method that closes `bdb` to `ContentDigestHistoryTest`

I speculate this may be the issue behind #175 as well.