### PR TITLE
fix exception starting DecideRuleSequence logging

### DIFF
--- a/modules/src/main/java/org/archive/modules/SimpleFileLoggerProvider.java
+++ b/modules/src/main/java/org/archive/modules/SimpleFileLoggerProvider.java
@@ -22,4 +22,5 @@ import java.util.logging.Logger;
 
 public interface SimpleFileLoggerProvider {
     public Logger setupSimpleLog(String logName);
+    public void start();
 }

--- a/modules/src/main/java/org/archive/modules/deciderules/DecideRuleSequence.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/DecideRuleSequence.java
@@ -171,6 +171,10 @@ public class DecideRuleSequence extends DecideRule implements BeanNameAware, Lif
     @Override
     public void start() {
         if (getLogToFile() && fileLogger == null) {
+            // loggerModule.start() creates the log directory, and evidently
+            // it's possible for this module to start before loggerModule,
+            // so we need to run this here to prevent an exception
+            loggerModule.start();
             fileLogger = loggerModule.setupSimpleLog(getBeanName());
         }
         isRunning = true;


### PR DESCRIPTION
I don't know why we've never seen this before, and now we suddenly have
a case of it, but this is the exception:

2018-07-23 17:47:01.123 SEVERE thread-2875088 org.archive.crawler.framework.CrawlJob.beansException() Failed to start bean 'scope'; nested exception is java.lang.IllegalStateException: java.nio.file.NoSuchFileException: /1/ait-h3-jobs/8144-20180723162745141/20180723174701/logs/scope.log.lck
org.springframework.context.ApplicationContextException: Failed to start bean 'scope'; nested exception is java.lang.IllegalStateException: java.nio.file.NoSuchFileException: /1/ait-h3-jobs/8144-20180723162745141/20180723174701/logs/scope.log.lck
        at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:169)
        at org.springframework.context.support.DefaultLifecycleProcessor.access$1(DefaultLifecycleProcessor.java:154)
        at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:335)
        at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:143)
        at org.springframework.context.support.DefaultLifecycleProcessor.start(DefaultLifecycleProcessor.java:89)
        at org.springframework.context.support.AbstractApplicationContext.start(AbstractApplicationContext.java:1236)
        at org.archive.spring.PathSharingContext.start(PathSharingContext.java:115)
        at org.archive.crawler.framework.CrawlJob.startContext(CrawlJob.java:455)
        at org.archive.crawler.framework.CrawlJob$1.run(CrawlJob.java:428)
Caused by: java.lang.IllegalStateException: java.nio.file.NoSuchFileException: /1/ait-h3-jobs/8144-20180723162745141/20180723174701/logs/scope.log.lck
        at org.archive.crawler.reporting.CrawlerLoggerModule.setupSimpleLog(CrawlerLoggerModule.java:298)
        at org.archive.modules.deciderules.DecideRuleSequence.start(DecideRuleSequence.java:174)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:166)
        ... 8 more
Caused by: java.nio.file.NoSuchFileException: /1/ait-h3-jobs/8144-20180723162745141/20180723174701/logs/scope.log.lck
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:177)
        at java.nio.channels.FileChannel.open(FileChannel.java:287)
        at java.nio.channels.FileChannel.open(FileChannel.java:335)
        at java.util.logging.FileHandler.openFiles(FileHandler.java:478)
        at java.util.logging.FileHandler.<init>(FileHandler.java:344)
        at org.archive.io.GenerationFileHandler.<init>(GenerationFileHandler.java:63)
        at org.archive.io.GenerationFileHandler.makeNew(GenerationFileHandler.java:158)
        at org.archive.crawler.reporting.CrawlerLoggerModule.setupLogFile(CrawlerLoggerModule.java:275)
        at org.archive.crawler.reporting.CrawlerLoggerModule.setupSimpleLog(CrawlerLoggerModule.java:296)
        ... 10 more