### PR TITLE
Extend API to simplify using the latest checkpoint

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
@@ -393,6 +393,21 @@ public class CheckpointService implements Lifecycle, ApplicationContextAware, Ha
         if(isRunning) {
             throw new RuntimeException("may not set recovery Checkpoint after launch");
         }
+        // If the selectedCheckpoint is 'latest', pick up the latest checkpoint
+        // and use that:
+        if ("latest".equalsIgnoreCase(selectedCheckpoint)) {
+            List<File> cps = this.findAvailableCheckpointDirectories();
+            if (cps == null || cps.size() == 0) {
+                throw new RuntimeException(
+                        "Cannot find any checkpoints so cannot choose the latest one.");
+            }
+            // As per the API above, the most recent checkpoint is the first in
+            // the list:
+            File latestFile = cps.get(0);
+            // For the checkpoint we use the folder name:
+            selectedCheckpoint = latestFile.getName();
+        }
+        // Now setup the checkpoint:
         Checkpoint recoveryCheckpoint = new Checkpoint();
         recoveryCheckpoint.getCheckpointDir().setBase(getCheckpointsDir());
         recoveryCheckpoint.getCheckpointDir().setPath(selectedCheckpoint);

--- a/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
@@ -398,8 +398,9 @@ public class CheckpointService implements Lifecycle, ApplicationContextAware, Ha
         if ("latest".equalsIgnoreCase(selectedCheckpoint)) {
             List<File> cps = this.findAvailableCheckpointDirectories();
             if (cps == null || cps.size() == 0) {
-                throw new RuntimeException(
-                        "Cannot find any checkpoints so cannot choose the latest one.");
+                LOGGER.warning(
+                        "Cannot find any checkpoints so cannot choose the latest one! Assuming we should launch a new crawl.");
+                return;
             }
             // As per the API above, the most recent checkpoint is the first in
             // the list:


### PR DESCRIPTION
This extends the Launch API, so that if the string `latest` is passed, Heritrix3 will look up the most recent checkpoint and use that automatically.

This is just a small convenience to save the client having to look up and work out the latest checkpoint. 