### PR TITLE
use non-deprecated hbase api

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>0.96.1.1-cdh5.0.2</version>
+			<version>0.98.6-cdh5.3.5</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jets3t</artifactId>

--- a/contrib/src/main/java/org/archive/modules/recrawl/hbase/HBase.java
+++ b/contrib/src/main/java/org/archive/modules/recrawl/hbase/HBase.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HConnectionManager;
 import org.springframework.context.Lifecycle;
 
 /**

--- a/contrib/src/main/java/org/archive/modules/recrawl/hbase/HBaseTable.java
+++ b/contrib/src/main/java/org/archive/modules/recrawl/hbase/HBaseTable.java
@@ -23,10 +23,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HConnection;
+import org.apache.hadoop.hbase.client.HConnectionManager;
 import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.hadoop.hbase.client.HTablePool;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 
@@ -40,6 +42,9 @@ public class HBaseTable extends HBaseTableBean {
             Logger.getLogger(HBaseTable.class.getName());
 
     protected boolean create = false;
+    protected HConnection hconn = null;
+    protected HTableInterface htable;
+
     public boolean getCreate() {
         return create;
     }
@@ -48,81 +53,104 @@ public class HBaseTable extends HBaseTableBean {
         this.create = create;
     }
 
-    protected HTablePool htablePool = null;
-
     public HBaseTable() {
     }
 
-    protected synchronized HTablePool htablePool() throws IOException {
-        if (htablePool == null) {
-            // XXX maxSize = number of toe threads?
-            htablePool = new HTablePool(hbase.configuration(),
-                    Integer.MAX_VALUE);
+    protected HConnection hconnection() throws IOException {
+        if (hconn == null) {
+            hconn = HConnectionManager.createConnection(hbase.configuration());
         }
+        return hconn;
+    }
 
-        return htablePool;
+    protected HTableInterface htable() throws IOException {
+        if (htable == null) {
+            htable = hconnection().getTable(htableName);
+        }
+        return htable();
     }
 
     @Override
     public void put(Put p) throws IOException {
-        HTableInterface table = htablePool().getTable(htableName);
+        HTableInterface table = hconnection().getTable(htableName);
         try {
             table.put(p);
-        } finally {
-            htablePool().putTable(table);
-            // table.close(); // XXX hbase 0.92
+        } catch (IOException e) {
+            reset();
+            throw e;
         }
     }
 
     @Override
     public Result get(Get g) throws IOException {
-        HTableInterface table = htablePool().getTable(htableName);
+        HTableInterface table = hconnection().getTable(htableName);
         try {
             return table.get(g);
-        } finally {
-            htablePool().putTable(table);
-            // table.close(); // XXX hbase 0.92
+        } catch (IOException e) {
+            reset();
+            throw e;
         }
     }
 
     public HTableDescriptor getHtableDescriptor() throws IOException {
-        HTableInterface table = htablePool().getTable(htableName);
+        HTableInterface table = hconnection().getTable(htableName);
         try {
             return table.getTableDescriptor();
-        } finally {
-            htablePool().putTable(table);
+        } catch (IOException e) {
+            reset();
+            throw e;
         }
     }
 
     @Override
     public void start() {
-        try {
-            if (getCreate()) {
-                HBaseAdmin admin = hbase.admin();
-                if (!admin.tableExists(htableName)) {
-                    HTableDescriptor desc = new HTableDescriptor(htableName);
-                    logger.info("hbase table '" + htableName + "' does not exist, creating it... " + desc);
-                    admin.createTable(desc);
+        int ATTEMPTS = 3;
+
+        for (int attempt = 1; attempt <= ATTEMPTS; attempt++) {
+            try {
+                if (getCreate()) {
+                    HBaseAdmin admin = hbase.admin();
+                    if (!admin.tableExists(htableName)) {
+                        HTableDescriptor desc = new HTableDescriptor(TableName.valueOf(htableName));
+                        logger.info("hbase table '" + htableName + "' does not exist, creating it... " + desc);
+                        admin.createTable(desc);
+                    }
+                }
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "(attempt " + attempt + "/" + ATTEMPTS + ") problem creating hbase table " + htableName, e);
+                if (attempt >= ATTEMPTS) {
+                    throw new RuntimeException(e);
                 }
             }
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "problem creating hbase table " + htableName, e);
         }
 
         super.start();
     }
 
+    protected void reset() {
+        logger.info("attempting to reset hbase connection state");
+        if (htable != null) {
+            try {
+                htable.close();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "htablename='" + htableName + "' htable.close() threw " + e, e);
+            }
+            htable = null;
+        }
+
+        if (hconn != null) {
+            try {
+                hconn.close();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "hconn.close() threw " + e, e);
+            }
+            hconn = null;
+        }
+    }
+
     @Override
     public synchronized void stop() {
         super.stop();
-        // org.apache.hadoop.io.IOUtils.closeStream(htablePool); // XXX hbase 0.92
-        if (htablePool != null) {
-            try {
-                htablePool.close();
-            } catch (IOException e) {
-                logger.warning("problem closing HTablePool " + htablePool + " - " + e);
-            }
-            htablePool = null;
-        }
+        reset();
     }
 }


### PR DESCRIPTION
Catch exceptions and attempt to reset the hbase connection. The intent
is for this to fix the problem where the hbase connection (under the
hood the problem is the zookeeper connection) gets into a borked state,
and we never reset it.