### PR TITLE
implement PredicatedDecideRule.onlyDecision()

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/PredicatedDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/PredicatedDecideRule.java
@@ -28,6 +28,7 @@ import org.archive.modules.CrawlURI;
  * @author gojomo
  */
 public abstract class PredicatedDecideRule extends DecideRule {
+    private static final long serialVersionUID = 1L;
 
     {
         setDecision(DecideResult.ACCEPT);
@@ -48,6 +49,11 @@ public abstract class PredicatedDecideRule extends DecideRule {
             return getDecision();
         }
         return DecideResult.NONE;
+    }
+
+    @Override
+    public DecideResult onlyDecision(CrawlURI uri) {
+        return getDecision();
     }
 
     protected abstract boolean evaluate(CrawlURI object);


### PR DESCRIPTION
DecideRuleSequence already has the optimization that I was looking for,
namely, don't bother evaluating a DecideRule if we know it won't change
the current result. For some reason PredicatedDecideRule, which is a
parent class to most of the decide rules in heritrix, didn't implement
onlyDecision(). Certain crawl configurations could see significant
performance improvement with this change.