### PR TITLE
namespace scope log logger to crawl job

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/CrawlerLoggerModule.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/CrawlerLoggerModule.java
@@ -282,8 +282,6 @@ public class CrawlerLoggerModule
     }
     
     public Logger setupSimpleLog(String logName) {
-        Logger logger = Logger.getLogger(logName + ".log");
-        
         Formatter f = new Formatter() {
             public String format(java.util.logging.LogRecord record) {
                 return ArchiveUtils.getLog17Date(record.getMillis()) + " " + record.getMessage() + '\n';
@@ -292,6 +290,7 @@ public class CrawlerLoggerModule
 
         ConfigPath logPath = new ConfigPath(logName + ".log", logName + ".log");
         logPath.setBase(getPath());
+        Logger logger = Logger.getLogger(logPath.getFile().getAbsolutePath());
         try {
             setupLogFile(logger, logPath.getFile().getAbsolutePath(), f, true);
         } catch (IOException e) {


### PR DESCRIPTION
This is a bad bug. Stupid, too. When multiple crawls are running with
`DecideRuleSequence.logToFile` enabled, all the scope log lines from all
the crawls are going to all the scope logs for all the crawls. It was
because of this line:

    Logger logger = Logger.getLogger(logName + ".log");

`logName` here is "scope" normally, for all crawl jobs.
`Logger` is shared across the whole java vm, so
`Logger.getLogger("scope.log")` returns the same logger for every
crawl job. Each time a crawl starts, it adds another output file to
the logger.

Fix is to give the logger a name specific to the crawl job.

😳🥵🥶💩