### PR TITLE
do not checkpoint if crawl job has not started

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
@@ -240,6 +240,11 @@ public class CheckpointService implements Lifecycle, ApplicationContextAware, Ha
      * Run a checkpoint of the crawler
      */
     public synchronized String requestCrawlCheckpoint() throws IllegalStateException {
+        if (!controller.hasStarted()) {
+            LOGGER.info("crawl job has not started; ignoring");
+            return null;
+        }
+
         if (isCheckpointing()) {
             throw new IllegalStateException("Checkpoint already running.");
         }


### PR DESCRIPTION
Sometimes our crawl jobs get stuck in the NEW state (due to hbase
problems). But the checkpoint service has started and sees fit to
checkpoint every five minutes. Evidently, at this stage the seeds have
not been queued yet, the frontier is empty. Thus, if we try to resume
from one of these checkpoints, the crawl has an empty frontier and ends
immediately.

The fix is to avoid checkpointing in this NEW state before crawling has
really started.