### PR TITLE
Allow failed lookups to expire, for #234.

### DIFF
--- a/engine/src/main/java/org/archive/crawler/prefetch/PreconditionEnforcer.java
+++ b/engine/src/main/java/org/archive/crawler/prefetch/PreconditionEnforcer.java
@@ -291,7 +291,7 @@ public class PreconditionEnforcer extends Processor  {
         // cancel further fetch-processing of this URI, because
         // the domain is unresolvable
         CrawlHost ch = serverCache.getHostFor(curi.getUURI());
-        if (ch == null || ch.hasBeenLookedUp() && ch.getIP() == null) {
+        if (ch == null || ch.getIP() == null && !isIpExpired(curi)) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.fine( "no dns for " + ch +
                     " cancelling processing for CrawlURI " + curi.toString());


### PR DESCRIPTION
This change should ensure that DNS failures are not cached 'forever' and instead expire just as successful DNS lookups do.