### PR TITLE
Fix for srcset parsing base64 encoded images as urls.

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -685,6 +685,11 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
             String[] links = value.toString().split(",");
             for (int i=0; i < links.length; i++){
                 String link = links[i].trim().split(" +")[0];
+		//base64 encoded images contain a comma, so the next element is a continuation of this encoded image
+		if(link.startsWith("data:image")){
+		    i++;
+		    continue;
+		}
                 logger.finer("Found " + link + " adding to outlinks.");
                 addLinkFromString(curi, link, context, hop);
                 numberOfLinksExtracted.incrementAndGet();

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -512,7 +512,7 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
 
         CharSequence cs = "<img width=\"800\" height=\"1200\" src=\"/images/foo.jpg\" "
                 + "class=\"attachment-full size-full\" alt=\"\" "
-                + "srcset=\"/images/foo1.jpg 800w, /images/foo2.jpg 480w, /images/foo3.jpg 96w\" "
+                + "srcset=\"/images/foo1.jpg 800w, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 700w, /images/foo2.jpg 480w, /images/foo3.jpg 96w\" "
                 + "sizes=\"(max-width: 800px) 100vw, 800px\">";
 
         getExtractor().extract(curi, cs);


### PR DESCRIPTION
srcset attributes contain a comma separated list of urls, however base64 encoded images also contain a comma. This causes the srcset url parser to split the encoded image and interpret it as 2 urls instead of ignoring it.