### PR TITLE
Handle commas more compliantly when parsing srcset

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -682,7 +682,7 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
 
             logger.fine("Found srcset listing: " + value.toString());
 
-            Matcher matcher = TextUtils.getMatcher("[\\s,]*(\\S*[^,\\s])(?:\\s(?:[^,(]+|\\([^)]*\\))*)?", value);
+            Matcher matcher = TextUtils.getMatcher("[\\s,]*(\\S*[^,\\s])(?:\\s(?:[^,(]+|\\([^)]*(?:\\)|$))*)?", value);
             while (matcher.lookingAt()) {
                 String link = matcher.group(1);
                 matcher.region(matcher.end(), matcher.regionEnd());

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -682,13 +682,15 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
 
             logger.fine("Found srcset listing: " + value.toString());
 
-            String[] links = value.toString().split(",");
-            for (int i=0; i < links.length; i++){
-                String link = links[i].trim().split(" +")[0];
+            Matcher matcher = TextUtils.getMatcher("[\\s,]*(\\S*[^,\\s])(?:\\s(?:[^,(]+|\\([^)]*\\))*)?", value);
+            while (matcher.lookingAt()) {
+                String link = matcher.group(1);
+                matcher.region(matcher.end(), matcher.regionEnd());
                 logger.finer("Found " + link + " adding to outlinks.");
                 addLinkFromString(curi, link, context, hop);
                 numberOfLinksExtracted.incrementAndGet();
             }
+            TextUtils.recycleMatcher(matcher);
         } else {
             addLinkFromString(curi,
                 (value instanceof String)?

--- a/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
@@ -196,6 +196,13 @@ public class JerichoExtractorHTML extends ExtractorHTML {
 
             processEmbed(curi, attrValue, context, hopType);
         }
+        // SRCSET
+        if (((attr = attributes.get("srcset")) != null) &&
+                ((attrValue = attr.getValue()) != null)) {
+            codebase = StringEscapeUtils.unescapeHtml(attrValue);
+            CharSequence context = elementContext(elementName, attr.getKey());
+            processEmbed(curi, codebase, context);
+        }
         // CODEBASE
         if (((attr = attributes.get("codebase")) != null) &&
                  ((attrValue = attr.getValue()) != null)) {

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -512,7 +512,7 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
 
         CharSequence cs = "<img width=\"800\" height=\"1200\" src=\"/images/foo.jpg\" "
                 + "class=\"attachment-full size-full\" alt=\"\" "
-                + "srcset=\"/images/foo1.jpg 800w, /images/foo2.jpg 480w, /images/foo3.jpg 96w\" "
+                + "srcset=\"a,b,c,,, /images/foo1.jpg 800w,data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 700w, /images/foo2.jpg 480w(data:,foo, ,), /images/foo3.jpg 96w\" "
                 + "sizes=\"(max-width: 800px) 100vw, 800px\">";
 
         getExtractor().extract(curi, cs);
@@ -521,6 +521,8 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
         Arrays.sort(links);
 
         String[] dest = {
+                "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "http://www.example.com/a,b,c",
                 "http://www.example.com/images/foo.jpg",
                 "http://www.example.com/images/foo1.jpg",
                 "http://www.example.com/images/foo2.jpg",

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -512,7 +512,7 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
 
         CharSequence cs = "<img width=\"800\" height=\"1200\" src=\"/images/foo.jpg\" "
                 + "class=\"attachment-full size-full\" alt=\"\" "
-                + "srcset=\"a,b,c,,, /images/foo1.jpg 800w,data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 700w, /images/foo2.jpg 480w(data:,foo, ,), /images/foo3.jpg 96w\" "
+                + "srcset=\"a,b,c,,, /images/foo1.jpg 800w,data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 700w, /images/foo2.jpg 480w(data:,foo, ,), /images/foo3.jpg 96w(x\" "
                 + "sizes=\"(max-width: 800px) 100vw, 800px\">";
 
         getExtractor().extract(curi, cs);

--- a/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
@@ -151,15 +151,6 @@ public class JerichoExtractorHTMLTest extends ExtractorHTMLTest {
     @Override
     public void testConditionalComment1() throws URIException {
     }
-    
-    /*
-     * Override of ExtractorHTMLTest method because the test fails with
-     * JerichoExtractorHTML
-     */
-    @Override
-    public void testImgSrcSetAttribute() throws URIException {
-        // jericho parser doesn't understand srcset
-    }
 
     /*
      * Override of ExtractorHTMLTest method because the test fails with

--- a/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
@@ -157,6 +157,15 @@ public class JerichoExtractorHTMLTest extends ExtractorHTMLTest {
      * JerichoExtractorHTML
      */
     @Override
+    public void testImgSrcSetAttribute() throws URIException {
+        // jericho parser doesn't understand srcset
+    }
+
+    /*
+     * Override of ExtractorHTMLTest method because the test fails with
+     * JerichoExtractorHTML
+     */
+    @Override
     public void testMetaContentURI() throws URIException {
     }
     


### PR DESCRIPTION
Commas are allowed if they're in the middle of the URL. Consequently:

    srcset="a,b,,c,"   => ["a,b,,c"]
    srcset="a, b,, c," => ["a", "b", "c"]

They occur particularly commonly in data: URLs before the base64 value.

Commas are also allowed in descriptors if they are enclosed by parens:

    srcset="a (b,c),d" => ["a", "d"]

Spec: https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute