### PR TITLE
Update README and add LICENSE.txt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,37 @@
-Readme for Heritrix
-====================
+# Heritrix
+[![Build Status](https://travis-ci.org/internetarchive/heritrix3.svg?branch=master)](https://travis-ci.org/internetarchive/heritrix3)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.archive/heritrix/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.archive/heritrix)
+[![Javadoc](https://javadoc-badge.appspot.com/org.archive/heritrix.svg?label=javadoc)](http://builds.archive.org/javadoc/heritrix-3.2.0/)
+[![LICENSE](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](./LICENSE)
 
-1. Introduction
-2. Crawl Operators!
-3. Getting Started
-4. Developer Documentation
-5. Release History
-6. License
+## Introduction
 
+Heritrix is the Internet Archive's open-source, extensible, web-scale, archival-quality web crawler project. Heritrix (sometimes spelled heretrix, or misspelled or missaid as heratrix/heritix/heretix/heratix) is an archaic word for heiress (woman who inherits). Since our crawler seeks to collect and preserve the digital artifacts of our culture for the benefit of future researchers and generations, this name seemed apt.
 
-## 1. Introduction
+## Crawl Operators!
 
-Heritrix is the Internet Archive's open-source, extensible, web-scale,
-archival-quality web crawler project. Heritrix (sometimes spelled heretrix, or
-misspelled or missaid as heratrix/heritix/heretix/heratix) is an archaic word
-for heiress (woman who inherits). Since our crawler seeks to collect and
-preserve the digital artifacts of our culture for the benefit of future
-researchers and generations, this name seemed apt.
+Heritrix is designed to respect the [`robots.txt`](http://www.robotstxt.org/wc/robots.html) exclusion directives and [META robots tags](http://www.robotstxt.org/wc/exclusion.html#meta). Please consider the
+load your crawl will place on seed sites and set politeness policies accordingly. Also, always identify your crawl with contact information in the `User-Agent` so sites that may be adversely affected by your crawl can contact you or adapt their server behavior accordingly.
 
+## Getting Started
 
-## 2. Crawl Operators!
+- [User Manual](https://github.com/internetarchive/heritrix3/wiki)
 
-Heritrix is designed to respect the robots.txt
-<http://www.robotstxt.org/wc/robots.html> exclusion directives and META robots
-tags <http://www.robotstxt.org/wc/exclusion.html#meta>.  Please consider the
-load your crawl will place on seed sites and set politeness policies
-accordingly. Also, always identify your crawl with contact information in the
-User-Agent so sites that may be adversely affected by your crawl can contact
-you or adapt their server behavior accordingly.
+## Developer Documentation
+
+- [Developer Manual](http://crawler.archive.org/articles/developer_manual/index.html)
+- [REST API documentation](https://heritrix.readthedocs.io/en/latest/api.html)
+- [JavaDoc](http://builds.archive.org/javadoc/heritrix-3.2.0/) (n.b. Javadoc currently out of date)
 
 
-## 3. Getting Started
+## Latest Releases
 
-See the User Manual, available from <https://github.com/internetarchive/heritrix3/wiki>
+Information about releases can be found [here](https://github.com/internetarchive/heritrix3/wiki#latest-releases).
 
+## License
 
-## 4. Developer Documentation
+Heritrix is free software; you can redistribute it and/or modify it under the terms of the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-See <http://crawler.archive.org/articles/developer_manual/index.html>.
-For REST API documentation, see <https://heritrix.readthedocs.io/en/latest/api.html>
-and for JavaDoc see <http://builds.archive.org/javadoc/heritrix-3.2.0/> (n.b. Javadoc currently out of date).
+Some individual source code files are subject to or offered under other licenses. See the included [`LICENSE.txt`](./LICENSE) file for more information.
 
-
-## 5. Latest Releases
-
-Information about releases can be found at <https://github.com/internetarchive/heritrix3/wiki#latest-releases>
-
-
-## 6. License
-
-Heritrix is free software; you can redistribute it and/or modify it
-under the terms of the Apache License, Version 2.0:
-
- http://www.apache.org/licenses/LICENSE-2.0
-
-Some individual source code files are subject to or offered under other
-licenses. See the included LICENSE.txt file for more information.
-
-Heritrix is distributed with the libraries it depends upon.  The
-libraries can be found under the 'lib' directory, and are used under
-the terms of their respective licenses, which are included alongside
-the libraries in the 'lib' directory.
-
+Heritrix is distributed with the libraries it depends upon. The libraries can be found under the `lib` directory in the release distribution, and are used under the terms of their respective licenses, which are included alongside the libraries in the `lib` directory.


### PR DESCRIPTION
- Add badges to README
- Update Markdown
- Clean-up formatting
- Add LICENSE.txt in root
- Partially addresses #233

<hr />

The javadocs badge displays the current release number, but links to the `3.2.0` docs. Looking at the release procedures, it doesn't look like they get updated. Should we create a separate issue to take care of this?
