### PR TITLE
JDK11 support: explicitly depend on JAXB

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -69,6 +69,18 @@
 			<artifactId>joda-time</artifactId>
 			<version>1.6</version>
 		</dependency>
+		<!-- jaxb is no longer included in jdk11+ -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.1</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.littleshoot</groupId>
 			<artifactId>littleproxy</artifactId>


### PR DESCRIPTION
JAXB is no longer included in the JDK as of JDK 11 (JEP 320) so add it as an external dependency.

Fixes #264