### PR TITLE
JDK11 support: exclude tools.jar from hbase-client dependency

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -26,6 +26,13 @@
 					<artifactId>junit</artifactId>
 					<groupId>junit</groupId>
 				</exclusion>
+				<!-- tools.jar is not available in JDK 11 so exclude it
+				     hbase-client accidentally leaked it as a transitive dependency
+				     https://issues.apache.org/jira/browse/HBASE-13963 -->
+				<exclusion>
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
tools.jar is no longer included in the JDK as of JDK 11 (per JEP 220) so exclude it as a dependency. According to [HBASE-13963] it is only required when compiling hbase itself and was unintentionally leaked as a transitive dependency.

Fixes #265

[HBASE-13963]: https://issues.apache.org/jira/browse/HBASE-13963