### PR TITLE
JDK11 support: upgrade maven-surefire-plugin to 2.22.2

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -221,7 +221,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.22.2</version>
 				<configuration>
 					<!--
 					There was a unit test, SinkHandlerTest, that required

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.22.2</version>
 				<configuration>
 					<useSystemClassLoader>true</useSystemClassLoader>
 				</configuration>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -99,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.22.2</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TestAll.java</exclude>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.22.2</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TestAll.java</exclude>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -80,6 +80,9 @@
 				<configuration>
 					<excludes>
 						<exclude>**/TestAll.java</exclude>
+						<!-- exclude FetchHTTPTests because its not meant to be invoked directly and newer
+						  versions of surefire are more lax about the filenames they pickup -->
+						<exclude>**/*Tests.java</exclude>
 					</excludes>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.22.2</version>
                 <configuration>
                     <argLine>-Xmx1g</argLine>
                     <systemPropertyVariables>


### PR DESCRIPTION
Under JDK11 our old version of it throws ClassNotFoundExceptions when
tests load some builtin classes like javax.transaction.xa.Xid.

Fixes #266