### PR TITLE
JDK11 support: upgrade to Jetty 9.4.19, Restlet 2.4.0 and drop JDK 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
   include:
   - jdk: oraclejdk8
     dist: trusty
-  - jdk: openjdk7
-    dist: trusty
-    env: PROJECTS='--projects commons,modules,engine'
   - jdk: openjdk8
   - jdk: openjdk11
   allow_failures:
@@ -22,14 +19,14 @@ before_install:
  - "export _JAVA_OPTIONS=-Xmx1500m"
  - "echo _JAVA_OPTIONS=$_JAVA_OPTIONS"
  
-install: mvn dependency:resolve -B -V $PROJECTS
+install: mvn dependency:resolve -B -V
 
 cache:
   directories:
   - $HOME/.m2
 
 script:
- - travis_wait 30 mvn install $PROJECTS
+ - travis_wait 30 mvn install
 
 after_failure:
   - cat */target/surefire-reports/*.txt

--- a/commons/src/test/resources/log4j.xml
+++ b/commons/src/test/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/contrib/src/main/resources/log4j.xml
+++ b/contrib/src/main/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/contrib/src/test/resources/log4j.xml
+++ b/contrib/src/test/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/dist/src/main/conf/logging.properties
+++ b/dist/src/main/conf/logging.properties
@@ -5,7 +5,7 @@
 # ...and even less from the too-chatty-with-WARNINGs HttpClient library...
 org.apache.commons.httpclient.level = SEVERE
 org.restlet.Component.LogFilter.level = SEVERE
-org.mortbay.log.level = SEVERE
+org.eclipse.jetty.log.level = SEVERE
 # ...but INFO for our classes, which reserve FINE/FINER/FINEST for bulk/trivia...
 org.archive.level = INFO
 

--- a/dist/src/test/resources/log4j.xml
+++ b/dist/src/test/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -25,44 +25,50 @@
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
+		<!-- we force the version of jetty rather than allowing restlet
+		     to include it transitively as we need at least 9.4.12 for jdk11 -->
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty</artifactId>
-			<version>6.1.26</version>
-			<scope>compile</scope>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>9.4.19.v20190610</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
+			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>6.1.26</version>
-			<scope>compile</scope>
+			<version>9.4.19.v20190610</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-sslengine</artifactId>
-			<version>6.1.26</version>
-			<scope>compile</scope>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+            <version>9.4.19.v20190610</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.restlet.jse</groupId>
+            <artifactId>org.restlet</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+		<dependency>
+			<groupId>org.restlet.jse</groupId>
+			<artifactId>org.restlet.ext.jetty</artifactId>
+			<version>2.4.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-client</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-ajp</artifactId>
-			<version>6.1.26</version>
-			<scope>compile</scope>
+			<groupId>org.restlet.jse</groupId>
+			<artifactId>org.restlet.ext.xml</artifactId>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.restlet</groupId>
-			<artifactId>org.restlet</artifactId>
-			<version>1.1.10</version>
-		</dependency>
-		<dependency>
-			<groupId>com.noelios.restlet</groupId>
-			<artifactId>com.noelios.restlet</artifactId>
-			<version>1.1.10</version>
-		</dependency>
-		<dependency>
-			<groupId>com.noelios.restlet</groupId>
-			<artifactId>com.noelios.restlet.ext.jetty</artifactId>
-			<version>1.1.10</version>
+			<!-- for HTTP Digest auth -->
+			<groupId>org.restlet.jse</groupId>
+			<artifactId>org.restlet.ext.crypto</artifactId>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/engine/src/main/java/org/archive/crawler/Heritrix.java
+++ b/engine/src/main/java/org/archive/crawler/Heritrix.java
@@ -351,7 +351,7 @@ public class Heritrix {
             MapVerifier verifier = new MapVerifier();
             verifier.getLocalSecrets().put(authLogin, authPassword.toCharArray());
 
-            ChallengeAuthenticator guard = new RateLimitGuard(component.getContext(),
+            ChallengeAuthenticator guard = new RateLimitGuard(component.getContext().createChildContext(),
                     ChallengeScheme.HTTP_DIGEST, "Authentication Required");
             guard.setVerifier(verifier);
             guard.setNext(new EngineApplication(engine));

--- a/engine/src/main/java/org/archive/crawler/Heritrix.java
+++ b/engine/src/main/java/org/archive/crawler/Heritrix.java
@@ -57,10 +57,11 @@ import org.archive.crawler.restlet.RateLimitGuard;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.KeyTool;
 import org.restlet.Component;
-import org.restlet.Guard;
 import org.restlet.Server;
 import org.restlet.data.ChallengeScheme;
 import org.restlet.data.Protocol;
+import org.restlet.security.ChallengeAuthenticator;
+import org.restlet.security.MapVerifier;
 
 
 /**
@@ -212,7 +213,7 @@ public class Heritrix {
                     "mailto, clsid, res, file, rtsp, about");
         }
 
-        String maxFormSize = "org.mortbay.jetty.Request.maxFormContentSize";
+        String maxFormSize = "org.eclipse.jetty.server.Request.maxFormContentSize";
         if (System.getProperty(maxFormSize) == null) {
             System.setProperty(maxFormSize, "52428800");
         }
@@ -334,24 +335,30 @@ public class Heritrix {
         try {
             engine = new Engine(jobsDir);
             component = new Component();
-            
+
             if(bindHosts.isEmpty()) {
                 // listen all addresses
-                setupServer(port, null, keystorePath, keystorePassword, keyPassword);
+                setupServer(component, port, null, keystorePath, keystorePassword, keyPassword);
             } else {
                 // bind only to declared addresses, or just 'localhost'
                 for(String address : bindHosts) {
-                    setupServer(port, address, keystorePath, keystorePassword, keyPassword);
+                    setupServer(component, port, address, keystorePath, keystorePassword, keyPassword);
                 }
             }
             component.getClients().add(Protocol.FILE);
-            component.getClients().add(Protocol.CLAP); 
-            Guard guard = new RateLimitGuard(null,
+            component.getClients().add(Protocol.CLAP);
+
+            MapVerifier verifier = new MapVerifier();
+            verifier.getLocalSecrets().put(authLogin, authPassword.toCharArray());
+
+            ChallengeAuthenticator guard = new RateLimitGuard(component.getContext(),
                     ChallengeScheme.HTTP_DIGEST, "Authentication Required");
-            guard.getSecrets().put(authLogin, authPassword.toCharArray());
-            component.getDefaultHost().attach(guard);
+            guard.setVerifier(verifier);
             guard.setNext(new EngineApplication(engine));
+
+            component.getDefaultHost().attach(guard);
             component.start();
+
             startupOut.println("engine listening at port "+port);
             startupOut.println("operator login set per " +
                     ((aOption.startsWith("@")) ? "file "+aOption : "command-line"));
@@ -457,16 +464,16 @@ public class Heritrix {
 
     /**
      * Create an HTTPS restlet Server instance matching the given parameters. 
-     * 
+     *
+     * @param component
      * @param port
      * @param address
      * @param keystorePath
      * @param keystorePassword
      * @param keyPassword
      */
-    protected void setupServer(int port, String address, String keystorePath, String keystorePassword, String keyPassword) {
-        Server server = new Server(Protocol.HTTPS,address,port,null);
-        component.getServers().add(server);
+    protected void setupServer(Component component, int port, String address, String keystorePath, String keystorePassword, String keyPassword) {
+        Server server = component.getServers().add(Protocol.HTTPS, address, port);
         server.getContext().getParameters().add("keystorePath", keystorePath);
         server.getContext().getParameters().add("keystorePassword", keystorePassword);
         server.getContext().getParameters().add("keyPassword", keyPassword);

--- a/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
@@ -19,55 +19,14 @@
 
 package org.archive.crawler.restlet;
 
-import java.util.List;
-
-import org.restlet.Context;
-import org.restlet.data.MediaType;
-import org.restlet.data.Preference;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
-import org.restlet.resource.Resource;
-import org.restlet.resource.Variant;
+import org.restlet.resource.ServerResource;
 
 /**
  * Abstract {@code Resource} with common shared functionality. 
  * 
  * @author nlevitt
  */
-public abstract class BaseResource extends Resource {
-
-    public BaseResource(Context ctx, Request req, Response res) {
-        super(ctx, req, res);
-    }
-
-    /**
-     * If client can accept text/html, always prefer it. WebKit-based browsers
-     * claim to want application/xml, but we don't want to give it to them. See
-     * <a href="https://webarchive.jira.com/browse/HER-1603">https://webarchive.jira.com/browse/HER-1603</a>
-     */
-    public Variant getPreferredVariant() {
-        boolean addExplicitTextHtmlPreference = false;
-
-        for (Preference<MediaType> mediaTypePreference: getRequest().getClientInfo().getAcceptedMediaTypes()) {
-            if (mediaTypePreference.getMetadata().equals(MediaType.TEXT_HTML)) {
-                mediaTypePreference.setQuality(Float.MAX_VALUE);
-                addExplicitTextHtmlPreference = false;
-                break;
-            } else if (mediaTypePreference.getMetadata().includes(MediaType.TEXT_HTML)) {
-                addExplicitTextHtmlPreference = true;
-            }
-        }
-        
-        if (addExplicitTextHtmlPreference) {
-            List<Preference<MediaType>> acceptedMediaTypes = getRequest().getClientInfo().getAcceptedMediaTypes();
-            acceptedMediaTypes.add(new Preference<MediaType>(MediaType.TEXT_HTML, Float.MAX_VALUE));
-            getRequest().getClientInfo().setAcceptedMediaTypes(acceptedMediaTypes);
-        }
-        
-        
-        return super.getPreferredVariant();
-    }
-    
+public abstract class BaseResource extends ServerResource {
     protected String getStaticRef(String resource) {
         String rootRef = getRequest().getRootRef().toString();
         return rootRef + "/engine/static/" + resource;

--- a/engine/src/main/java/org/archive/crawler/restlet/EditRepresentation.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EditRepresentation.java
@@ -30,8 +30,8 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.restlet.data.CharacterSet;
 import org.restlet.data.MediaType;
 import org.restlet.data.Reference;
-import org.restlet.resource.CharacterRepresentation;
-import org.restlet.resource.FileRepresentation;
+import org.restlet.representation.CharacterRepresentation;
+import org.restlet.representation.FileRepresentation;
 
 /**
  * Representation wrapping a FileRepresentation, displaying its contents
@@ -40,9 +40,9 @@ import org.restlet.resource.FileRepresentation;
  * @author gojomo
  */
 public class EditRepresentation extends CharacterRepresentation {
-    protected FileRepresentation fileRepresentation; 
+    protected FileRepresentation fileRepresentation;
     protected EnhDirectoryResource dirResource;
-    
+
     public EditRepresentation(FileRepresentation representation, EnhDirectoryResource resource) {
         super(MediaType.TEXT_HTML);
         fileRepresentation = representation;

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
@@ -26,19 +26,19 @@ import java.io.StringWriter;
 import org.archive.crawler.framework.Engine;
 import org.archive.util.TextUtils;
 import org.restlet.Application;
-import org.restlet.Directory;
-import org.restlet.Redirector;
 import org.restlet.Restlet;
-import org.restlet.Router;
 import org.restlet.data.MediaType;
 import org.restlet.data.Reference;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
+import org.restlet.Request;
+import org.restlet.Response;
 import org.restlet.data.Status;
-import org.restlet.resource.Representation;
-import org.restlet.resource.StringRepresentation;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Directory;
+import org.restlet.routing.Redirector;
+import org.restlet.routing.Router;
+import org.restlet.routing.Template;
 import org.restlet.service.StatusService;
-import org.restlet.util.Template;
 
 /**
  * Restlet Application for a Heritrix crawl 'Engine', which is aware of
@@ -56,7 +56,8 @@ public class EngineApplication extends Application {
         setStatusService(new EngineStatusService());
     }
 
-     public synchronized Restlet createRoot() {
+    @Override
+    public Restlet createInboundRoot() {
         Router router = new Router(getContext());
 
         router.attach("/",new Redirector(null,"/engine",Redirector.MODE_CLIENT_TEMPORARY));

--- a/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
@@ -23,22 +23,18 @@ package org.archive.crawler.restlet;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.commons.io.FileUtils;
-import org.restlet.data.CharacterSet;
-import org.restlet.data.Form;
-import org.restlet.data.Reference;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
-import org.restlet.data.Status;
-import org.restlet.resource.FileRepresentation;
-import org.restlet.resource.Representation;
+import org.restlet.data.*;
+import org.restlet.engine.local.DirectoryServerResource;
+import org.restlet.representation.EmptyRepresentation;
+import org.restlet.representation.FileRepresentation;
+import org.restlet.representation.Representation;
+import org.restlet.representation.Variant;
 import org.restlet.resource.ResourceException;
-import org.restlet.resource.Variant;
-
-import com.noelios.restlet.local.DirectoryResource;
 
 /**
  * Enhanced version of Restlet DirectoryResource, adding ability to 
@@ -46,20 +42,15 @@ import com.noelios.restlet.local.DirectoryResource;
  * 
  * @author gojomo
  */
-public class EnhDirectoryResource extends DirectoryResource {
-    
-    public EnhDirectoryResource(EnhDirectory directory, Request request, Response response) throws IOException {
-        super(directory, request, response);
-    }
-
-    /** 
+public class EnhDirectoryResource extends DirectoryServerResource {
+    /**
      * Add EditRepresentation as a variant when appropriate. 
      * 
-     * @see com.noelios.restlet.local.DirectoryResource#getVariants()
+     * @see org.restlet.engine.local.DirectoryServerResource#getVariants()
      */
     @Override
     public List<Variant> getVariants() {
-        List<Variant> variants = super.getVariants();
+        List<Variant> variants = new LinkedList<>(super.getVariants(Method.GET));
         Form f = getRequest().getResourceRef().getQueryAsForm();
         String format = f.getFirstValue("format");
         if("textedit".equals(format)) {
@@ -73,7 +64,7 @@ public class EnhDirectoryResource extends DirectoryResource {
                 } catch (Exception e) {
                     throw new RuntimeException(e); 
                 }
-                variants = super.getVariants();
+                variants = new LinkedList<>(super.getVariants(Method.GET));
             }
             // wrap FileRepresentations in EditRepresentations
             ListIterator<Variant> iter = variants.listIterator(); 
@@ -119,18 +110,18 @@ public class EnhDirectoryResource extends DirectoryResource {
     }
     
     protected EnhDirectory getEnhDirectory() {
-        return (EnhDirectory)getDirectory();
+        return (EnhDirectory) getDirectory();
     }
 
-    /** 
+    /**
      * Accept a POST used to edit or create a file.
      * 
-     * @see org.restlet.resource.Resource#acceptRepresentation(org.restlet.resource.Representation)
+     * @see org.restlet.resource.ServerResource#post(Representation, Variant)
      */
-    public void acceptRepresentation(Representation entity)
-    throws ResourceException {
+    @Override
+    protected Representation post(Representation entity, Variant variant) throws ResourceException {
         // TODO: only allowPost on valid targets
-        Form form = getRequest().getEntityAsForm();
+        Form form = new Form(entity);
         String newContents = form.getFirstValue("contents");
         EditRepresentation er;
         try {
@@ -152,6 +143,6 @@ public class EnhDirectoryResource extends DirectoryResource {
         Reference ref = getRequest().getOriginalRef().clone(); 
         /// ref.setQuery(null);
         getResponse().redirectSeeOther(ref);
-        
+        return new EmptyRepresentation();
     }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/Flash.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/Flash.java
@@ -29,10 +29,10 @@ import java.util.Map.Entry;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.RandomUtils;
+import org.restlet.Request;
+import org.restlet.Response;
 import org.restlet.data.Cookie;
 import org.restlet.data.CookieSetting;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
 import org.restlet.util.Series;
 
 /**

--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -40,8 +40,8 @@ import org.archive.crawler.framework.Engine;
 import org.archive.util.TextUtils;
 import org.restlet.Context;
 import org.restlet.data.Reference;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
+import org.restlet.Request;
+import org.restlet.Response;
 import org.restlet.resource.ResourceException;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapperImpl;
@@ -58,18 +58,19 @@ public abstract class JobRelatedResource extends BaseResource {
     private final static Logger LOGGER =
             Logger.getLogger(JobRelatedResource.class.getName());
 
-    protected CrawlJob cj; 
+    protected CrawlJob cj;
 
     protected IdentityHashMap<Object, String> beanToNameMap;
-    
-    public JobRelatedResource(Context ctx, Request req, Response res) throws ResourceException {
-        super(ctx, req, res);
+
+    @Override
+    public void init(Context ctx, Request req, Response res) {
+        super.init(ctx, req, res);
         cj = getEngine().getJob((String)req.getAttributes().get("job"));
-        if(cj==null) {
+        if(cj == null) {
             throw new ResourceException(404);
         }
     }
-    
+
     protected Engine getEngine() {
         return ((EngineApplication)getApplication()).getEngine();
     }

--- a/engine/src/main/java/org/archive/crawler/restlet/PagedRepresentation.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/PagedRepresentation.java
@@ -38,8 +38,8 @@ import org.restlet.data.CharacterSet;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
 import org.restlet.data.Reference;
-import org.restlet.resource.CharacterRepresentation;
-import org.restlet.resource.FileRepresentation;
+import org.restlet.representation.CharacterRepresentation;
+import org.restlet.representation.FileRepresentation;
 
 /**
  * Representation wrapping a FileRepresentation, displaying its contents
@@ -50,7 +50,7 @@ import org.restlet.resource.FileRepresentation;
 public class PagedRepresentation extends CharacterRepresentation {
     // passed-in at construction
     /** wrapped FileRepresentation **/
-    protected FileRepresentation fileRepresentation; 
+    protected FileRepresentation fileRepresentation;
     /** wrapped EnhDirectoryResource; used to formulate self-links **/
     protected EnhDirectoryResource dirResource;
     
@@ -124,7 +124,7 @@ public class PagedRepresentation extends CharacterRepresentation {
     /** 
      * Write the paged HTML. 
      * 
-     * @see org.restlet.resource.Representation#write(java.io.Writer)
+     * @see org.restlet.representation.Representation#write(java.io.Writer)
      */
     @Override
     public void write(Writer writer) throws IOException {

--- a/engine/src/main/java/org/archive/crawler/restlet/ReportGenResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/ReportGenResource.java
@@ -23,12 +23,12 @@ import java.io.File;
 
 import org.restlet.Context;
 import org.restlet.data.MediaType;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
-import org.restlet.resource.Representation;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.ResourceException;
-import org.restlet.resource.StringRepresentation;
-import org.restlet.resource.Variant;
+import org.restlet.representation.Variant;
 
 /**
  * Restlet Resource which generates fresh reports and then redirects
@@ -38,24 +38,26 @@ import org.restlet.resource.Variant;
  */
 public class ReportGenResource extends JobRelatedResource {
     protected String reportClass;
-    
-    public ReportGenResource(Context ctx, Request req, Response res) throws ResourceException {
-        super(ctx, req, res);
+
+    @Override
+    public void init(Context ctx, Request req, Response res) throws ResourceException {
+        super.init(ctx, req, res);
         getVariants().add(new Variant(MediaType.TEXT_PLAIN));
         reportClass = (String)req.getAttributes().get("reportClass");
     }
 
-    public Representation represent(Variant variant) throws ResourceException {
+    @Override
+    protected Representation get(Variant variant) throws ResourceException {
         // generate report
         if (cj == null || cj.getCrawlController() == null) {
             throw new ResourceException(500);
         }
-        File f = cj.getCrawlController().getStatisticsTracker().writeReportFile(reportClass); 
+        File f = cj.getCrawlController().getStatisticsTracker().writeReportFile(reportClass);
         if (f==null) {
             throw new ResourceException(500);
         }
         // redirect
-        String relative = JobResource.getHrefPath(f,cj);
+        String relative = JobResource.getHrefPath(f, cj);
         if(relative!=null) {
             getResponse().redirectSeeOther("../"+relative+"?m="+f.lastModified());
             return new StringRepresentation("");

--- a/engine/src/main/java/org/archive/crawler/restlet/XmlMarshaller.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/XmlMarshaller.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 import org.apache.commons.lang.StringUtils;
-import org.restlet.util.XmlWriter;
+import org.restlet.ext.xml.XmlWriter;
 import org.xml.sax.SAXException;
 
 /**

--- a/engine/src/test/java/org/archive/crawler/selftest/CheckpointSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/CheckpointSelfTest.java
@@ -22,10 +22,10 @@ package org.archive.crawler.selftest;
 import java.io.IOException;
 
 import org.archive.crawler.framework.CrawlJob;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 
 /**
@@ -85,7 +85,7 @@ public class CheckpointSelfTest extends SelfTestBase {
     
     private Server makeHttpServer(int port) throws Exception {
         Server server = new Server();
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost(HOST);
         sc.setPort(port);
         server.addConnector(sc);

--- a/engine/src/test/java/org/archive/crawler/selftest/FormAuthSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/FormAuthSelfTest.java
@@ -19,19 +19,20 @@
 
 package org.archive.crawler.selftest;
 
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
 
 /**
  * Test form-based authentication
@@ -60,17 +61,17 @@ public class FormAuthSelfTest
     protected void startHttpServer() throws Exception {
         Server server = new Server();
         
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
         rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
         
-        ServletHandler servletHandler = new ServletHandler();        
+        ServletHandler servletHandler = new ServletHandler();
         
         HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] { 
+        handlers.setHandlers(new Handler[] {
                 rhandler, 
                 servletHandler,
                 new DefaultHandler() });

--- a/engine/src/test/java/org/archive/crawler/selftest/FormLoginSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/FormLoginSelfTest.java
@@ -19,19 +19,19 @@
 
 package org.archive.crawler.selftest;
 
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
 
 /**
  * Test form-based authentication
@@ -60,17 +60,17 @@ public class FormLoginSelfTest
     protected void startHttpServer() throws Exception {
         Server server = new Server();
         
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
         rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
         
-        ServletHandler servletHandler = new ServletHandler();        
+        ServletHandler servletHandler = new ServletHandler();
         
         HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] { 
+        handlers.setHandlers(new Handler[] {
                 rhandler, 
                 servletHandler,
                 new DefaultHandler() });

--- a/engine/src/test/java/org/archive/crawler/selftest/SelfTestBase.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/SelfTestBase.java
@@ -38,12 +38,12 @@ import org.archive.io.arc.ARCReaderFactory;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.util.TmpDirTestCase;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
 
 /**
  * Base class for 'self tests', integrations tests formatted as unit 
@@ -182,7 +182,7 @@ public abstract class SelfTestBase extends TmpDirTestCase {
     
     protected void startHttpServer() throws Exception {
         Server server = new Server();
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7777);
         server.addConnector(sc);

--- a/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
@@ -48,12 +48,12 @@ public class StatisticsSelfTest extends SelfTestBase {
         StatisticsTracker stats = heritrix.getEngine().getJob("selftest-job").getCrawlController().getStatisticsTracker();
         assertNotNull(stats);
         assertEquals(13, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(12669, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
+        assertEquals(7501, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
 
         assertEquals(3, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(2942, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(2133, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(10, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(9727, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(5368, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(0, (long) stats.getServerCache().getHostFor("dns:").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
     }
 
@@ -66,17 +66,17 @@ public class StatisticsSelfTest extends SelfTestBase {
         sourceStats = stats.getSourceStats("http://127.0.0.1:7777/a.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(2942l, (long) sourceStats.get("novel"));
+        assertEquals(2133l, (long) sourceStats.get("novel"));
         assertEquals(3l, (long) sourceStats.get("novelCount"));
-        assertEquals(2942l, (long) sourceStats.get("warcNovelContentBytes"));
+        assertEquals(2133l, (long) sourceStats.get("warcNovelContentBytes"));
         assertEquals(3l, (long) sourceStats.get("warcNovelUrls"));
 
         sourceStats = stats.getSourceStats("http://localhost:7777/b.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(9727l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
+        assertEquals(5368l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
         assertEquals(11l, (long) sourceStats.get("novelCount"));
-        assertEquals(9727l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
+        assertEquals(5368l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
         assertEquals(10l, (long) sourceStats.get("warcNovelUrls"));
     }
 

--- a/engine/src/test/java/org/archive/crawler/selftest/UserAgentSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/UserAgentSelfTest.java
@@ -20,14 +20,14 @@
 package org.archive.crawler.selftest;
 
 import org.archive.util.ArchiveUtils;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 /**
  * @author pjack
@@ -54,17 +54,17 @@ public class UserAgentSelfTest extends SelfTestBase {
     protected void startHttpServer() throws Exception {
         Server server = new Server();
         
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
         rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
         
-        ServletHandler servletHandler = new ServletHandler();        
+        ServletHandler servletHandler = new ServletHandler();
         
         HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] { 
+        handlers.setHandlers(new Handler[] {
                 rhandler, 
                 servletHandler,
                 new DefaultHandler() });

--- a/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
+++ b/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
@@ -44,20 +44,19 @@ import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.util.Recorder;
 import org.archive.util.TmpDirTestCase;
-import org.mortbay.jetty.NCSARequestLog;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.HandlerCollection;
-import org.mortbay.jetty.handler.RequestLogHandler;
-import org.mortbay.jetty.security.Authenticator;
-import org.mortbay.jetty.security.Constraint;
-import org.mortbay.jetty.security.ConstraintMapping;
-import org.mortbay.jetty.security.FormAuthenticator;
-import org.mortbay.jetty.security.HashUserRealm;
-import org.mortbay.jetty.security.SecurityHandler;
-import org.mortbay.jetty.servlet.HashSessionManager;
-import org.mortbay.jetty.servlet.SessionHandler;
+import org.eclipse.jetty.security.*;
+import org.eclipse.jetty.security.authentication.FormAuthenticator;
+import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.handler.RequestLogHandler;
+import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.SessionCache;
+import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.security.Password;
 
 /* Somewhat redundant to org.archive.crawler.selftest.FormAuthSelfTest, but 
  * the code is written, it's easier to run in eclipse, and no doubt tests 
@@ -211,12 +210,9 @@ public class FormAuthTest extends TestCase {
         public FormAuthTestHandler() {
             super();
         }
-        
+
         @Override
-        public void handle(String target, HttpServletRequest request,
-                HttpServletResponse response, int dispatch) throws IOException,
-                ServletException {
-            
+        public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
             if (target.endsWith("/set-cookie")) {
                 response.addCookie(new javax.servlet.http.Cookie("test-cookie-name", "test-cookie-value"));
             }
@@ -247,16 +243,16 @@ public class FormAuthTest extends TestCase {
         constraintMapping.setConstraint(constraint);
         constraintMapping.setPathSpec("/auth/*");
 
-        SecurityHandler authWrapper = new SecurityHandler();
+        UserStore userStore = new UserStore();
+        userStore.addUser(login, new Password(password), new String[]{role});
+
+        HashLoginService loginService = new HashLoginService(realm);
+        loginService.setUserStore(userStore);
+
+        ConstraintSecurityHandler authWrapper = new ConstraintSecurityHandler();
         authWrapper.setAuthenticator(authenticator);
-        
         authWrapper.setConstraintMappings(new ConstraintMapping[] {constraintMapping});
-        authWrapper.setUserRealm(new HashUserRealm(realm) {
-            {
-                put(login, password);
-                addUserToRole(login, role);
-            }
-        });
+        authWrapper.setLoginService(loginService);
 
         return authWrapper;
     }
@@ -265,7 +261,7 @@ public class FormAuthTest extends TestCase {
         // server for form auth
         Server server = new Server();
         
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7779);
         server.addConnector(sc);
@@ -277,16 +273,16 @@ public class FormAuthTest extends TestCase {
         requestLogHandler.setRequestLog(requestLog);
         handlers.addHandler(requestLogHandler);
         
-        FormAuthenticator formAuthenticatrix = new FormAuthenticator();
-        formAuthenticatrix.setLoginPage("/login.html");
-        
+        FormAuthenticator formAuthenticatrix = new FormAuthenticator("/login.html", null, false);
+
         SecurityHandler authWrapper = makeAuthWrapper(formAuthenticatrix,
                 FORM_AUTH_ROLE, FORM_AUTH_REALM, FORM_AUTH_LOGIN,
                 FORM_AUTH_PASSWORD);
         authWrapper.setHandler(handlers);
 
         SessionHandler sessionHandler = new SessionHandler();
-        sessionHandler.setSessionManager(new HashSessionManager());
+        SessionCache cache = new DefaultSessionCache(sessionHandler);
+        sessionHandler.setSessionCache(cache);
         sessionHandler.setHandler(authWrapper);
         server.setHandler(sessionHandler);
         

--- a/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
+++ b/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.NullSessionDataStore;
 import org.eclipse.jetty.server.session.SessionCache;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.security.Constraint;
@@ -282,6 +283,7 @@ public class FormAuthTest extends TestCase {
 
         SessionHandler sessionHandler = new SessionHandler();
         SessionCache cache = new DefaultSessionCache(sessionHandler);
+        cache.setSessionDataStore(new NullSessionDataStore());
         sessionHandler.setSessionCache(cache);
         sessionHandler.setHandler(authWrapper);
         server.setHandler(sessionHandler);

--- a/engine/src/test/resources/log4j.xml
+++ b/engine/src/test/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -35,23 +35,15 @@
 			<version>1.6.3</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-util</artifactId>
-			<version>6.1.26</version>
-			<scope>test</scope>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>9.4.19.v20190610</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-sslengine</artifactId>
-			<version>6.1.26</version>
-			<scope>test</scope>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-security</artifactId>
+			<version>9.4.19.v20190610</version>
 		</dependency>
-                <dependency>
-                        <groupId>org.mortbay.jetty</groupId>
-                        <artifactId>jetty</artifactId>
-                        <version>6.1.26</version>
-                        <scope>test</scope>
-                </dependency>
 		<dependency>
 			<groupId>org.littleshoot</groupId>
 			<artifactId>littleproxy</artifactId>

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -157,7 +157,7 @@ public class FetchHTTPTests extends ProcessorTestBase {
         assertEquals(DEFAULT_PAYLOAD_STRING, curi.getRecorder().getContentReplayCharSequence().toString());
         
         if (!exclusions.contains("httpBindAddress")) {
-            assertEquals("127.0.0.1", FetchHTTPTest.getLastRequest().getRemoteAddr());
+            assertTrue(rawResponseString(curi).contains("Client-Host: 127.0.0.1\r\n"));
         }
         
         if (!exclusions.contains("nonFatalFailuresIsEmpty")) {
@@ -262,7 +262,7 @@ public class FetchHTTPTests extends ProcessorTestBase {
 
         // check that we got the expected response and the fetcher did its thing
         assertEquals(401, curi.getFetchStatus());
-        assertEquals("Basic realm=\"basic-auth-realm\"", curi.getHttpResponseHeader("WWW-Authenticate"));
+        assertEquals("basic realm=\"basic-auth-realm\"", curi.getHttpResponseHeader("WWW-Authenticate"));
         assertTrue(curi.getCredentials().contains(basicAuthCredential));
         assertTrue(curi.getHttpAuthChallenges() != null && curi.getHttpAuthChallenges().containsKey("basic"));
         
@@ -406,8 +406,8 @@ public class FetchHTTPTests extends ProcessorTestBase {
         fetcher().process(curi);
 
         // the client bind address isn't recorded anywhere in heritrix as
-        // far as i can tell, so we get it this way...
-        assertEquals(addr, FetchHTTPTest.getLastRequest().getRemoteAddr());
+        // far as i can tell, so we get the server to echo it back to us...
+        assertTrue(rawResponseString(curi).contains("Client-Host: " + addr + "\r\n"));
 
         runDefaultChecks(curi, "httpBindAddress");
     }
@@ -780,7 +780,9 @@ public class FetchHTTPTests extends ProcessorTestBase {
         fetcher().process(curi);
         // logger.info('\n' + httpRequestString(curi) + "\n\n" + rawResponseString(curi));
         assertTrue(httpRequestString(curi).startsWith("GET /99% HTTP/1.0\r\n"));
-        runDefaultChecks(curi, "requestLine");
+        // jetty 9 rejects requests with paths like this with 400 Bad Request
+        // so we can't run these checks anymore
+        //runDefaultChecks(curi, "requestLine");
     }
     
     public void testTwoQuestionMarks() throws Exception {

--- a/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
+++ b/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
@@ -70,11 +70,11 @@ import org.archive.spring.ConfigPath;
 import org.archive.util.Base32;
 import org.archive.util.Recorder;
 import org.archive.util.TmpDirTestCase;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.HandlerCollection;
-import org.mortbay.jetty.servlet.SessionHandler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.session.SessionHandler;
 
 public class ContentDigestHistoryTest extends TmpDirTestCase {
 
@@ -237,7 +237,6 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
 
             fetcher.process(curi1);
             assertEquals(200, curi1.getFetchStatus());
-            assertEquals(141, curi1.getContentSize());
             assertEquals(expectedDigest, curi1.getContentDigestSchemeString());
             assertFalse(curi1.hasContentDigestHistory());
 
@@ -260,7 +259,6 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
 
             fetcher.process(curi2);
             assertEquals(200, curi1.getFetchStatus());
-            assertEquals(141, curi1.getContentSize());
             assertEquals(expectedDigest, curi1.getContentDigestSchemeString());
             assertFalse(curi2.hasContentDigestHistory());
 
@@ -305,7 +303,6 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
             assertTrue(recordIterator.hasNext());
             record = recordIterator.next();
             assertEquals(WARCRecordType.response.toString(), record.getHeader().getHeaderValue(HEADER_KEY_TYPE));
-            assertEquals("141", record.getHeader().getHeaderValue(CONTENT_LENGTH));
             assertEquals(expectedDigest, record.getHeader().getHeaderValue(HEADER_KEY_PAYLOAD_DIGEST));
             assertEquals(curi1.getUURI().toString(), record.getHeader().getHeaderValue(HEADER_KEY_URI));
             assertEquals(payloadRecordIdWithBrackets, record.getHeader().getHeaderValue(HEADER_KEY_ID));
@@ -374,10 +371,7 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
         HandlerCollection handlers = new HandlerCollection();
         handlers.addHandler(new SessionHandler(){
             @Override
-            public void handle(String target, HttpServletRequest request,
-                    HttpServletResponse response, int dispatch) throws IOException,
-                    ServletException {
-
+            public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
                 response.setContentType("text/plain;charset=US-ASCII");
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.getOutputStream().write(DEFAULT_PAYLOAD_STRING.getBytes("US-ASCII"));
@@ -388,7 +382,7 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
         Server server = new Server();
         server.setHandler(handlers);
         
-        SocketConnector sc = new SocketConnector();
+        ServerConnector sc = new ServerConnector(server);
         sc.setHost("127.0.0.1");
         sc.setPort(7777);
         server.addConnector(sc);

--- a/modules/src/test/resources/log4j.xml
+++ b/modules/src/test/resources/log4j.xml
@@ -11,7 +11,7 @@
 		<level value="ERROR" />
 	</logger>
 
-	<logger name="org.mortbay.log">
+	<logger name="org.eclipse.jetty">
 		<level value="ERROR" />
 	</logger>
 

--- a/pom.xml
+++ b/pom.xml
@@ -373,8 +373,8 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 				<artifactId>maven-compiler-plugin</artifactId>
                                <version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Jetty 9.4.12+ is required for TLS to work correctly under JDK11 (due to SSL handshake failures).

Unfortunately Jetty 9.4 requires JDK 8. This means we can't support JDK 11 and 8 at the same time so we drop support for JDK 7.

We also upgrade Restlet to 2.4.0 for compatibility with the new version of Jetty.

There is one intentional change in behaviour to simplify upgrading. We remove a workaround for an old [webkit bug] where the browser claimed to prefer application/xml over text/html. The bug was fixed in 2011.

[webkit bug]: https://bugs.webkit.org/show_bug.cgi?id=27267

Summary of Jetty API changes:
- package names changed such as org.mortbay -> org.eclipse
- SocketConnector and SslSocketConnector merged to ServerConnector
- HashUserRealm split into UserStore and HashLoginService
- SecurityHandler -> ConstraintSecurityHandler

Summary of Restlet API changes:
- some classes have moved package (Request, Response, Router etc)
- ServerResource replaces Resource
- represent(), acceptRepresentation() renamed to get(), post()
- constructors were replaced by an init() method
- setModifiable() was removed
- getRequest().getEntityAsForm() -> new Form(entity)
- Guard -> ChallengeAuthenticator