### PR TITLE
WIP: Upgrade BDB JE to version 7.5.11

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.sleepycat</groupId>
 			<artifactId>je</artifactId>
-			<version>4.1.6</version>
+			<version>7.5.11</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/modules/src/test/java/org/archive/modules/fetcher/CookieStoreTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/CookieStoreTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
@@ -301,12 +302,14 @@ public class CookieStoreTest extends TmpDirTestCase {
         bdbCookieStore().clear();
         basicCookieStore().clear();
         final Random rand = new Random();
+        
+        final AtomicBoolean keepRunning = new AtomicBoolean(true);
 
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
                 try {
-                    while (!Thread.interrupted()) {
+                    while (keepRunning.get()) {
                         BasicClientCookie cookie = new BasicClientCookie(UUID.randomUUID().toString(), UUID.randomUUID().toString());
                         cookie.setDomain("d" + rand.nextInt() + ".example.com");
                         bdbCookieStore().addCookie(cookie);
@@ -326,10 +329,9 @@ public class CookieStoreTest extends TmpDirTestCase {
         }
 
         Thread.sleep(5000);
-
-        for (int i = 0; i < threads.length; i++) {
-            threads[i].interrupt();
-        }
+        
+        // Shutdown the threads:
+        keepRunning.set(false);
         for (int i = 0; i < threads.length; i++) {
             threads[i].join();
         }
@@ -343,12 +345,14 @@ public class CookieStoreTest extends TmpDirTestCase {
         bdbCookieStore().clear();
         basicCookieStore().clear();
         final Random rand = new Random();
+        
+        final AtomicBoolean keepRunning = new AtomicBoolean(true);
 
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
                 try {
-                    while (!Thread.interrupted()) {
+                    while (keepRunning.get()) {
                         BasicClientCookie cookie = new BasicClientCookie(UUID.randomUUID().toString(), UUID.randomUUID().toString());
                         cookie.setDomain("d" + rand.nextInt(20) + ".example.com");
                         bdbCookieStore().addCookie(cookie);
@@ -369,9 +373,8 @@ public class CookieStoreTest extends TmpDirTestCase {
 
         Thread.sleep(1000);
 
-        for (int i = 0; i < threads.length; i++) {
-            threads[i].interrupt();
-        }
+        // Shutdown the threads:
+        keepRunning.set(false);
         for (int i = 0; i < threads.length; i++) {
             threads[i].join();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,15 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 			<id>builds.archive.org,maven2</id>
 			<url>http://builds.archive.org/maven2</url>
 		</repository>
+        <repository>
+            <id>oracleReleases</id>
+            <name>Oracle Released Java Packages</name>
+            <url>http://download.oracle.com/maven</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots />
+        </repository>
 	</repositories>
 
 	<prerequisites>


### PR DESCRIPTION
For #277 and other issues relating to using a very old version of BDB JE, this patch updates to the latest version. Apart from one test which relied on `Thread.interrupt()` (which makes BDB flake out), the upgrade appears to be straightforward.

However, marking this as a Work In Progress until I get a chance to run a large-scale test with it.