### PR TITLE
Fix jobdir PUT

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EnhDirectoryResource.java
@@ -50,7 +50,11 @@ public class EnhDirectoryResource extends DirectoryServerResource {
      */
     @Override
     public List<Variant> getVariants() {
-        List<Variant> variants = new LinkedList<>(super.getVariants(Method.GET));
+        List<Variant> superVariants = super.getVariants();
+        if (superVariants == null) {
+            return null; // PUT and DELETE return no content
+        }
+        List<Variant> variants = new LinkedList<>(superVariants);
         Form f = getRequest().getResourceRef().getQueryAsForm();
         String format = f.getFirstValue("format");
         if("textedit".equals(format)) {
@@ -64,7 +68,11 @@ public class EnhDirectoryResource extends DirectoryServerResource {
                 } catch (Exception e) {
                     throw new RuntimeException(e); 
                 }
-                variants = new LinkedList<>(super.getVariants(Method.GET));
+                superVariants = super.getVariants();
+                if (superVariants == null) {
+                    return null;
+                }
+                variants = new LinkedList<>(superVariants);
             }
             // wrap FileRepresentations in EditRepresentations
             ListIterator<Variant> iter = variants.listIterator(); 


### PR DESCRIPTION
The first patch fixes regression #282 where PUT and DELETE on jobdir files return 405 Method Not Allowed.

With the first patch applied PUT still doesn't behave correctly though as Restlet unhelpfully changes the file extension cxml to xml. This behaviour affected Restlet 1 for other file types as described in [HER-1907](https://webarchive.jira.com/browse/HER-1907) however was mitigated for .cxml by registering it as the application/xml content-type. Under Restlet 2 the extension resolution appears to have changed so that always .xml gets picked.

The second patch overrides PUT to disable the file extension manipulation entirely.