### PR TITLE
Warc writer chain

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -66,11 +66,6 @@
 			<artifactId>rethinkdb-driver</artifactId>
 			<version>2.3.3</version>
 		</dependency>
-		<dependency>
-			<groupId>com.googlecode.json-simple</groupId>
-			<artifactId>json-simple</artifactId>
-			<version>1.1.1</version>
-		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>

--- a/contrib/src/main/java/org/archive/crawler/reporting/XmlCrawlSummaryReport.java
+++ b/contrib/src/main/java/org/archive/crawler/reporting/XmlCrawlSummaryReport.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.archive.crawler.restlet.XmlMarshaller;
-import org.archive.modules.writer.WARCWriterProcessor;
+import org.archive.modules.writer.BaseWARCWriterProcessor;
 import org.archive.util.ArchiveUtils;
 
 public class XmlCrawlSummaryReport extends Report {
@@ -28,7 +28,7 @@ public class XmlCrawlSummaryReport extends Report {
         CrawlStatSnapshot snapshot = stats.getLastSnapshot();
 
         info.put("crawlName", 
-                ((WARCWriterProcessor) stats.appCtx.getBean("warcWriter")).getPrefix());
+                ((BaseWARCWriterProcessor) stats.appCtx.getBean("warcWriter")).getPrefix());
         info.put("crawlJobShortName", 
                 stats.getCrawlController().getMetadata().getJobName());
         info.put("scheduledDate", this.scheduledDate);

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -175,7 +175,7 @@ public class ExtractorYoutubeDL extends Extractor
                     JSONObject jsonO = (JSONObject) jsonEntries.get(i);
 
                     // media url
-                    if (jsonO.get("url") != null) {
+                    if (!jsonO.isNull("url")) {
                         String videoUrl = jsonO.getString("url");
                         addVideoOutlink(uri, jsonO, videoUrl);
                     }
@@ -214,7 +214,7 @@ public class ExtractorYoutubeDL extends Extractor
 
             // annotation
             String annotation = "youtube-dl:1/1";
-            if (jsonO.opt("playlist_index") != null) {
+            if (!jsonO.isNull("playlist_index")) {
                 annotation = "youtube-dl:" + jsonO.get("playlist_index") + "/"
                         + jsonO.get("n_entries");
             }

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -177,12 +177,28 @@ public class ExtractorYoutubeDL extends Extractor
                 }
 
                 int count = 0;
-                for (JsonElement e: jsonEntries) {
+                for (JsonElement jsonE: jsonEntries) {
                     count += 1;
-                    JsonObject json = (JsonObject) e;
-                    if (json.get("url") != null) {
-                        String videoUrl = json.get("url").getAsString();
-                        addVideoOutlink(uri, json, videoUrl);
+                    JsonObject jsonO = (JsonObject) jsonE;
+
+                    // media url
+                    if (jsonO.get("url") != null) {
+                        String videoUrl = jsonO.get("url").getAsString();
+                        addVideoOutlink(uri, jsonO, videoUrl);
+                    }
+
+                    // make sure we extract watch page links from youtube playlists,
+                    // and equivalent for other sites
+                    if (jsonO.get("webpage_url") != null) {
+                        String webpageUrl = jsonO.get("webpage_url").getAsString();
+                        try {
+                            UURI dest = UURIFactory.getInstance(uri.getUURI(), webpageUrl);
+                            CrawlURI link = uri.createCrawlURI(dest, LinkContext.NAVLINK_MISC,
+                                    Hop.NAVLINK);
+                            uri.getOutLinks().add(link);
+                        } catch (URIException e1) {
+                            logUriError(e1, uri.getUURI(), webpageUrl);
+                        }
                     }
                 }
 

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -79,6 +79,8 @@ public class ExtractorYoutubeDL extends Extractor implements Lifecycle {
     protected static final String YDL_CONTAINING_PAGE_TIMESTAMP = "ydl-containing-page-timestamp";
     protected static final String YDL_CONTAINING_PAGE_URI = "ydl-containing-page-uri";
 
+    protected static final int MAX_VIDEOS_PER_PAGE = 1000;
+
     protected transient Logger ydlLogger = null;
 
     protected CrawlerLoggerModule crawlerLoggerModule;
@@ -305,7 +307,8 @@ public class ExtractorYoutubeDL extends Extractor implements Lifecycle {
          * https://github.com/ytdl-org/youtube-dl/blob/master/README.md#format-selection
          */
         ProcessBuilder pb = new ProcessBuilder("youtube-dl", "--ignore-config",
-                "--simulate", "--dump-json", "--format=best", uri.toString());
+                "--simulate", "--dump-json", "--format=best",
+                "--playlist-end=" + MAX_VIDEOS_PER_PAGE, uri.toString());
         logger.fine("running " + pb.command());
 
         Process proc = null;

--- a/contrib/src/main/java/org/archive/modules/postprocessor/WARCLimitEnforcer.java
+++ b/contrib/src/main/java/org/archive/modules/postprocessor/WARCLimitEnforcer.java
@@ -18,17 +18,18 @@
  */
 package org.archive.modules.postprocessor;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.archive.crawler.framework.CrawlController;
 import org.archive.crawler.framework.CrawlStatus;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;
-import org.archive.modules.writer.WARCWriterProcessor;
+import org.archive.modules.writer.BaseWARCWriterProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class WARCLimitEnforcer extends Processor {
@@ -38,7 +39,7 @@ public class WARCLimitEnforcer extends Processor {
 
     protected Map<String, Map<String, Long>> limits = new HashMap<String, Map<String, Long>>();
     /**
-     * Should match structure of {@link WARCWriterProcessor#getStats()}
+     * Should match structure of {@link BaseWARCWriterProcessor#getStats()}
      * @param limits
      */
     public void setLimits(Map<String, Map<String, Long>> limits) {
@@ -48,23 +49,23 @@ public class WARCLimitEnforcer extends Processor {
         return limits;
     }
 
-    protected WARCWriterProcessor warcWriter;
+    protected BaseWARCWriterProcessor warcWriter;
     @Autowired
-    public void setWarcWriter(WARCWriterProcessor warcWriter) {
+    public void setWarcWriter(BaseWARCWriterProcessor warcWriter) {
         this.warcWriter = warcWriter;
     }
-    public WARCWriterProcessor getWarcWriter() {
+    public BaseWARCWriterProcessor getWarcWriter() {
         return warcWriter;
     }
 
     {
-        setWarcWriters(new ArrayList<WARCWriterProcessor>());
+        setWarcWriters(new ArrayList<BaseWARCWriterProcessor>());
     }
     @SuppressWarnings("unchecked")
-    public List<WARCWriterProcessor> getWarcWriters() {
-        return (List<WARCWriterProcessor>) kp.get("warcWriters");
+    public List<BaseWARCWriterProcessor> getWarcWriters() {
+        return (List<BaseWARCWriterProcessor>) kp.get("warcWriters");
     }
-    public void setWarcWriters(List<WARCWriterProcessor> warcWriters) {
+    public void setWarcWriters(List<BaseWARCWriterProcessor> warcWriters) {
         kp.put("warcWriters", warcWriters);
     }
 
@@ -91,7 +92,7 @@ public class WARCLimitEnforcer extends Processor {
                 AtomicLong value = null;
                 if(getWarcWriters() !=null && getWarcWriters().size()>0) {
                     value = new AtomicLong(0);
-                    for (WARCWriterProcessor w: getWarcWriters()) {
+                    for (BaseWARCWriterProcessor w: getWarcWriters()) {
                         Map<String, AtomicLong> valueBucket = w.getStats().get(j);
                         if(valueBucket != null) {
                             value.set(value.addAndGet(valueBucket.get(k).get()));

--- a/contrib/src/main/java/org/archive/modules/recrawl/TroughContentDigestHistory.java
+++ b/contrib/src/main/java/org/archive/modules/recrawl/TroughContentDigestHistory.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
 
 import org.archive.crawler.event.CrawlStateEvent;
 import org.archive.modules.CrawlURI;
-import org.archive.modules.writer.WARCWriterProcessor;
+import org.archive.modules.writer.WARCWriterChainProcessor;
 import org.archive.spring.HasKeyedProperties;
 import org.archive.spring.KeyedProperties;
 import org.archive.trough.TroughClient;
@@ -31,7 +31,7 @@ import org.springframework.context.ApplicationListener;
  * <p>To use, define a {@code TroughContentDigestHistory} top-level bean in your
  * crawler-beans.cxml, then add {@link ContentDigestHistoryLoader} and
  * {@link ContentDigestHistoryStorer} to your fetch chain, sandwiching the
- * {@link WARCWriterProcessor}. In other words, follow the directions at
+ * {@link WARCWriterChainProcessor}. In other words, follow the directions at
  * <a href="https://github.com/internetarchive/heritrix3/wiki/Duplication%20Reduction%20Processors">https://github.com/internetarchive/heritrix3/wiki/Duplication%20Reduction%20Processors</a>
  * but replace the {@link BdbContentDigestHistory} bean with a
  * {@code TroughContentDigestHistory} bean.

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -334,7 +334,7 @@ http://example.example/example
   
  <!-- DISPOSITION CHAIN -->
  <!-- first, processors are declared as top-level named beans  -->
- <bean id="warcWriter" class="org.archive.modules.writer.WARCWriterProcessor">
+ <bean id="warcWriter" class="org.archive.modules.writer.WARCWriterChainProcessor">
   <!-- <property name="compress" value="true" /> -->
   <!-- <property name="prefix" value="IAH" /> -->
   <!-- <property name="maxFileSizeBytes" value="1000000000" /> -->
@@ -349,11 +349,19 @@ http://example.example/example
         </list>
        </property> -->
   <!-- <property name="template" value="${prefix}-${timestamp17}-${serialno}-${heritrix.pid}~${heritrix.hostname}~${heritrix.port}" /> -->
-  <!-- <property name="writeRequests" value="true" /> -->
-  <!-- <property name="writeMetadata" value="true" /> -->
-  <!-- <property name="writeRevisitForIdenticalDigests" value="true" /> -->
-  <!-- <property name="writeRevisitForNotModified" value="true" /> -->
   <!-- <property name="startNewFilesOnCheckpoint" value="true" /> -->
+  <property name="chain">
+   <list>
+    <bean class="org.archive.modules.warc.DnsResponseRecordBuilder"/>
+    <bean class="org.archive.modules.warc.HttpResponseRecordBuilder"/>
+    <bean class="org.archive.modules.warc.WhoisResponseRecordBuilder"/>
+    <bean class="org.archive.modules.warc.FtpControlConversationRecordBuilder"/>
+    <bean class="org.archive.modules.warc.FtpResponseRecordBuilder"/>
+    <bean class="org.archive.modules.warc.RevisitRecordBuilder"/>
+    <bean class="org.archive.modules.warc.HttpRequestRecordBuilder"/>
+    <bean class="org.archive.modules.warc.MetadataRecordBuilder"/>
+   </list>
+  </property>
  </bean>
  <bean id="candidates" class="org.archive.crawler.postprocessor.CandidatesProcessor">
   <!-- <property name="seedsRedirectNewSeeds" value="true" /> -->

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -350,6 +350,7 @@ http://example.example/example
        </property> -->
   <!-- <property name="template" value="${prefix}-${timestamp17}-${serialno}-${heritrix.pid}~${heritrix.hostname}~${heritrix.port}" /> -->
   <!-- <property name="startNewFilesOnCheckpoint" value="true" /> -->
+  <!--
   <property name="chain">
    <list>
     <bean class="org.archive.modules.warc.DnsResponseRecordBuilder"/>
@@ -362,6 +363,7 @@ http://example.example/example
     <bean class="org.archive.modules.warc.MetadataRecordBuilder"/>
    </list>
   </property>
+  -->
  </bean>
  <bean id="candidates" class="org.archive.crawler.postprocessor.CandidatesProcessor">
   <!-- <property name="seedsRedirectNewSeeds" value="true" /> -->

--- a/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
@@ -25,7 +25,7 @@ public class StatisticsSelfTest extends SelfTestBase {
 
     @Override
     protected String changeGlobalConfig(String config) {
-        String warcWriterConfig = " <bean id='warcWriter' class='org.archive.modules.writer.WARCWriterProcessor'/>\n";
+        String warcWriterConfig = " <bean id='warcWriter' class='org.archive.modules.writer.WARCWriterChainProcessor'/>\n";
         config = config.replace("<!--@@MORE_EXTRACTORS@@-->", warcWriterConfig);
         return super.changeGlobalConfig(config);
     }

--- a/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
@@ -23,7 +23,7 @@ public abstract class BaseWARCRecordBuilder implements WARCRecordBuilder {
         this.serverCache = serverCache;
     }
     
-    public URI generateRecordID() {
+    public static URI generateRecordID() {
         try {
             return new URI("urn:uuid:" + UUID.randomUUID());
         } catch (URISyntaxException e) {

--- a/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
@@ -1,0 +1,66 @@
+package org.archive.modules.warc;
+
+import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import org.archive.modules.CrawlURI;
+import org.archive.modules.net.CrawlHost;
+import org.archive.modules.net.ServerCache;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class BaseWARCRecordBuilder implements WARCRecordBuilder {
+
+    transient protected ServerCache serverCache;
+    public ServerCache getServerCache() {
+        return this.serverCache;
+    }
+    @Autowired
+    public void setServerCache(ServerCache serverCache) {
+        this.serverCache = serverCache;
+    }
+    
+    public URI generateRecordID() {
+        try {
+            return new URI("urn:uuid:" + UUID.randomUUID());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e); // impossible 
+        }
+    }
+    
+    /**
+     * Return IP address of given URI suitable for recording (as in a
+     * classic ARC 5-field header line).
+     * 
+     * @param curi CrawlURI
+     * @return String of IP address
+     */
+    protected String getHostAddress(CrawlURI curi) {
+        // special handling for DNS URIs: want address of DNS server
+        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
+            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        }
+        // otherwise, host referenced in URI
+        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
+        // use that rather than inferred by CrawlHost lookup 
+        CrawlHost h = getServerCache().getHostFor(curi.getUURI());
+        if (h == null) {
+            throw new NullPointerException("Crawlhost is null for " +
+                curi + " " + curi.getVia());
+        }
+        InetAddress a = h.getIP();
+        if (a == null) {
+            throw new NullPointerException("Address is null for " +
+                curi + " " + curi.getVia() + ". Address " +
+                ((h.getIpFetched() == CrawlHost.IP_NEVER_LOOKED_UP)?
+                     "was never looked up.":
+                     (System.currentTimeMillis() - h.getIpFetched()) +
+                         " ms ago."));
+        }
+        return h.getIP().getHostAddress();
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
@@ -1,0 +1,49 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
+import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+
+public class DnsResponseRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return "dns".equals(curi.getUURI().getScheme().toLowerCase());
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setType(WARCRecordType.response);
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(curi.getContentType());
+        recordInfo.setRecordId(generateRecordID());
+        
+        recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
+        recordInfo.setEnforceLength(true);
+        
+        String ip = (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        if (ip != null && ip.length() > 0) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, ip);
+        }
+        
+        ReplayInputStream ris =
+            curi.getRecorder().getRecordedInput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+        
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
@@ -12,7 +12,7 @@ import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 
-public class DnsResponseRecordBuilder extends WARCRecordBuilder {
+public class DnsResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
@@ -1,5 +1,6 @@
 package org.archive.modules.warc;
 
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
 import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
 
@@ -25,11 +26,15 @@ public class DnsResponseRecordBuilder extends BaseWARCRecordBuilder {
                 ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
         recordInfo.setType(WARCRecordType.response);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setMimetype(curi.getContentType());
-        recordInfo.setRecordId(generateRecordID());
         
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);

--- a/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
@@ -15,7 +15,7 @@ import org.archive.util.ArchiveUtils;
 public class DnsResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return "dns".equals(curi.getUURI().getScheme().toLowerCase());
     }
 

--- a/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
@@ -14,7 +14,7 @@ import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.anvl.ANVLRecord;
 
-public class FtpControlConversationRecordBuilder extends WARCRecordBuilder {
+public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
@@ -1,6 +1,7 @@
 package org.archive.modules.warc;
 
 import static org.archive.format.warc.WARCConstants.FTP_CONTROL_CONVERSATION_MIMETYPE;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
 import static org.archive.modules.CoreAttributeConstants.A_FTP_CONTROL_CONVERSATION;
 
@@ -31,14 +32,17 @@ public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
         headers.addLabelValue(HEADER_KEY_IP, getHostAddress(curi));
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setUrl(curi.toString());
         recordInfo.setMimetype(FTP_CONTROL_CONVERSATION_MIMETYPE);
         recordInfo.setExtraHeaders(headers);
         recordInfo.setEnforceLength(true);
         recordInfo.setType(WARCRecordType.metadata);
-
-        recordInfo.setRecordId(generateRecordID());
         
         byte[] b = controlConversation.getBytes("UTF-8");
         

--- a/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
@@ -17,7 +17,7 @@ import org.archive.util.anvl.ANVLRecord;
 public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return "ftp".equals(curi.getUURI().getScheme().toLowerCase());
     }
 

--- a/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
@@ -1,0 +1,51 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.FTP_CONTROL_CONVERSATION_MIMETYPE;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
+import static org.archive.modules.CoreAttributeConstants.A_FTP_CONTROL_CONVERSATION;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+import org.archive.util.anvl.ANVLRecord;
+
+public class FtpControlConversationRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return "ftp".equals(curi.getUURI().getScheme().toLowerCase());
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+        String controlConversation =
+                curi.getData().get(A_FTP_CONTROL_CONVERSATION).toString();
+        ANVLRecord headers = new ANVLRecord();
+        headers.addLabelValue(HEADER_KEY_IP, getHostAddress(curi));
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setMimetype(FTP_CONTROL_CONVERSATION_MIMETYPE);
+        recordInfo.setExtraHeaders(headers);
+        recordInfo.setEnforceLength(true);
+        recordInfo.setType(WARCRecordType.metadata);
+
+        recordInfo.setRecordId(generateRecordID());
+        
+        byte[] b = controlConversation.getBytes("UTF-8");
+        
+        recordInfo.setContentStream(new ByteArrayInputStream(b));
+        recordInfo.setContentLength((long) b.length);
+
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -28,8 +28,10 @@ public class FtpResponseRecordBuilder extends BaseWARCRecordBuilder {
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
         recordInfo.setRecordId(generateRecordID());
-        recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
-                '<' + concurrentTo.toString() + '>');
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
         recordInfo.setType(WARCRecordType.response);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);

--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -16,7 +16,7 @@ import org.archive.util.ArchiveUtils;
 public class FtpResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return !curi.isRevisit() 
                 && "ftp".equals(curi.getUURI().getScheme().toLowerCase());
     }

--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -13,7 +13,7 @@ import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 
-public class FtpResponseRecordBuilder extends WARCRecordBuilder {
+public class FtpResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -1,0 +1,53 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
+import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+
+public class FtpResponseRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return !curi.isRevisit() 
+                && "ftp".equals(curi.getUURI().getScheme().toLowerCase());
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setRecordId(generateRecordID());
+        recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                '<' + concurrentTo.toString() + '>');
+        recordInfo.setType(WARCRecordType.response);
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(curi.getContentType());
+        
+        recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
+        recordInfo.setEnforceLength(true);
+        
+        String ip = (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        if (ip != null && ip.length() > 0) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, ip);
+        }
+        
+        ReplayInputStream ris =
+            curi.getRecorder().getRecordedInput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+        
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
@@ -27,8 +27,10 @@ public class HttpRequestRecordBuilder extends BaseWARCRecordBuilder {
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
         recordInfo.setRecordId(generateRecordID());
-        recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
-                "<" + concurrentTo + ">");
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
         recordInfo.setType(WARCRecordType.request);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);

--- a/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
@@ -15,7 +15,7 @@ import org.archive.util.ArchiveUtils;
 public class HttpRequestRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return curi.getUURI().getScheme().toLowerCase().startsWith("http");
     }
 

--- a/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
@@ -12,7 +12,7 @@ import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 
-public class HttpRequestRecordBuilder extends WARCRecordBuilder {
+public class HttpRequestRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
@@ -1,0 +1,46 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
+import static org.archive.format.warc.WARCConstants.HTTP_REQUEST_MIMETYPE;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+
+public class HttpRequestRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return curi.getUURI().getScheme().toLowerCase().startsWith("http");
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
+            throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setRecordId(generateRecordID());
+        recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                "<" + concurrentTo + ">");
+        recordInfo.setType(WARCRecordType.request);
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(HTTP_REQUEST_MIMETYPE);
+        recordInfo.setContentLength(curi.getRecorder().getRecordedOutput().getSize());
+        recordInfo.setEnforceLength(true);
+        
+        ReplayInputStream 
+            ris = curi.getRecorder().getRecordedOutput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -1,0 +1,82 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_TRUNCATED;
+import static org.archive.format.warc.WARCConstants.HTTP_RESPONSE_MIMETYPE;
+import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_HEAD;
+import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_LENGTH;
+import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_TIME;
+import static org.archive.modules.CoreAttributeConstants.A_WARC_RESPONSE_HEADERS;
+import static org.archive.modules.CoreAttributeConstants.HEADER_TRUNC;
+import static org.archive.modules.CoreAttributeConstants.LENGTH_TRUNC;
+import static org.archive.modules.CoreAttributeConstants.TIMER_TRUNC;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.lang.StringUtils;
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+
+public class HttpResponseRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return !curi.isRevisit()
+                && "http".equals(curi.getUURI().getScheme().toLowerCase());
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setType(WARCRecordType.response);
+        recordInfo.setRecordId(generateRecordID());
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(HTTP_RESPONSE_MIMETYPE);
+        recordInfo.setContentLength(
+                curi.getRecorder().getRecordedInput().getSize());
+        recordInfo.setEnforceLength(true);
+
+        if (curi.getContentDigest() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_PAYLOAD_DIGEST,
+                    curi.getContentDigestSchemeString());
+        }
+
+        // Check for truncated annotation
+        String value = null;
+        Collection<String> anno = curi.getAnnotations();
+        if (anno.contains(TIMER_TRUNC)) {
+            value = NAMED_FIELD_TRUNCATED_VALUE_TIME;
+        } else if (anno.contains(LENGTH_TRUNC)) {
+            value = NAMED_FIELD_TRUNCATED_VALUE_LENGTH;
+        } else if (anno.contains(HEADER_TRUNC)) {
+            value = NAMED_FIELD_TRUNCATED_VALUE_HEAD;
+        }
+        // TODO: Add annotation for TRUNCATED_VALUE_UNSPECIFIED
+        if (value != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_TRUNCATED, value);
+        }
+
+        if (curi.getData().containsKey(A_WARC_RESPONSE_HEADERS)) {
+            for (Object headerObj: curi.getDataList(A_WARC_RESPONSE_HEADERS)) {
+                String[] kv = StringUtils.split(((String) headerObj), ":", 2);
+                recordInfo.addExtraHeader(kv[0].trim(), kv[1].trim());
+            }
+        }
+
+        ReplayInputStream ris =
+            curi.getRecorder().getRecordedInput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -22,7 +22,7 @@ import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 
-public class HttpResponseRecordBuilder extends WARCRecordBuilder {
+public class HttpResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -25,7 +25,7 @@ import org.archive.util.ArchiveUtils;
 public class HttpResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return !curi.isRevisit()
                 && curi.getUURI().getScheme().toLowerCase().startsWith("http");
     }

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -27,7 +27,7 @@ public class HttpResponseRecordBuilder extends WARCRecordBuilder {
     @Override
     public boolean shouldProcess(CrawlURI curi) {
         return !curi.isRevisit()
-                && "http".equals(curi.getUURI().getScheme().toLowerCase());
+                && curi.getUURI().getScheme().toLowerCase().startsWith("http");
     }
 
     @Override

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -1,5 +1,6 @@
 package org.archive.modules.warc;
 
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_TRUNCATED;
 import static org.archive.format.warc.WARCConstants.HTTP_RESPONSE_MIMETYPE;
@@ -36,8 +37,12 @@ public class HttpResponseRecordBuilder extends BaseWARCRecordBuilder {
                 ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
-        recordInfo.setType(WARCRecordType.response);
         recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
+        recordInfo.setType(WARCRecordType.response);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setMimetype(HTTP_RESPONSE_MIMETYPE);

--- a/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
@@ -16,7 +16,7 @@ import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.anvl.ANVLRecord;
 
-public class MetadataRecordBuilder extends WARCRecordBuilder {
+public class MetadataRecordBuilder extends BaseWARCRecordBuilder {
 
     /**
      * If you don't want metadata records, take this class out of the chain.

--- a/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
@@ -1,0 +1,111 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
+import static org.archive.modules.CoreAttributeConstants.A_FTP_FETCH_STATUS;
+import static org.archive.modules.CoreAttributeConstants.A_SOURCE_TAG;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.lang.StringUtils;
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+import org.archive.util.anvl.ANVLRecord;
+
+public class MetadataRecordBuilder extends WARCRecordBuilder {
+
+    /**
+     * If you don't want metadata records, take this class out of the chain.
+     */
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        String scheme = curi.getUURI().getScheme().toLowerCase();
+        return scheme.startsWith("http") || "ftp".equals(scheme); 
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setType(WARCRecordType.metadata);
+        recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    "<" + concurrentTo + ">");
+        }
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(ANVLRecord.MIMETYPE);
+        recordInfo.setEnforceLength(true);
+
+        // Get some metadata from the curi.
+        // TODO: Get all curi metadata.
+        // TODO: Use other than ANVL (or rename ANVL as NameValue or use
+        // RFC822 (commons-httpclient?).
+        ANVLRecord r = new ANVLRecord();
+        if (curi.isSeed()) {
+            r.addLabel("seed");
+        } else {
+            if (curi.forceFetch()) {
+                r.addLabel("force-fetch");
+            }
+            if(StringUtils.isNotBlank(curi.getVia().toString())) {
+                r.addLabelValue("via", curi.getVia().toString());
+            }
+            if(StringUtils.isNotBlank(curi.getPathFromSeed())) {
+                r.addLabelValue("hopsFromSeed", curi.getPathFromSeed());
+            }
+            if (curi.containsDataKey(A_SOURCE_TAG)) {
+                r.addLabelValue("sourceTag", 
+                        (String)curi.getData().get(A_SOURCE_TAG));
+            }
+        }
+        long duration = curi.getFetchCompletedTime() - curi.getFetchBeginTime();
+        if (duration > -1) {
+            r.addLabelValue("fetchTimeMs", Long.toString(duration));
+        }
+        
+        if (curi.getData().containsKey(A_FTP_FETCH_STATUS)) {
+            r.addLabelValue("ftpFetchStatus", curi.getData().get(A_FTP_FETCH_STATUS).toString());
+        }
+
+        if (curi.getRecorder() != null && curi.getRecorder().getCharset() != null) {
+            r.addLabelValue("charsetForLinkExtraction", curi.getRecorder().getCharset().name());
+        }
+        
+        for (String annotation: curi.getAnnotations()) {
+            if (annotation.startsWith("usingCharsetIn") || annotation.startsWith("inconsistentCharsetIn")) {
+                String[] kv = annotation.split(":", 2);
+                r.addLabelValue(kv[0], kv[1]);
+            }
+        }
+
+        // Add outlinks though they are effectively useless without anchor text.
+        Collection<CrawlURI> links = curi.getOutLinks();
+        if (links != null && links.size() > 0) {
+            for (CrawlURI link: links) {
+                r.addLabelValue("outlink", link.getURI()+" "+link.getLastHop()+" "+link.getViaContext());
+            }
+        }
+        
+        // TODO: Other curi fields to write to metadata.
+        // 
+        // Credentials
+        // 
+        // fetch-began-time: 1154569278774
+        // fetch-completed-time: 1154569281816
+        //
+        // Annotations.
+        
+        byte [] b = r.getUTF8Bytes();
+        recordInfo.setContentStream(new ByteArrayInputStream(b));
+        recordInfo.setContentLength((long) b.length);
+        
+        return recordInfo;
+    }
+}

--- a/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
@@ -22,7 +22,7 @@ public class MetadataRecordBuilder extends BaseWARCRecordBuilder {
      * If you don't want metadata records, take this class out of the chain.
      */
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         String scheme = curi.getUURI().getScheme().toLowerCase();
         return scheme.startsWith("http") || "ftp".equals(scheme); 
     }

--- a/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
@@ -21,7 +21,7 @@ import org.archive.util.ArchiveUtils;
 public class RevisitRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         String scheme = curi.getUURI().getScheme().toLowerCase();
         return curi.isRevisit()
                 && (scheme.startsWith("http") || scheme.equals("ftp"));

--- a/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
@@ -1,5 +1,6 @@
 package org.archive.modules.warc;
 
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_PROFILE;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_TRUNCATED;
 import static org.archive.format.warc.WARCConstants.HTTP_RESPONSE_MIMETYPE;
@@ -42,8 +43,12 @@ public class RevisitRecordBuilder extends BaseWARCRecordBuilder {
         }
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
-        recordInfo.setType(WARCRecordType.revisit);
         recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
+        recordInfo.setType(WARCRecordType.revisit);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);
         String scheme = curi.getUURI().getScheme().toLowerCase();

--- a/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
@@ -22,7 +22,9 @@ public class RevisitRecordBuilder extends WARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {
-        return curi.isRevisit();
+        String scheme = curi.getUURI().getScheme().toLowerCase();
+        return curi.isRevisit()
+                && (scheme.startsWith("http") || scheme.equals("ftp"));
     }
 
     @Override

--- a/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
@@ -18,7 +18,7 @@ import org.archive.modules.CrawlURI;
 import org.archive.modules.revisit.RevisitProfile;
 import org.archive.util.ArchiveUtils;
 
-public class RevisitRecordBuilder extends WARCRecordBuilder {
+public class RevisitRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
@@ -1,0 +1,71 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_PROFILE;
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_TRUNCATED;
+import static org.archive.format.warc.WARCConstants.HTTP_RESPONSE_MIMETYPE;
+import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_LENGTH;
+import static org.archive.format.warc.WARCConstants.PROFILE_REVISIT_IDENTICAL_DIGEST;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.revisit.RevisitProfile;
+import org.archive.util.ArchiveUtils;
+
+public class RevisitRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return curi.isRevisit();
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+        
+        long revisedLength = 0; // By default, truncate all data 
+        if (curi.getRevisitProfile().getProfileName().equals(PROFILE_REVISIT_IDENTICAL_DIGEST)) {
+            // Save response from identical digest matches
+            revisedLength = curi.getRecorder().getRecordedInput().getContentBegin();
+            revisedLength = revisedLength > 0 
+                    ? revisedLength 
+                    : curi.getRecorder().getRecordedInput().getSize();
+        }
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setType(WARCRecordType.revisit);
+        recordInfo.setRecordId(generateRecordID());
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        String scheme = curi.getUURI().getScheme().toLowerCase();
+        if (scheme.startsWith("http")) {
+            recordInfo.setMimetype(HTTP_RESPONSE_MIMETYPE);
+        }
+        recordInfo.setContentLength(revisedLength);
+        recordInfo.setEnforceLength(false);
+
+        RevisitProfile revisitProfile = curi.getRevisitProfile();
+        recordInfo.addExtraHeader(HEADER_KEY_PROFILE,
+                revisitProfile.getProfileName());
+        recordInfo.addExtraHeader(HEADER_KEY_TRUNCATED,
+                NAMED_FIELD_TRUNCATED_VALUE_LENGTH);
+
+        Map<String, String> revisitHeaders = revisitProfile.getWarcHeaders();
+        for (Entry<String, String> entry: revisitHeaders.entrySet()) {
+            recordInfo.addExtraHeader(entry.getKey(), entry.getValue());            
+        }
+
+        ReplayInputStream ris = curi.getRecorder().getRecordedInput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
@@ -8,7 +8,7 @@ import org.archive.modules.CrawlURI;
 
 public interface WARCRecordBuilder {
 
-    boolean shouldProcess(CrawlURI curi);
+    boolean shouldBuildRecord(CrawlURI curi);
 
     WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
             throws IOException;

--- a/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
@@ -6,10 +6,40 @@ import java.net.URI;
 import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 
+/**
+ * Implementations of this interface are each responsible for building a
+ * particular type of WARC record.
+ *
+ * @author nlevitt
+ */
 public interface WARCRecordBuilder {
 
+    /**
+     * Decides whether to build a record for the given capture.
+     *
+     * <p>
+     * For example, {@link DnsResponseRecordBuilder#shouldBuildRecord(CrawlURI)}
+     * will return true if and only if <code>curi</code> is a capture of a dns: url.
+     *
+     * @param curi a captured url
+     * @return <code>true</code> if it is appropriate for this
+     *         {@link WARCRecordBuilder} to build a record for this capture,
+     *         <code>false</code> otherwise
+     */
     boolean shouldBuildRecord(CrawlURI curi);
 
+    /**
+     * Builds a warc record for this capture.
+     *
+     * @param curi a captured url
+     * @param concurrentTo implementations should do this:
+     * <pre>    if (concurrentTo != null) {
+     *        recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+     *                "<" + concurrentTo + ">");
+     *    }</pre>
+     * @return the freshly built warc record
+     * @throws IOException
+     */
     WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
             throws IOException;
 

--- a/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
@@ -1,0 +1,72 @@
+package org.archive.modules.warc;
+
+import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.net.CrawlHost;
+import org.archive.modules.net.ServerCache;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class WARCRecordBuilder {
+
+    transient protected ServerCache serverCache;
+    public ServerCache getServerCache() {
+        return this.serverCache;
+    }
+    @Autowired
+    public void setServerCache(ServerCache serverCache) {
+        this.serverCache = serverCache;
+    }
+
+    public abstract boolean shouldProcess(CrawlURI curi);
+    public abstract WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
+            throws IOException;
+    
+    public URI generateRecordID() {
+        try {
+            return new URI("urn:uuid:" + UUID.randomUUID());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e); // impossible 
+        }
+    }
+    
+    /**
+     * Return IP address of given URI suitable for recording (as in a
+     * classic ARC 5-field header line).
+     * 
+     * @param curi CrawlURI
+     * @return String of IP address
+     */
+    protected String getHostAddress(CrawlURI curi) {
+        // special handling for DNS URIs: want address of DNS server
+        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
+            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        }
+        // otherwise, host referenced in URI
+        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
+        // use that rather than inferred by CrawlHost lookup 
+        CrawlHost h = getServerCache().getHostFor(curi.getUURI());
+        if (h == null) {
+            throw new NullPointerException("Crawlhost is null for " +
+                curi + " " + curi.getVia());
+        }
+        InetAddress a = h.getIP();
+        if (a == null) {
+            throw new NullPointerException("Address is null for " +
+                curi + " " + curi.getVia() + ". Address " +
+                ((h.getIpFetched() == CrawlHost.IP_NEVER_LOOKED_UP)?
+                     "was never looked up.":
+                     (System.currentTimeMillis() - h.getIpFetched()) +
+                         " ms ago."));
+        }
+        return h.getIP().getHostAddress();
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WARCRecordBuilder.java
@@ -1,72 +1,16 @@
 package org.archive.modules.warc;
 
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
-
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
 
 import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
-import org.archive.modules.net.CrawlHost;
-import org.archive.modules.net.ServerCache;
-import org.springframework.beans.factory.annotation.Autowired;
 
-public abstract class WARCRecordBuilder {
+public interface WARCRecordBuilder {
 
-    transient protected ServerCache serverCache;
-    public ServerCache getServerCache() {
-        return this.serverCache;
-    }
-    @Autowired
-    public void setServerCache(ServerCache serverCache) {
-        this.serverCache = serverCache;
-    }
+    boolean shouldProcess(CrawlURI curi);
 
-    public abstract boolean shouldProcess(CrawlURI curi);
-    public abstract WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
+    WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo)
             throws IOException;
-    
-    public URI generateRecordID() {
-        try {
-            return new URI("urn:uuid:" + UUID.randomUUID());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e); // impossible 
-        }
-    }
-    
-    /**
-     * Return IP address of given URI suitable for recording (as in a
-     * classic ARC 5-field header line).
-     * 
-     * @param curi CrawlURI
-     * @return String of IP address
-     */
-    protected String getHostAddress(CrawlURI curi) {
-        // special handling for DNS URIs: want address of DNS server
-        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
-            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
-        }
-        // otherwise, host referenced in URI
-        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
-        // use that rather than inferred by CrawlHost lookup 
-        CrawlHost h = getServerCache().getHostFor(curi.getUURI());
-        if (h == null) {
-            throw new NullPointerException("Crawlhost is null for " +
-                curi + " " + curi.getVia());
-        }
-        InetAddress a = h.getIP();
-        if (a == null) {
-            throw new NullPointerException("Address is null for " +
-                curi + " " + curi.getVia() + ". Address " +
-                ((h.getIpFetched() == CrawlHost.IP_NEVER_LOOKED_UP)?
-                     "was never looked up.":
-                     (System.currentTimeMillis() - h.getIpFetched()) +
-                         " ms ago."));
-        }
-        return h.getIP().getHostAddress();
-    }
 
 }

--- a/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
@@ -1,5 +1,6 @@
 package org.archive.modules.warc;
 
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
 
 import java.io.IOException;
@@ -25,11 +26,15 @@ public class WhoisResponseRecordBuilder extends BaseWARCRecordBuilder {
                 ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setRecordId(generateRecordID());
+        if (concurrentTo != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
+                    '<' + concurrentTo.toString() + '>');
+        }
         recordInfo.setType(WARCRecordType.response);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setMimetype(curi.getContentType());
-        recordInfo.setRecordId(generateRecordID());
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
         

--- a/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
@@ -12,7 +12,7 @@ import org.archive.modules.CoreAttributeConstants;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
 
-public class WhoisResponseRecordBuilder extends WARCRecordBuilder {
+public class WhoisResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
     public boolean shouldProcess(CrawlURI curi) {

--- a/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
@@ -15,7 +15,7 @@ import org.archive.util.ArchiveUtils;
 public class WhoisResponseRecordBuilder extends BaseWARCRecordBuilder {
 
     @Override
-    public boolean shouldProcess(CrawlURI curi) {
+    public boolean shouldBuildRecord(CrawlURI curi) {
         return "whois".equals(curi.getUURI().getScheme().toLowerCase());
     }
 

--- a/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
@@ -1,0 +1,48 @@
+package org.archive.modules.warc;
+
+import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.ReplayInputStream;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.modules.CoreAttributeConstants;
+import org.archive.modules.CrawlURI;
+import org.archive.util.ArchiveUtils;
+
+public class WhoisResponseRecordBuilder extends WARCRecordBuilder {
+
+    @Override
+    public boolean shouldProcess(CrawlURI curi) {
+        return "whois".equals(curi.getUURI().getScheme().toLowerCase());
+    }
+
+    @Override
+    public WARCRecordInfo buildRecord(CrawlURI curi, URI concurrentTo) throws IOException {
+        final String timestamp =
+                ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
+
+        WARCRecordInfo recordInfo = new WARCRecordInfo();
+        recordInfo.setType(WARCRecordType.response);
+        recordInfo.setUrl(curi.toString());
+        recordInfo.setCreate14DigitDate(timestamp);
+        recordInfo.setMimetype(curi.getContentType());
+        recordInfo.setRecordId(generateRecordID());
+        recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
+        recordInfo.setEnforceLength(true);
+        
+        Object whoisServerIP = curi.getData().get(CoreAttributeConstants.A_WHOIS_SERVER_IP);
+        if (whoisServerIP != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, whoisServerIP.toString());
+        }
+        
+        ReplayInputStream ris =
+            curi.getRecorder().getRecordedInput().getReplayInputStream();
+        recordInfo.setContentStream(ris);
+        
+        return recordInfo;
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/writer/BaseWARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/BaseWARCWriterProcessor.java
@@ -1,0 +1,253 @@
+package org.archive.modules.writer;
+
+import static org.archive.modules.CoreAttributeConstants.A_WARC_STATS;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_CONTENT_DIGEST_COUNT;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_ORIGINAL_DATE;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_ORIGINAL_URL;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_FILENAME;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_FILE_OFFSET;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_RECORD_ID;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WRITE_TAG;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+import org.archive.format.warc.WARCConstants.WARCRecordType;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.io.warc.WARCWriter;
+import org.archive.io.warc.WARCWriterPool;
+import org.archive.io.warc.WARCWriterPoolSettings;
+import org.archive.modules.CrawlMetadata;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.revisit.IdenticalPayloadDigestRevisit;
+import org.archive.spring.ConfigPath;
+import org.archive.uid.RecordIDGenerator;
+import org.archive.uid.UUIDGenerator;
+import org.archive.util.ArchiveUtils;
+import org.archive.util.anvl.ANVLRecord;
+
+abstract public class BaseWARCWriterProcessor extends WriterPoolProcessor
+        implements WARCWriterPoolSettings {
+
+    private static final Logger logger = 
+            Logger.getLogger(BaseWARCWriterProcessor.class.getName());
+
+    protected AtomicLong urlsWritten = new AtomicLong();
+    protected ConcurrentMap<String, ConcurrentMap<String, AtomicLong>> stats = new ConcurrentHashMap<String, ConcurrentMap<String, AtomicLong>>();
+    public ConcurrentMap<String, ConcurrentMap<String, AtomicLong>> getStats() {
+        return stats;
+    }
+
+
+    /**
+     * Generator for record IDs
+     */
+    protected RecordIDGenerator generator = new UUIDGenerator();
+    public RecordIDGenerator getRecordIDGenerator() {
+        return generator; 
+    }
+    public void setRecordIDGenerator(RecordIDGenerator generator) {
+        this.generator = generator;
+    }
+
+    protected URI getRecordID() throws IOException {
+        return generator.getRecordID();
+    }
+
+    public long getDefaultMaxFileSize() {
+        return 1000000000L; // 1 SI giga-byte (10^9 bytes), per WARC appendix A
+    }
+
+    public List<ConfigPath> getDefaultStorePaths() {
+        List<ConfigPath> paths = new ArrayList<ConfigPath>();
+        paths.add(new ConfigPath("warcs default store path", "warcs"));
+        return paths;
+    }
+
+    @Override
+    protected void setupPool(final AtomicInteger serialNo) {
+        setPool(new WARCWriterPool(serialNo, this, getPoolMaxActive(), getMaxWaitForIdleMs()));
+    }
+
+    private transient List<String> cachedMetadata;
+    public List<String> getMetadata() {
+        if (cachedMetadata != null) {
+            return cachedMetadata;
+        }
+        ANVLRecord record = new ANVLRecord();
+        record.addLabelValue("software", "Heritrix/" +
+                ArchiveUtils.VERSION + " http://crawler.archive.org");
+        try {
+            InetAddress host = InetAddress.getLocalHost();
+            record.addLabelValue("ip", host.getHostAddress());
+            record.addLabelValue("hostname", host.getCanonicalHostName());
+        } catch (UnknownHostException e) {
+            logger.log(Level.WARNING,"unable top obtain local crawl engine host",e);
+        }
+        
+        // conforms to ISO 28500:2009 as of May 2009
+        // as described at http://bibnum.bnf.fr/WARC/ 
+        // latest draft as of November 2008
+        record.addLabelValue("format","WARC File Format 1.0"); 
+        record.addLabelValue("conformsTo","http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf");
+        
+        // Get other values from metadata provider
+
+        CrawlMetadata provider = getMetadataProvider();
+
+        addIfNotBlank(record,"operator", provider.getOperator());
+        addIfNotBlank(record,"publisher", provider.getOrganization());
+        addIfNotBlank(record,"audience", provider.getAudience());
+        addIfNotBlank(record,"isPartOf", provider.getJobName());
+        // TODO: make date match 'job creation date' as in Heritrix 1.x
+        // until then, leave out (plenty of dates already in WARC 
+        // records
+//            String rawDate = provider.getBeginDate();
+//            if(StringUtils.isNotBlank(rawDate)) {
+//                Date date;
+//                try {
+//                    date = ArchiveUtils.parse14DigitDate(rawDate);
+//                    addIfNotBlank(record,"created",ArchiveUtils.getLog14Date(date));
+//                } catch (ParseException e) {
+//                    logger.log(Level.WARNING,"obtaining warc created date",e);
+//                }
+//            }
+        addIfNotBlank(record,"description", provider.getDescription());
+        addIfNotBlank(record,"robots", provider.getRobotsPolicyName().toLowerCase());
+
+        addIfNotBlank(record,"http-header-user-agent",
+                provider.getUserAgent());
+        addIfNotBlank(record,"http-header-from",
+                provider.getOperatorFrom());
+
+        // really ugly to return as List<String>, but changing would require 
+        // larger refactoring
+        return Collections.singletonList(record.toString());
+    }
+    
+    protected void addIfNotBlank(ANVLRecord record, String label, String value) {
+        if(StringUtils.isNotBlank(value)) {
+            record.addLabelValue(label, value);
+        }
+    }
+
+
+    protected void addStats(Map<String, Map<String, Long>> substats) {
+        for (String key: substats.keySet()) {
+            // intentionally redundant here -- if statement avoids creating
+            // unused empty map every time; putIfAbsent() ensures thread safety
+            if (stats.get(key) == null) {
+                stats.putIfAbsent(key, new ConcurrentHashMap<String, AtomicLong>());
+            }
+            
+            for (String subkey: substats.get(key).keySet()) {
+                AtomicLong oldValue = stats.get(key).get(subkey);
+                if (oldValue == null) {
+                    oldValue = stats.get(key).putIfAbsent(subkey, new AtomicLong(substats.get(key).get(subkey)));
+                }
+                if (oldValue != null) {
+                    oldValue.addAndGet(substats.get(key).get(subkey));
+                }
+            }
+        }
+    }
+
+    @Override
+    public String report() {
+        // XXX note in report that stats include recovered checkpoint?
+        logger.info("final stats: " + stats);
+        
+        StringBuilder buf = new StringBuilder();
+        buf.append("Processor: " + getClass().getName() + "\n");
+        buf.append("  Function:          Writes WARCs\n");
+        buf.append("  Total CrawlURIs:   " + urlsWritten + "\n");
+        buf.append("  Revisit records:   " + WARCWriter.getStat(stats, WARCRecordType.revisit.toString(), WARCWriter.NUM_RECORDS) + "\n");
+        
+        long bytes = WARCWriter.getStat(stats, WARCRecordType.response.toString(), WARCWriter.CONTENT_BYTES)
+                + WARCWriter.getStat(stats, WARCRecordType.resource.toString(), WARCWriter.CONTENT_BYTES);
+        buf.append("  Crawled content bytes (including http headers): "
+                + bytes + " (" + ArchiveUtils.formatBytesForDisplay(bytes) + ")\n");
+        
+        bytes = WARCWriter.getStat(stats, WARCWriter.TOTALS, WARCWriter.TOTAL_BYTES);
+        buf.append("  Total uncompressed bytes (including all warc records): "
+                + bytes + " (" + ArchiveUtils.formatBytesForDisplay(bytes) + ")\n");
+        
+        buf.append("  Total size on disk ("+ (getCompress() ? "compressed" : "uncompressed") + "): "
+                + getTotalBytesWritten() + " (" + ArchiveUtils.formatBytesForDisplay(getTotalBytesWritten()) + ")\n");
+        
+        return buf.toString();
+    }
+
+    protected Map<String, Map<String, Long>> copyStats(Map<String, Map<String, Long>> orig) {
+        Map<String, Map<String, Long>> copy = new HashMap<String, Map<String, Long>>(orig.size());
+        for (String k: orig.keySet()) {
+            copy.put(k, new HashMap<String, Long>(orig.get(k)));
+        }
+        return copy;
+    }
+   
+    protected void updateMetadataAfterWrite(final CrawlURI curi,
+            WARCWriter writer, long startPosition) {
+        if (WARCWriter.getStat(writer.getTmpStats(), WARCWriter.TOTALS, WARCWriter.NUM_RECORDS) > 0l) {
+             addStats(writer.getTmpStats());
+             urlsWritten.incrementAndGet();
+        }
+        if (logger.isLoggable(Level.FINE)) { 
+            logger.fine("wrote " 
+                + WARCWriter.getStat(writer.getTmpStats(), WARCWriter.TOTALS, WARCWriter.SIZE_ON_DISK) 
+                + " bytes to " + writer.getFile().getName() + " for " + curi);
+        }
+        setTotalBytesWritten(getTotalBytesWritten() + (writer.getPosition() - startPosition));
+
+        curi.addExtraInfo("warcFilename", writer.getFilenameWithoutOccupiedSuffix());
+        curi.addExtraInfo("warcFileOffset", startPosition);
+
+        curi.getData().put(A_WARC_STATS, copyStats(writer.getTmpStats()));
+
+        // history for uri-based dedupe
+        Map<String,Object>[] history = curi.getFetchHistory();
+        if (history != null && history[0] != null) {
+            history[0].put(A_WRITE_TAG, writer.getFilenameWithoutOccupiedSuffix());
+        }
+        
+        // history for uri-agnostic, content digest based dedupe
+        if (curi.getContentDigest() != null && curi.hasContentDigestHistory()) {
+            for (WARCRecordInfo warcRecord: writer.getTmpRecordLog()) {
+                if ((warcRecord.getType() == WARCRecordType.response 
+                        || warcRecord.getType() == WARCRecordType.resource)
+                        && warcRecord.getContentStream() != null
+                        && warcRecord.getContentLength() > 0) {
+                    curi.getContentDigestHistory().put(A_ORIGINAL_URL, warcRecord.getUrl());
+                    curi.getContentDigestHistory().put(A_WARC_RECORD_ID, warcRecord.getRecordId().toString());
+                    curi.getContentDigestHistory().put(A_WARC_FILENAME, warcRecord.getWARCFilename());
+                    curi.getContentDigestHistory().put(A_WARC_FILE_OFFSET, warcRecord.getWARCFileOffset());
+                    curi.getContentDigestHistory().put(A_ORIGINAL_DATE, warcRecord.getCreate14DigitDate());
+                    curi.getContentDigestHistory().put(A_CONTENT_DIGEST_COUNT, 1);
+                } else if (warcRecord.getType() == WARCRecordType.revisit
+                        && curi.getRevisitProfile() instanceof IdenticalPayloadDigestRevisit) {
+                     Integer oldCount = (Integer) curi.getContentDigestHistory().get(A_CONTENT_DIGEST_COUNT);
+                     if (oldCount == null) {
+                         // shouldn't happen, log a warning?
+                         oldCount = 1;
+                     }
+                     curi.getContentDigestHistory().put(A_CONTENT_DIGEST_COUNT, oldCount + 1);
+                }
+            }
+        }
+    }
+
+}

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
@@ -2,7 +2,7 @@ package org.archive.modules.writer;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -12,7 +12,15 @@ import org.archive.io.warc.WARCWriter;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.ProcessResult;
 import org.archive.modules.deciderules.recrawl.IdenticalDigestDecideRule;
+import org.archive.modules.warc.DnsResponseRecordBuilder;
+import org.archive.modules.warc.FtpControlConversationRecordBuilder;
+import org.archive.modules.warc.FtpResponseRecordBuilder;
+import org.archive.modules.warc.HttpRequestRecordBuilder;
+import org.archive.modules.warc.HttpResponseRecordBuilder;
+import org.archive.modules.warc.MetadataRecordBuilder;
+import org.archive.modules.warc.RevisitRecordBuilder;
 import org.archive.modules.warc.WARCRecordBuilder;
+import org.archive.modules.warc.WhoisResponseRecordBuilder;
 import org.archive.spring.HasKeyedProperties;
 
 public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements HasKeyedProperties {
@@ -20,7 +28,15 @@ public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements
             Logger.getLogger(WARCWriterChainProcessor.class.getName());
     
     {
-        setChain(new ArrayList<WARCRecordBuilder>());
+        setChain(Arrays.asList(
+                new DnsResponseRecordBuilder(),
+                new HttpResponseRecordBuilder(),
+                new WhoisResponseRecordBuilder(),
+                new FtpControlConversationRecordBuilder(),
+                new FtpResponseRecordBuilder(),
+                new RevisitRecordBuilder(),
+                new HttpRequestRecordBuilder(),
+                new MetadataRecordBuilder()));
     }
     @SuppressWarnings("unchecked")
     public List<WARCRecordBuilder> getChain() {

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
@@ -128,7 +128,7 @@ public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements
     protected void writeRecords(CrawlURI curi, WARCWriter writer) throws IOException {
         URI concurrentTo = null;
         for (WARCRecordBuilder recordBuilder: getChain()) {
-            if (recordBuilder.shouldProcess(curi)) {
+            if (recordBuilder.shouldBuildRecord(curi)) {
                 WARCRecordInfo record = recordBuilder.buildRecord(curi, concurrentTo);
                 if (record != null) {
                     writer.writeRecord(record);

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
@@ -1,0 +1,126 @@
+package org.archive.modules.writer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.io.warc.WARCWriter;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.ProcessResult;
+import org.archive.modules.deciderules.recrawl.IdenticalDigestDecideRule;
+import org.archive.modules.warc.WARCRecordBuilder;
+import org.archive.spring.HasKeyedProperties;
+
+public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements HasKeyedProperties {
+    private static final Logger logger = 
+            Logger.getLogger(WARCWriterChainProcessor.class.getName());
+    
+    {
+        setChain(new ArrayList<WARCRecordBuilder>());
+    }
+    @SuppressWarnings("unchecked")
+    public List<WARCRecordBuilder> getChain() {
+        return (List<WARCRecordBuilder>) kp.get("chain");
+    }
+    public void setChain(List<WARCRecordBuilder> chain) {
+        kp.put("chain", chain);
+    }
+
+    @Override
+    protected boolean shouldWrite(CrawlURI curi) {
+        if (getSkipIdenticalDigests()
+                && IdenticalDigestDecideRule.hasIdenticalDigest(curi)) {
+            curi.getAnnotations().add(ANNOTATION_UNWRITTEN 
+                    + ":identicalDigest");
+            return false;
+        }
+
+        // WARCWriterProcessor has seemingly unnecessarily complicated logic
+        if (curi.getFetchStatus() <= 0) {
+            curi.getAnnotations().add(ANNOTATION_UNWRITTEN + ":status");
+            return false;
+        }
+        
+        return true;
+    }
+    
+    @Override
+    protected ProcessResult innerProcessResult(CrawlURI curi) {
+        try {
+            if (shouldWrite(curi)) {
+                return write(curi);
+            } else {
+                copyForwardWriteTagIfDupe(curi);
+            }
+        } catch (IOException e) {
+            curi.getNonFatalFailures().add(e);
+            logger.log(Level.SEVERE, "Failed write of Records: " +
+                curi.toString(), e);
+        }
+        return ProcessResult.PROCEED;
+    }
+    
+    protected ProcessResult write(final CrawlURI curi)
+    throws IOException {
+        WARCWriter writer = (WARCWriter) getPool().borrowFile();
+
+        // Reset writer temp stats so they reflect only this set of records.
+        writer.resetTmpStats();
+        writer.resetTmpRecordLog();
+
+        long position = writer.getPosition();
+        try {
+            // Roll over to new warc file if we've exceeded maxBytes.
+            writer.checkSize();
+            if (writer.getPosition() != position) {
+                // We rolled over to a new warc and wrote a warcinfo record.
+                // Tally stats and reset temp stats, to avoid including warcinfo
+                // record in stats for current url.
+                setTotalBytesWritten(getTotalBytesWritten() +
+                    (writer.getPosition() - position));
+                addStats(writer.getTmpStats());
+                writer.resetTmpStats();
+                writer.resetTmpRecordLog();
+
+                position = writer.getPosition();
+            }
+
+            writeRecords(curi, writer);
+        } catch (IOException e) {
+            // Invalidate this file (It gets a '.invalid' suffix).
+            getPool().invalidateFile(writer);
+            // Set the writer to null otherwise the pool accounting
+            // of how many active writers gets skewed if we subsequently
+            // do a returnWriter call on this object in the finally block.
+            writer = null;
+            throw e;
+        } finally {
+            if (writer != null) {
+                updateMetadataAfterWrite(curi, writer, position);
+                getPool().returnFile(writer);
+            }
+        }
+        // XXX this looks wrong, check should happen *before* writing the
+        // record, the way checkBytesWritten() currently works
+        return checkBytesWritten();
+    }
+
+    protected void writeRecords(CrawlURI curi, WARCWriter writer) throws IOException {
+        URI concurrentTo = null;
+        for (WARCRecordBuilder recordBuilder: getChain()) {
+            if (recordBuilder.shouldProcess(curi)) {
+                WARCRecordInfo record = recordBuilder.buildRecord(curi, concurrentTo);
+                if (record != null) {
+                    writer.writeRecord(record);
+                    if (concurrentTo == null) {
+                        concurrentTo = record.getRecordId();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
@@ -39,10 +39,10 @@ public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements
                 new MetadataRecordBuilder()));
     }
     @SuppressWarnings("unchecked")
-    public List<WARCRecordBuilder> getChain() {
+    public List<? extends WARCRecordBuilder> getChain() {
         return (List<WARCRecordBuilder>) kp.get("chain");
     }
-    public void setChain(List<WARCRecordBuilder> chain) {
+    public void setChain(List<? extends WARCRecordBuilder> chain) {
         kp.put("chain", chain);
     }
 

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
@@ -23,6 +23,33 @@ import org.archive.modules.warc.WARCRecordBuilder;
 import org.archive.modules.warc.WhoisResponseRecordBuilder;
 import org.archive.spring.HasKeyedProperties;
 
+/**
+ * WARC writer processor. The types of records that to be written can be
+ * configured by including or excluding {@link WARCRecordBuilder}
+ * implementations (see {@link #setChain(List)}).
+ *
+ * <p>This is the default chain:
+ * <pre>
+ *   &lt;property name="chain"&gt;
+ *    &lt;list&gt;
+ *     &lt;bean class="org.archive.modules.warc.DnsResponseRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.HttpResponseRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.WhoisResponseRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.FtpControlConversationRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.FtpResponseRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.RevisitRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.HttpRequestRecordBuilder"/&gt;
+ *     &lt;bean class="org.archive.modules.warc.MetadataRecordBuilder"/&gt;
+ *    &lt;/list&gt;
+ *   &lt;/property&gt;
+ * </pre>
+ *
+ * <p>
+ * Replaces {@link WARCWriterProcessor}.
+ *
+ * @see WARCRecordBuilder
+ * @author nlevitt
+ */
 public class WARCWriterChainProcessor extends BaseWARCWriterProcessor implements HasKeyedProperties {
     private static final Logger logger = 
             Logger.getLogger(WARCWriterChainProcessor.class.getName());

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
@@ -37,33 +37,16 @@ import static org.archive.modules.CoreAttributeConstants.A_FTP_CONTROL_CONVERSAT
 import static org.archive.modules.CoreAttributeConstants.A_FTP_FETCH_STATUS;
 import static org.archive.modules.CoreAttributeConstants.A_SOURCE_TAG;
 import static org.archive.modules.CoreAttributeConstants.A_WARC_RESPONSE_HEADERS;
-import static org.archive.modules.CoreAttributeConstants.A_WARC_STATS;
 import static org.archive.modules.CoreAttributeConstants.HEADER_TRUNC;
 import static org.archive.modules.CoreAttributeConstants.LENGTH_TRUNC;
 import static org.archive.modules.CoreAttributeConstants.TIMER_TRUNC;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_CONTENT_DIGEST_COUNT;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_ORIGINAL_DATE;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_ORIGINAL_URL;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_FILENAME;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_FILE_OFFSET;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WARC_RECORD_ID;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WRITE_TAG;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -73,17 +56,11 @@ import org.archive.format.warc.WARCConstants.WARCRecordType;
 import org.archive.io.ReplayInputStream;
 import org.archive.io.warc.WARCRecordInfo;
 import org.archive.io.warc.WARCWriter;
-import org.archive.io.warc.WARCWriterPool;
 import org.archive.io.warc.WARCWriterPoolSettings;
 import org.archive.modules.CoreAttributeConstants;
-import org.archive.modules.CrawlMetadata;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.ProcessResult;
-import org.archive.modules.revisit.IdenticalPayloadDigestRevisit;
 import org.archive.modules.revisit.RevisitProfile;
-import org.archive.spring.ConfigPath;
-import org.archive.uid.RecordIDGenerator;
-import org.archive.uid.UUIDGenerator;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.anvl.ANVLRecord;
 import org.json.JSONException;
@@ -97,29 +74,16 @@ import org.json.JSONObject;
  * (commons-httpclient?) or find something else.
  * 
  * @author stack
+ * 
+ * @deprecated in favor of {@link WARCWriterChainProcessor}
  */
-public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWriterPoolSettings {
+@Deprecated
+public class WARCWriterProcessor extends BaseWARCWriterProcessor implements WARCWriterPoolSettings {
     @SuppressWarnings("unused")
     private static final long serialVersionUID = 6182850087635847443L;
     private static final Logger logger = 
         Logger.getLogger(WARCWriterProcessor.class.getName());
 
-    private ConcurrentMap<String, ConcurrentMap<String, AtomicLong>> stats = new ConcurrentHashMap<String, ConcurrentMap<String, AtomicLong>>();
-    public ConcurrentMap<String, ConcurrentMap<String, AtomicLong>> getStats() {
-        return stats;
-    }
-
-    private AtomicLong urlsWritten = new AtomicLong();
-    
-    public long getDefaultMaxFileSize() {
-        return 1000000000L; // 1 SI giga-byte (10^9 bytes), per WARC appendix A
-    }
-    public List<ConfigPath> getDefaultStorePaths() {
-        List<ConfigPath> paths = new ArrayList<ConfigPath>();
-        paths.add(new ConfigPath("warcs default store path", "warcs"));
-        return paths;
-    }
-    
     /**
      * Whether to write 'request' type records. Default is true.
      */
@@ -145,17 +109,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
     public void setWriteMetadata(boolean writeMetadata) {
         kp.put("writeMetadata",writeMetadata);
     }
-    
-    /**
-     * Generator for record IDs
-     */
-    protected RecordIDGenerator generator = new UUIDGenerator();
-    public RecordIDGenerator getRecordIDGenerator() {
-        return generator; 
-    }
-    public void setRecordIDGenerator(RecordIDGenerator generator) {
-        this.generator = generator;
-    }
 
     @Deprecated
     public void setWriteRevisitForIdenticalDigests(boolean writeRevisits) {
@@ -167,14 +120,7 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         logger.warning("setting writeRevisitForNotModified is deprecated, value ignored");
     }
 
-    private transient List<String> cachedMetadata;
-
     public WARCWriterProcessor() {
-    }
-
-    @Override
-    protected void setupPool(final AtomicInteger serialNo) {
-        setPool(new WARCWriterPool(serialNo, this, getPoolMaxActive(), getMaxWaitForIdleMs()));
     }
 
     /**
@@ -264,84 +210,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         return checkBytesWritten();
     }
     
-    protected Map<String, Map<String, Long>> copyStats(Map<String, Map<String, Long>> orig) {
-        Map<String, Map<String, Long>> copy = new HashMap<String, Map<String, Long>>(orig.size());
-        for (String k: orig.keySet()) {
-            copy.put(k, new HashMap<String, Long>(orig.get(k)));
-        }
-        return copy;
-    }
-
-    protected void updateMetadataAfterWrite(final CrawlURI curi,
-            WARCWriter writer, long startPosition) {
-        if (WARCWriter.getStat(writer.getTmpStats(), WARCWriter.TOTALS, WARCWriter.NUM_RECORDS) > 0l) {
-             addStats(writer.getTmpStats());
-             urlsWritten.incrementAndGet();
-        }
-        if (logger.isLoggable(Level.FINE)) { 
-            logger.fine("wrote " 
-                + WARCWriter.getStat(writer.getTmpStats(), WARCWriter.TOTALS, WARCWriter.SIZE_ON_DISK) 
-                + " bytes to " + writer.getFile().getName() + " for " + curi);
-        }
-        setTotalBytesWritten(getTotalBytesWritten() + (writer.getPosition() - startPosition));
-
-        curi.addExtraInfo("warcFilename", writer.getFilenameWithoutOccupiedSuffix());
-        curi.addExtraInfo("warcFileOffset", startPosition);
-
-        curi.getData().put(A_WARC_STATS, copyStats(writer.getTmpStats()));
-
-        // history for uri-based dedupe
-        Map<String,Object>[] history = curi.getFetchHistory();
-        if (history != null && history[0] != null) {
-            history[0].put(A_WRITE_TAG, writer.getFilenameWithoutOccupiedSuffix());
-        }
-        
-        // history for uri-agnostic, content digest based dedupe
-        if (curi.getContentDigest() != null && curi.hasContentDigestHistory()) {
-            for (WARCRecordInfo warcRecord: writer.getTmpRecordLog()) {
-                if ((warcRecord.getType() == WARCRecordType.response 
-                        || warcRecord.getType() == WARCRecordType.resource)
-                        && warcRecord.getContentStream() != null
-                        && warcRecord.getContentLength() > 0) {
-                    curi.getContentDigestHistory().put(A_ORIGINAL_URL, warcRecord.getUrl());
-                    curi.getContentDigestHistory().put(A_WARC_RECORD_ID, warcRecord.getRecordId().toString());
-                    curi.getContentDigestHistory().put(A_WARC_FILENAME, warcRecord.getWARCFilename());
-                    curi.getContentDigestHistory().put(A_WARC_FILE_OFFSET, warcRecord.getWARCFileOffset());
-                    curi.getContentDigestHistory().put(A_ORIGINAL_DATE, warcRecord.getCreate14DigitDate());
-                    curi.getContentDigestHistory().put(A_CONTENT_DIGEST_COUNT, 1);
-                } else if (warcRecord.getType() == WARCRecordType.revisit
-                        && curi.getRevisitProfile() instanceof IdenticalPayloadDigestRevisit) {
-                     Integer oldCount = (Integer) curi.getContentDigestHistory().get(A_CONTENT_DIGEST_COUNT);
-                     if (oldCount == null) {
-                         // shouldn't happen, log a warning?
-                         oldCount = 1;
-                     }
-                     curi.getContentDigestHistory().put(A_CONTENT_DIGEST_COUNT, oldCount + 1);
-                }
-            }
-        }
-    }
-
-    protected void addStats(Map<String, Map<String, Long>> substats) {
-        for (String key: substats.keySet()) {
-            // intentionally redundant here -- if statement avoids creating
-            // unused empty map every time; putIfAbsent() ensures thread safety
-            if (stats.get(key) == null) {
-                stats.putIfAbsent(key, new ConcurrentHashMap<String, AtomicLong>());
-            }
-            
-            for (String subkey: substats.get(key).keySet()) {
-                AtomicLong oldValue = stats.get(key).get(subkey);
-                if (oldValue == null) {
-                    oldValue = stats.get(key).putIfAbsent(subkey, new AtomicLong(substats.get(key).get(subkey)));
-                }
-                if (oldValue != null) {
-                    oldValue.addAndGet(substats.get(key).get(subkey));
-                }
-            }
-        }
-    }
-   
     protected void writeDnsRecords(final CrawlURI curi, WARCWriter w,
             final URI baseid, final String timestamp) throws IOException {
         WARCRecordInfo recordInfo = new WARCRecordInfo();
@@ -767,10 +635,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         return recordInfo.getRecordId();
     }
     
-    protected URI getRecordID() throws IOException {
-        return generator.getRecordID();
-    }
-    
     protected URI qualifyRecordID(final URI base, final String key,
             final String value)
     throws IOException {
@@ -778,67 +642,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
         qualifiers.put(key, value);
         return generator.qualifyRecordID(base, qualifiers);
     }  
-
-    public List<String> getMetadata() {
-        if (cachedMetadata != null) {
-            return cachedMetadata;
-        }
-        ANVLRecord record = new ANVLRecord();
-        record.addLabelValue("software", "Heritrix/" +
-                ArchiveUtils.VERSION + " http://crawler.archive.org");
-        try {
-            InetAddress host = InetAddress.getLocalHost();
-            record.addLabelValue("ip", host.getHostAddress());
-            record.addLabelValue("hostname", host.getCanonicalHostName());
-        } catch (UnknownHostException e) {
-            logger.log(Level.WARNING,"unable top obtain local crawl engine host",e);
-        }
-        
-        // conforms to ISO 28500:2009 as of May 2009
-        // as described at http://bibnum.bnf.fr/WARC/ 
-        // latest draft as of November 2008
-        record.addLabelValue("format","WARC File Format 1.0"); 
-        record.addLabelValue("conformsTo","http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf");
-        
-        // Get other values from metadata provider
-
-        CrawlMetadata provider = getMetadataProvider();
-
-        addIfNotBlank(record,"operator", provider.getOperator());
-        addIfNotBlank(record,"publisher", provider.getOrganization());
-        addIfNotBlank(record,"audience", provider.getAudience());
-        addIfNotBlank(record,"isPartOf", provider.getJobName());
-        // TODO: make date match 'job creation date' as in Heritrix 1.x
-        // until then, leave out (plenty of dates already in WARC 
-        // records
-//            String rawDate = provider.getBeginDate();
-//            if(StringUtils.isNotBlank(rawDate)) {
-//                Date date;
-//                try {
-//                    date = ArchiveUtils.parse14DigitDate(rawDate);
-//                    addIfNotBlank(record,"created",ArchiveUtils.getLog14Date(date));
-//                } catch (ParseException e) {
-//                    logger.log(Level.WARNING,"obtaining warc created date",e);
-//                }
-//            }
-        addIfNotBlank(record,"description", provider.getDescription());
-        addIfNotBlank(record,"robots", provider.getRobotsPolicyName().toLowerCase());
-
-        addIfNotBlank(record,"http-header-user-agent",
-                provider.getUserAgent());
-        addIfNotBlank(record,"http-header-from",
-                provider.getOperatorFrom());
-
-        // really ugly to return as List<String>, but changing would require 
-        // larger refactoring
-        return Collections.singletonList(record.toString());
-    }
-    
-    protected void addIfNotBlank(ANVLRecord record, String label, String value) {
-        if(StringUtils.isNotBlank(value)) {
-            record.addLabelValue(label, value);
-        }
-    }
     
     @Override
     protected JSONObject toCheckpointJson() throws JSONException {
@@ -877,32 +680,6 @@ public class WARCWriterProcessor extends WriterPoolProcessor implements WARCWrit
                 addStats(cpStats);
             }
         }
-    }
-
-    @Override
-    public String report() {
-        // XXX note in report that stats include recovered checkpoint?
-        logger.info("final stats: " + stats);
-        
-        StringBuilder buf = new StringBuilder();
-        buf.append("Processor: " + getClass().getName() + "\n");
-        buf.append("  Function:          Writes WARCs\n");
-        buf.append("  Total CrawlURIs:   " + urlsWritten + "\n");
-        buf.append("  Revisit records:   " + WARCWriter.getStat(stats, WARCRecordType.revisit.toString(), WARCWriter.NUM_RECORDS) + "\n");
-        
-        long bytes = WARCWriter.getStat(stats, WARCRecordType.response.toString(), WARCWriter.CONTENT_BYTES)
-                + WARCWriter.getStat(stats, WARCRecordType.resource.toString(), WARCWriter.CONTENT_BYTES);
-        buf.append("  Crawled content bytes (including http headers): "
-                + bytes + " (" + ArchiveUtils.formatBytesForDisplay(bytes) + ")\n");
-        
-        bytes = WARCWriter.getStat(stats, WARCWriter.TOTALS, WARCWriter.TOTAL_BYTES);
-        buf.append("  Total uncompressed bytes (including all warc records): "
-                + bytes + " (" + ArchiveUtils.formatBytesForDisplay(bytes) + ")\n");
-        
-        buf.append("  Total size on disk ("+ (getCompress() ? "compressed" : "uncompressed") + "): "
-                + getTotalBytesWritten() + " (" + ArchiveUtils.formatBytesForDisplay(getTotalBytesWritten()) + ")\n");
-        
-        return buf.toString();
     }
     
 }

--- a/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
@@ -45,6 +45,7 @@ import org.archive.modules.Processor;
 import org.archive.modules.deciderules.recrawl.IdenticalDigestDecideRule;
 import org.archive.modules.net.CrawlHost;
 import org.archive.modules.net.ServerCache;
+import org.archive.modules.warc.WARCRecordBuilder;
 import org.archive.spring.ConfigPath;
 import org.archive.util.FileUtils;
 import org.json.JSONException;
@@ -370,7 +371,10 @@ implements Lifecycle, Checkpointable, WriterPoolSettings {
      * 
      * @param curi CrawlURI
      * @return String of IP address
+     * 
+     * @deprecated WARCRecordBuilder instances use {@link WARCRecordBuilder#getHostAddress(CrawlURI)}
      */
+    @Deprecated
     protected String getHostAddress(CrawlURI curi) {
         // special handling for DNS URIs: want address of DNS server
         if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {

--- a/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
@@ -45,7 +45,7 @@ import org.archive.modules.Processor;
 import org.archive.modules.deciderules.recrawl.IdenticalDigestDecideRule;
 import org.archive.modules.net.CrawlHost;
 import org.archive.modules.net.ServerCache;
-import org.archive.modules.warc.WARCRecordBuilder;
+import org.archive.modules.warc.BaseWARCRecordBuilder;
 import org.archive.spring.ConfigPath;
 import org.archive.util.FileUtils;
 import org.json.JSONException;
@@ -372,7 +372,7 @@ implements Lifecycle, Checkpointable, WriterPoolSettings {
      * @param curi CrawlURI
      * @return String of IP address
      * 
-     * @deprecated WARCRecordBuilder instances use {@link WARCRecordBuilder#getHostAddress(CrawlURI)}
+     * @deprecated WARCRecordBuilder instances use {@link BaseWARCRecordBuilder#getHostAddress(CrawlURI)}
      */
     @Deprecated
     protected String getHostAddress(CrawlURI curi) {

--- a/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
+++ b/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
@@ -62,8 +62,8 @@ import org.archive.io.warc.WARCReaderFactory;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.fetcher.FetchHTTP;
 import org.archive.modules.fetcher.FetchHTTPTests;
-import org.archive.modules.writer.WARCWriterProcessor;
-import org.archive.modules.writer.WARCWriterProcessorTest;
+import org.archive.modules.writer.WARCWriterChainProcessor;
+import org.archive.modules.writer.WARCWriterChainProcessorTest;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.spring.ConfigPath;
@@ -218,7 +218,7 @@ public class ContentDigestHistoryTest extends TmpDirTestCase {
         Server server = newHttpServer();
 
         FetchHTTP fetcher = FetchHTTPTests.newTestFetchHttp(getClass().getName());
-        WARCWriterProcessor warcWriter = WARCWriterProcessorTest.newTestWarcWriter(getClass().getName());
+        WARCWriterChainProcessor warcWriter = WARCWriterChainProcessorTest.makeTestWARCWriterChainProcessor();
         warcWriter.setServerCache(fetcher.getServerCache());
         for (File dir: warcWriter.calcOutputDirs()) {
             /* make sure we don't have other stuff hanging around that will

--- a/modules/src/test/java/org/archive/modules/writer/WARCWriterChainProcessorTest.java
+++ b/modules/src/test/java/org/archive/modules/writer/WARCWriterChainProcessorTest.java
@@ -1,0 +1,28 @@
+package org.archive.modules.writer;
+
+import java.io.File;
+
+import org.archive.modules.CrawlMetadata;
+import org.archive.modules.fetcher.DefaultServerCache;
+import org.archive.spring.ConfigPath;
+import org.archive.util.FileUtils;
+import org.archive.util.TmpDirTestCase;
+
+public class WARCWriterChainProcessorTest extends WARCWriterProcessorTest {
+
+    @Override
+    protected Object makeModule() throws Exception {
+        File tmp = TmpDirTestCase.tmpDir();
+        tmp = new File(tmp, getClass().getSimpleName());
+        FileUtils.ensureWriteableDirectory(tmp);
+
+        WARCWriterChainProcessor result = new WARCWriterChainProcessor();
+        result.setDirectory(new ConfigPath("test", tmp.getAbsolutePath()));
+        result.setServerCache(new DefaultServerCache());
+        CrawlMetadata metadata = new CrawlMetadata();
+        metadata.afterPropertiesSet();
+        result.setMetadataProvider(metadata);
+        result.start();
+        return result;
+    }
+}

--- a/modules/src/test/java/org/archive/modules/writer/WARCWriterChainProcessorTest.java
+++ b/modules/src/test/java/org/archive/modules/writer/WARCWriterChainProcessorTest.java
@@ -1,6 +1,7 @@
 package org.archive.modules.writer;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.archive.modules.CrawlMetadata;
 import org.archive.modules.fetcher.DefaultServerCache;
@@ -12,8 +13,15 @@ public class WARCWriterChainProcessorTest extends WARCWriterProcessorTest {
 
     @Override
     protected Object makeModule() throws Exception {
+        WARCWriterChainProcessor result = makeTestWARCWriterChainProcessor();
+        result.start();
+        return result;
+    }
+
+    public static WARCWriterChainProcessor makeTestWARCWriterChainProcessor()
+            throws IOException {
         File tmp = TmpDirTestCase.tmpDir();
-        tmp = new File(tmp, getClass().getSimpleName());
+        tmp = new File(tmp, WARCWriterChainProcessorTest.class.getSimpleName());
         FileUtils.ensureWriteableDirectory(tmp);
 
         WARCWriterChainProcessor result = new WARCWriterChainProcessor();
@@ -22,7 +30,6 @@ public class WARCWriterChainProcessorTest extends WARCWriterProcessorTest {
         CrawlMetadata metadata = new CrawlMetadata();
         metadata.afterPropertiesSet();
         result.setMetadataProvider(metadata);
-        result.start();
         return result;
     }
 }


### PR DESCRIPTION
Idea here is to make warc writing configurable such that a custom processor can write a special warc record. The proximate need is to write special youtube-dl json records. Really didn't want to hack something specific to that case into WARCWriterProcessor. 

The default chain (see profile-crawler-beans.cxml):
```
  <property name="chain">
   <list>
    <bean class="org.archive.modules.warc.DnsResponseRecordBuilder"/>
    <bean class="org.archive.modules.warc.HttpResponseRecordBuilder"/>
    <bean class="org.archive.modules.warc.WhoisResponseRecordBuilder"/>
    <bean class="org.archive.modules.warc.FtpControlConversationRecordBuilder"/>
    <bean class="org.archive.modules.warc.FtpResponseRecordBuilder"/>
    <bean class="org.archive.modules.warc.RevisitRecordBuilder"/>
    <bean class="org.archive.modules.warc.HttpRequestRecordBuilder"/>
    <bean class="org.archive.modules.warc.MetadataRecordBuilder"/>
   </list>
  </property>
```

As an example, to let ExtractorYoutubeDL write youtube-dl json warc records, add this to the chain:
```
        <ref bean="extractorYoutubeDL"/>
```
(You will have an identical element in the fetch chain.)

Informative code snippet:
```
    protected void writeRecords(CrawlURI curi, WARCWriter writer) throws IOException {
        URI concurrentTo = null;
        for (WARCRecordBuilder recordBuilder: getChain()) {
            if (recordBuilder.shouldBuildRecord(curi)) {
                WARCRecordInfo record = recordBuilder.buildRecord(curi, concurrentTo);
                if (record != null) {
                    writer.writeRecord(record);
                    if (concurrentTo == null) {
                        concurrentTo = record.getRecordId();
                    }
                }
            }
        }
    }
```

We've had this running successfully in QA for 4 months, to the point I had completely forgotten about it, so I think it's pretty much complete. (I had aspirations to refactor some of the messy stuff like managing the dedup metadata in `updateMetadataAfterWrite()`. But I don't have a specific approach in mind and there's no urgent need.) This code may inherit bugs from legacy WARCWriterProcessor. Probably just needs javadocs 😬