### PR TITLE
Disable test that connects to wwwb-dedup.us.archive.org

### DIFF
--- a/contrib/src/test/java/org/archive/modules/recrawl/wbm/WbmPersistLoadProcessorTest.java
+++ b/contrib/src/test/java/org/archive/modules/recrawl/wbm/WbmPersistLoadProcessorTest.java
@@ -156,8 +156,9 @@ public class WbmPersistLoadProcessorTest extends TestCase {
     FetchHistoryProcessor fhp = new FetchHistoryProcessor();
     fhp.process(curi);
   }
-  
-  public void testInnerProcessResultSingleShotWithRealServer() throws Exception {
+
+  // DISABLED: this relies on wwwb-dedup.us.archive.org which is intermittently returning 503
+  public void xtestInnerProcessResultSingleShotWithRealServer() throws Exception {
     WbmPersistLoadProcessor t = new WbmPersistLoadProcessor();
     //CrawlURI curi = new CrawlURI(UURIFactory.getInstance("http://archive.org/"));
     CrawlURI curi = new CrawlURI(UURIFactory.getInstance("http://www.mext.go.jp/null.gif"));


### PR DESCRIPTION
http://wwwb-dedup.us.archive.org:8083/web/timemap/cdx?url=http%3A%2F%2Fwww.mext.go.jp%2Fnull.gif&limit=-1
is returning 503 intermittently and so this test is breaking the Travis builds of
unrelated changes.