### PR TITLE
fix logging config

### DIFF
--- a/engine/src/main/java/org/archive/crawler/Heritrix.java
+++ b/engine/src/main/java/org/archive/crawler/Heritrix.java
@@ -314,6 +314,9 @@ public class Heritrix {
             useAdhocKeystore(startupOut); 
         }
 
+        // Restlet will reconfigure logging according to the system property
+        // so we must set it for -l to work properly
+        System.setProperty("java.util.logging.config.file", properties.getPath());
         if (properties.exists()) {
             FileInputStream finp = new FileInputStream(properties);
             LogManager.getLogManager().readConfiguration(finp);


### PR DESCRIPTION
by setting system property java.util.logging.config.file, because new
version restlet reconfigures logging after heritrix has already
configured it