### PR TITLE
Fix stream closed exception by not closing output stream

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/EditRepresentation.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EditRepresentation.java
@@ -109,7 +109,6 @@ public class EditRepresentation extends CharacterRepresentation {
         pw.println("</script>");
         pw.println("</body>");
         pw.println("</html>");
-        pw.close();
     }
 
     public FileRepresentation getFileRepresentation() {


### PR DESCRIPTION
ServerCall.writeResponseBody() flushes it after we return so it must
remain open.

Fixes #305