### PR TITLE
Fix stream closed exception for Paged view

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/PagedRepresentation.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/PagedRepresentation.java
@@ -144,7 +144,6 @@ public class PagedRepresentation extends CharacterRepresentation {
         pw.println("</pre>");
         
         emitControls(pw); 
-        pw.close();
     }
 
     /**


### PR DESCRIPTION
Related to #305 the stream closed exception is also showing up when clicking "more" to get the "Paged view" of the Job Log or Crawl Log for a job in the Heritrix web user interface. This commits a similar fix to what is seen in #306.