### PR TITLE
Exclude hbase-client's guava 12 transitive dependency

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -33,6 +33,11 @@
 					<groupId>jdk.tools</groupId>
 					<artifactId>jdk.tools</artifactId>
 				</exclusion>
+				<!-- prefer guava 17 from webarchive-commons over guava 12 from hbase-client -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Guava 12 from hbase-client is closer to the root of the dependency tree than guava 17 from webarchive-commons so Maven prefers it. But recent changes to heritrix-commons rely on classes in the newer version of Guava. So let's ensure webarchive-commons wins.

Hopefully this doesn't break the hbase module, I have no way of testing it.

Fixes #311