### PR TITLE
Add real crawlStatus in the crawlReport

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/CrawlSummaryReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/CrawlSummaryReport.java
@@ -35,7 +35,11 @@ public class CrawlSummaryReport extends Report {
     public void write(PrintWriter writer, StatisticsTracker stats) {
         CrawlStatSnapshot snapshot = stats.getLastSnapshot(); 
         writer.println("crawl name: " + stats.getCrawlController().getMetadata().getJobName());
-        writer.println("crawl status: " + stats.getCrawlController().getCrawlExitStatus().desc);
+        String crawlStatus = stats.getCrawlController().getCrawlExitStatus().desc;
+        if (stats.getCrawlController().isRunning() ) {
+        	crawlStatus = StringUtils.capitalize(stats.getCrawlController().getState().toString().toLowerCase()) + " - Active"; 
+        } 
+        writer.println("crawl status: " + crawlStatus);
         writer.println("duration: " +
                 ArchiveUtils.formatMillisecondsToConventional(stats.getCrawlElapsedTime()));
         writer.println();

--- a/engine/src/main/java/org/archive/crawler/reporting/CrawlSummaryReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/CrawlSummaryReport.java
@@ -23,6 +23,7 @@ import java.io.PrintWriter;
 
 import org.archive.crawler.util.CrawledBytesHistotable;
 import org.archive.util.ArchiveUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * The "Crawl Report", with summaries of overall crawl size.

--- a/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
@@ -881,11 +881,13 @@ public class StatisticsTracker
     protected File writeReportFile(Report report, boolean force) {
         File f = new File(getReportsDir().getFile(), report.getFilename());
         
-        if(f.exists() && !controller.isRunning() && controller.hasStarted() && !force) {
+        if(f.exists() && !controller.isRunning() && controller.hasStarted() && !force
+        	&& !(report instanceof CrawlSummaryReport)) {
             // controller already started and stopped 
             // and file exists
             // and force not requested
             // so, don't overwrite
+            // except for crawlReport
             logger.info("reusing report: " + f.getAbsolutePath());
             return f;
         }


### PR DESCRIPTION
During the crawl, we have "crawl status: Finished - Abnormal exit from crawling" in the crawlSummary report.
I have changed the crawlStatus to have the same info as the job main page:
- crawl status: Pausing - Active
- crawl status: Paused - Active
- crawl status: Running - Active
- crawl status: Empty - Active
- crawl status: Stopping - Active
when isRunning()=true.

The crawl summary report is always re generated to have the correct crawlStatus.