### PR TITLE
Fix match result is always false in MatchesListRegexDecideRule

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/MatchesListRegexDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/MatchesListRegexDecideRule.java
@@ -20,7 +20,6 @@ package org.archive.modules.deciderules;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.FutureTask;

--- a/modules/src/main/java/org/archive/modules/deciderules/MatchesListRegexDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/MatchesListRegexDecideRule.java
@@ -118,7 +118,7 @@ public class MatchesListRegexDecideRule extends PredicatedDecideRule {
                 FutureTask<Boolean> matchesFuture = new FutureTask<>(() -> p.matcher(interruptible).matches());
                 ForkJoinPool.commonPool().submit(matchesFuture);
                 try {
-                    matchesFuture.get(getTimeoutPerRegexSeconds(), TimeUnit.SECONDS);
+                    matches = matchesFuture.get(getTimeoutPerRegexSeconds(), TimeUnit.SECONDS);
                 } catch (TimeoutException e) {
                     matchesFuture.cancel(true);
                     logger.warning("Timed out after " + getTimeoutPerRegexSeconds() + " seconds waiting for '" + p + "' to match.");

--- a/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
@@ -32,4 +32,21 @@ public class MatchesListRegexDecideRuleTest extends TestCase {
         final DecideResult decideResult = rule.decisionFor(curi);
         assertEquals("Expected NONE not " + decideResult , DecideResult.NONE, decideResult);
     }
+
+    public void testEvaluateInTime() throws URIException {
+        final String regex = "http://www\\.netarkivet\\.dk/x+";
+        String seed = "http://www.netarkivet.dk/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        MatchesListRegexDecideRule rule = new MatchesListRegexDecideRule();
+        List<Pattern> patternList = new ArrayList<>();
+        patternList.add(Pattern.compile(regex));
+        rule.setRegexList(patternList);
+        rule.setEnabled(true);
+        rule.setListLogicalOr(true);
+        rule.setDecision(DecideResult.REJECT);
+        rule.setTimeoutPerRegexSeconds(2);
+        final CrawlURI curi = new CrawlURI(UURIFactory.getInstance(seed));
+        final DecideResult decideResult = rule.decisionFor(curi);
+        assertEquals("Expected REJECT not " + decideResult , DecideResult.REJECT, decideResult);
+    }
+
 }

--- a/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
@@ -1,6 +1,5 @@
 package org.archive.modules.deciderules;
 
-import com.google.common.annotations.VisibleForTesting;
 import junit.framework.TestCase;
 import org.apache.commons.httpclient.URIException;
 import org.archive.modules.CrawlURI;


### PR DESCRIPTION
It looks like #290 introduced a bug that `MatchesListRegexDecideRule#evaluate()` always returns false because future result is discarded.
This fix respects the returned future value.
Thanks,