### PR TITLE
Warc convention for storing ftp responses has been to use a WARC reso…

### DIFF
--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -32,7 +32,7 @@ public class FtpResponseRecordBuilder extends BaseWARCRecordBuilder {
             recordInfo.addExtraHeader(HEADER_KEY_CONCURRENT_TO,
                     '<' + concurrentTo.toString() + '>');
         }
-        recordInfo.setType(WARCRecordType.response);
+        recordInfo.setType(WARCRecordType.resource);
         recordInfo.setUrl(curi.toString());
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setMimetype(curi.getContentType());


### PR DESCRIPTION
…urce record and not a response record. Changing to be consisten with the default WARCWriterProcessor