### PR TITLE
Strip quotes from URL value.

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -986,7 +986,8 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
         } else if ("refresh".equalsIgnoreCase(httpEquiv) && content != null) {
             int urlIndex = content.indexOf("=") + 1;
             if(urlIndex>0) {
-                String refreshUri = content.substring(urlIndex);
+                // strip any quotes ("') characters from the URL value.
+                String refreshUri = TextUtils.replaceAll("[\"']", content.substring(urlIndex), "");
                 try {
                     int max = getExtractorParameters().getMaxOutlinks();
                     addRelativeToBase(curi, max, refreshUri, 


### PR DESCRIPTION
This change improves parsing of meta element URL values. It was recently merged into the AIT version (https://github.com/internetarchive/heritrix3/pull/349) and has been running successfully in production.