### PR TITLE
Upgrade to Spring 5.3.3

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -136,27 +136,22 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<version>3.0.5.RELEASE</version>
+			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>3.0.5.RELEASE</version>
+			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>3.0.5.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-asm</artifactId>
-			<version>3.0.5.RELEASE</version>
+			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-expression</artifactId>
-			<version>3.0.5.RELEASE</version>
+			<version>${spring.version}</version>
 		</dependency>
 
 		<dependency>
@@ -253,5 +248,6 @@
 	</build>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spring.version>5.3.3</spring.version>
 	</properties>
 </project>


### PR DESCRIPTION
Spring 3.0.5 is 10 years old now and is incompatible with classes using Java 9+ bytecode and even with Java 8 classes that use lambdas (see #337). We remove spring-asm as it is now part of spring-core module.

This introduces some deprecation warnings as Spring now recommends constructor injection instead of the [`@Required`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Required.html) annotation. I believe that would require a breaking change in the job config format (`<constructor-arg>` instead of `<property>`) though so I'm leaving the deprecated annotations in place for now.

@kris-sigur and I have both tested Heritrix against Spring 5.3.3 and neither of us encountered any compatibility issues.

Closes #254. Closes #255. Fixes #337.