### PR TITLE
Handle empty Optionals when browsing beans

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -91,7 +92,10 @@ public abstract class JobRelatedResource extends BaseResource {
      */
     protected void addPresentableNestedNames(Collection<Object> namedBeans, Object obj,
             Set<Object> alreadyWritten) {
-        if (obj == null || alreadyWritten.contains(obj)
+        if (obj == null
+                || (obj instanceof Optional && !((Optional<?>) obj).isPresent())
+                || obj instanceof Class
+                || alreadyWritten.contains(obj)
                 || obj.getClass().getName().startsWith("org.springframework.")) {
             return;
         }


### PR DESCRIPTION
addPresentableNestedNames() recursively walks the properties of beans
calling getters. Likely unintentionally this includes calling getClass()
and recursing into the reflection API. When running on JDK 11 the
reflection API has some methods (e.g. in java.lang.module) that return
instances of Optional. With the newer version of Spring's
BeanWrapperImpl encounters an Optional it attempts to unwrap it and
throws IllegalArgumentException if it is empty.

Let's fix this in two ways. Firstly let's avoid walking the reflection
API entirely as its irrelevant for the purposes of bean browsing by
not inspecting the properties of instances of java.lang.Class.

Secondly in case any Heritrix beans start using Optional in future lets
also handle the empty case by also not inspecting, the same as we do for
null.

Fixes #376
Reported-By: Lauren Ko <lauren.ko@unt.edu>
CC: @ldko