### PR TITLE
Avoid error when bean properties have no url available

### DIFF
--- a/engine/src/main/resources/org/archive/crawler/restlet/Beans.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Beans.ftl
@@ -125,7 +125,7 @@
 <#macro beanTemplate bean>
 <#if bean.field?? && (bean.field?length>0)>
 	<th>
-		<b><#if bean.field?contains("#")>${bean.field}<#else><a href='${bean.url}'>${bean.field}</a></#if>:</b>
+		<b><#if bean.field?contains("#") || !bean.url??>${bean.field}<#else><a href='${bean.url}'>${bean.field}</a></#if>:</b>
 	</th>
 </#if>
 <td>


### PR DESCRIPTION
This is to fix #378 . If there is no `bean.url` it just gives the field value without trying to create a link.

We may want to look more deeply at a lower level regarding why  `BeanWrapperImpl` now makes pattern() and flags() properties on the bean for `java.util.regex.Pattern` and what else is affected. 