### PR TITLE
Update to latest version of dnsjava, for #344

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -85,9 +85,9 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.dnsjava</groupId>
+			<groupId>dnsjava</groupId>
 			<artifactId>dnsjava</artifactId>
-			<version>2.0.3</version>
+			<version>3.3.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<!--

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>maven-restlet</id>
-			<url>https://maven.restlet.org</url>
+			<url>https://maven.restlet.com</url>
 		</repository>
 	</repositories>
 

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -239,7 +239,7 @@ public class FetchDNS extends Processor {
         try {
         	recordDNS(curi, rrecordSet);
             curi.setFetchStatus(S_DNS_SUCCESS);
-            curi.setDNSServerIPLabel(ResolverConfig.getCurrentConfig().server());
+            curi.setDNSServerIPLabel(ResolverConfig.getCurrentConfig().server().toString());
         } catch (IOException e) {
         	logger.log(Level.SEVERE, "Failed store of DNS Record for " +
         		curi.toString(), e);


### PR DESCRIPTION
This commit updates to version 3.3.1 of the dnsjava library.

Incidentally, the restlet.org certificate is currently invalid, so this
patch switched to maven.restlet.com.