### PR TITLE
Update dependencies 2021 05 26

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.1</version>
+			<version>3.2.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -30,17 +30,17 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.19.v20190610</version>
+			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>9.4.19.v20190610</version>
+			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-            <version>9.4.19.v20190610</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
@@ -48,12 +48,12 @@ public class StatisticsSelfTest extends SelfTestBase {
         StatisticsTracker stats = heritrix.getEngine().getJob("selftest-job").getCrawlController().getStatisticsTracker();
         assertNotNull(stats);
         assertEquals(13, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(7501, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
+        assertEquals(8005, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
 
         assertEquals(3, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(2133, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(2217, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(10, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(5368, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(5788, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(0, (long) stats.getServerCache().getHostFor("dns:").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
     }
 
@@ -66,17 +66,17 @@ public class StatisticsSelfTest extends SelfTestBase {
         sourceStats = stats.getSourceStats("http://127.0.0.1:7777/a.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(2133l, (long) sourceStats.get("novel"));
+        assertEquals(2217l, (long) sourceStats.get("novel"));
         assertEquals(3l, (long) sourceStats.get("novelCount"));
-        assertEquals(2133l, (long) sourceStats.get("warcNovelContentBytes"));
+        assertEquals(2217l, (long) sourceStats.get("warcNovelContentBytes"));
         assertEquals(3l, (long) sourceStats.get("warcNovelUrls"));
 
         sourceStats = stats.getSourceStats("http://localhost:7777/b.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(5368l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
+        assertEquals(5788l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
         assertEquals(11l, (long) sourceStats.get("novelCount"));
-        assertEquals(5368l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
+        assertEquals(5788l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
         assertEquals(10l, (long) sourceStats.get("warcNovelUrls"));
     }
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -37,12 +37,12 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.19.v20190610</version>
+			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-security</artifactId>
-			<version>9.4.19.v20190610</version>
+			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.littleshoot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.13</version>
+				<version>4.13.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -411,6 +411,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<build.timestamp>${maven.build.timestamp}</build.timestamp>
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
+		<jetty.version>9.4.37.v20210219</jetty.version>
 	</properties>
     <profiles>
         <profile>


### PR DESCRIPTION
This set of changes updates dependencies with known security issues.

Updating Jetty also means the tests need to be changed, as Jetty has changed how it formats responses.  I have checked the WARCs from the relevant test, and the differences are like:

```
< Content-Length: 327
< Server: Jetty(9.4.19.v20190610)
---
> Content-Length: 448
> Server: Jetty(9.4.37.v20210219)
733,735c748,755
< <body><h2>HTTP ERROR 404</h2>
< <p>Problem accessing /link2.html. Reason:
< <pre>    Not Found</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.4.19.v20190610</a><hr/>
---
> <body><h2>HTTP ERROR 404 Not Found</h2>
> <table>
> <tr><th>URI:</th><td>/link2.html</td></tr>
> <tr><th>STATUS:</th><td>404</td></tr>
> <tr><th>MESSAGE:</th><td>Not Found</td></tr>
> <tr><th>SERVLET:</th><td>-</td></tr>
> </table>
> <hr><a href="https://eclipse.org/jetty">Powered by Jetty:// 9.4.37.v20210219</a><hr/>
```

As these changes seem acceptable, I have updated the tests so the expected values match those being generated.