### PR TITLE
Annotate nested sitemap links as sitemaps

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
@@ -160,9 +160,15 @@ public class ExtractorSitemap extends ContentExtractor {
 
             // Add the URI:
         	// Adding 'regular' URL listed in the sitemap
-            addRelativeToBase(curi, max, newUri.toString(),
+            CrawlURI newCuri = addRelativeToBase(curi, max, newUri.toString(),
                     LinkContext.MANIFEST_MISC, Hop.MANIFEST);
 
+            if (isSitemap) {
+                // Annotate as a Site Map:
+                newCuri.getAnnotations().add(
+                        ExtractorRobotsTxt.ANNOTATION_IS_SITEMAP);
+            }
+            
             // And log about it:
             LOGGER.fine("Found " + newUri + " from " + curi + " Dated "
                     + lastModified + " and with isSitemap = " + isSitemap);


### PR DESCRIPTION
Currently, sitemaps discovered in extractorRobotsTxt are annotated as such but nested sitemaps are not. This works as long as the site serves the sitemaps as either "text/xml" or "application/xml" but there is no reason to rely on this for URLs we already know are sitemaps. This way we avoid missing nested sitemaps with, e.g. mimetype application/xhtml+xml (real world example).

This PR just adds that annotation. We'll still do content sniffing in case we find sitemaps via other paths.

@anjackson 