### PR TITLE
Switch to properties that enforce Java 8 compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,16 +382,6 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-                               <version>3.3</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -412,6 +402,9 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<jetty.version>9.4.37.v20210219</jetty.version>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.release>8</maven.compiler.release>
 	</properties>
     <profiles>
         <profile>


### PR DESCRIPTION
This change uses the newer `release` switch to ensure that the artefacts are built to be compatible with Java 8 at runtime.