### PR TITLE
Remove unnecessary fiddling with VIA path in ExtractorRobotsTxt

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
@@ -54,18 +54,6 @@ public class ExtractorRobotsTxt extends ContentExtractor {
     @Override
     protected boolean innerExtract(CrawlURI curi) {
         try {
-
-            // Clone the CrawlURI and change hop path and avoid queueing
-            // sitemaps as prerequisites (i.e. strip P from hop path).
-            CrawlURI curiClone = new CrawlURI(curi.getUURI(),
-                    curi.getPathFromSeed().replace("P", ""), curi.getVia(),
-                    curi.getViaContext());
-
-            // Also copy the source over:
-            if (curi.getSourceTag() != null) {
-                curiClone.setSourceTag(curi.getSourceTag());
-            }
-            
             // Parse the robots for the sitemaps.
             List<String> links = parseRobotsTxt(
                     curi.getRecorder()
@@ -84,7 +72,7 @@ public class ExtractorRobotsTxt extends ContentExtractor {
 
                     // Add links but using the cloned CrawlURI as the crawl
                     // context.
-                    CrawlURI newCuri = addRelativeToBase(curiClone, max, link,
+                    CrawlURI newCuri = addRelativeToBase(curi, max, link,
                             LinkContext.MANIFEST_MISC, Hop.MANIFEST);
 
                     // Annotate as a Site Map:
@@ -94,11 +82,6 @@ public class ExtractorRobotsTxt extends ContentExtractor {
                 } catch (URIException e) {
                     logUriError(e, curi.getUURI(), link);
                 }
-            }
-
-            // Patch outlinks back into original curi:
-            for (CrawlURI outlink : curiClone.getOutLinks()) {
-                curi.getOutLinks().add(outlink);
             }
 
             // Return number of links discovered:


### PR DESCRIPTION
When extracting sitemap URIs from robots.txt files, effort is made to clip the "P" (referring to the robots.txt being determined as a prerequisite) from the VIA path. Consequently, the sitemap URIs discovered from seeds will just start with "M" as if they are derived from a seed, but still with the robots.txt as parent in the crawl log.

The explanation for this behavior given in the code comments may be based on a misunderstanding or faulty code elsewhere. The VIA path is not used to determine if a crawlUri is a prerequisite (there is a field on crawlUri dedicated for that) and even if some module is sniffing the VIA path, they should only consider the last character. If they are looking at any other character it is a bug in that module and needs to be fixed there.

This PR removes this logic and handles the extracted sitemap URI normally, with the robots.txt as parent. I've verified that (running with the usual default configuration at least) sitemaps are not treated as prerequisites and are scheduled like any other discovered URI (i.e. same as L hops).

@anjackson 