### PR TITLE
Graceful UI shutdown

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
@@ -180,9 +180,17 @@ public class EngineResource extends BaseResource {
                     cancel = true; 
                 }
             }
-            if(!cancel) {
-                System.exit(0); 
-            }
+			if (!cancel) {
+				Flash.addFlash(getResponse(), "Shutting down ... bye");
+				new Thread(() -> {
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					System.exit(0);
+				}).start();
+			}
         } else if ("gc".equals(action)) {
             System.gc();
         }


### PR DESCRIPTION
Current behavior or selecting shutdown via UI is to terminate the java process _before_ returning an HTTP response to the UI.

The consequence of this is that if you shutdown Heritrix, start it back up again and immediately refresh your browser you will get the browser warning about reposting content. If you click to resend you shut down Heritrix again. At best you have to click back to get back to the main screen.

This seems unnecessary and this PR modifies the shutdown code to fork a thread that waits 1 second before terminating the java VM. That gives the UI code enough time to respond with a forward that is safe to reload.