### PR TITLE
Fix and document the -r option which runs a named job on startup

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
@@ -408,7 +408,7 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
      * (Note the crawl may have been configured to start in a 'paused'
      * state.) 
      */
-    public synchronized void launch() {
+    public void launch() {
         if (isProfile()) {
             throw new IllegalArgumentException("Can't launch profile" + this);
         }
@@ -449,9 +449,8 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
         getJobLogger().log(Level.INFO,"Job launched");
         scanJobLog();
         launcher.start();
-        // look busy (and give startContext/crawlStart a chance)
         try {
-            Thread.sleep(1500);
+            launcher.join();
         } catch (InterruptedException e) {
             // do nothing
         }


### PR DESCRIPTION
I noticed there was a non-functional and undocumented -r command-line option which automatically runs a given job when Heritrix starts. I suspect this was never finished due to the bug that was fixed in commit 643f16d where launch() returns before the job has been launched.

This option seems like it would be very useful so you could run a job from cron or another scheduling program without having to use the REST API to start it. Therefore I've enabled it and extended it so it also unpauses, waits for the crawl to finish and then exits.

**Merge note:** This PR shares commit "Remove arbitrary 1.5 second sleep() when launching jobs" with #405. I've included it in both so that the two PRs can be merged independently. Assuming that git will do the right thing and notice they're same commit anyway... :crossed_fingers: