### PR TITLE
Fix WARC-IP-Address and use a common server-ip CrawlURI attribute for all protocols

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -62,6 +62,12 @@
 			<version>1.6.6</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.ftpserver</groupId>
+			<artifactId>ftpserver-core</artifactId>
+			<version>1.1.1</version>
+			<scope>test</scope>
+		</dependency>
     <dependency>
       <groupId>com.github.crawler-commons</groupId>
       <artifactId>crawler-commons</artifactId>

--- a/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
+++ b/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
@@ -53,6 +53,11 @@ public interface CoreAttributeConstants {
     public static final String A_FETCH_BEGAN_TIME= "fetch-began-time";
     public static String A_FETCH_COMPLETED_TIME = "fetch-completed-time";
 
+    /**
+     * IP address of the server the resource was fetched from.
+     */
+    public static final String A_SERVER_IP = "server-ip";
+
     public static String A_RUNTIME_EXCEPTION = "runtime-exception";
     public static String A_NONFATAL_ERRORS = "nonfatal-errors";
 

--- a/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
+++ b/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
@@ -118,8 +118,6 @@ public interface CoreAttributeConstants {
     public static final String A_FTP_CONTROL_CONVERSATION = "ftp-control-conversation";
     public static final String A_FTP_FETCH_STATUS = "ftp-fetch-status";
 
-    public static final String A_WHOIS_SERVER_IP = "whois-server-ip";
-    
     public static final String A_HTTP_RESPONSE_HEADERS = "http-response-headers";
     
     public static final String A_HTTP_AUTH_CHALLENGES = "http-auth-challenges";

--- a/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
+++ b/modules/src/main/java/org/archive/modules/CoreAttributeConstants.java
@@ -49,7 +49,6 @@ public interface CoreAttributeConstants {
 
     public static String A_RRECORD_SET_LABEL = "dns-records";
     public static String A_DNS_FETCH_TIME    = "dns-fetch-time";
-    public static String A_DNS_SERVER_IP_LABEL = "dns-server-ip";
     public static final String A_FETCH_BEGAN_TIME= "fetch-began-time";
     public static String A_FETCH_COMPLETED_TIME = "fetch-completed-time";
 

--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -19,62 +19,6 @@
  
 package org.archive.modules;
 
-import static org.archive.modules.CoreAttributeConstants.A_ANNOTATIONS;
-import static org.archive.modules.CoreAttributeConstants.A_CREDENTIALS_KEY;
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
-import static org.archive.modules.CoreAttributeConstants.A_FETCH_COMPLETED_TIME;
-import static org.archive.modules.CoreAttributeConstants.A_FORCE_RETIRE;
-import static org.archive.modules.CoreAttributeConstants.A_HERITABLE_KEYS;
-import static org.archive.modules.CoreAttributeConstants.A_HTML_BASE;
-import static org.archive.modules.CoreAttributeConstants.A_HTTP_AUTH_CHALLENGES;
-import static org.archive.modules.CoreAttributeConstants.A_HTTP_RESPONSE_HEADERS;
-import static org.archive.modules.CoreAttributeConstants.A_NONFATAL_ERRORS;
-import static org.archive.modules.CoreAttributeConstants.A_PREREQUISITE_URI;
-import static org.archive.modules.CoreAttributeConstants.A_SOURCE_TAG;
-import static org.archive.modules.SchedulingConstants.NORMAL;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_BLOCKED_BY_CUSTOM_PROCESSOR;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_BLOCKED_BY_USER;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_CONNECT_FAILED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_CONNECT_LOST;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DEEMED_CHAFF;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DEFERRED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DELETED_BY_USER;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DNS_SUCCESS;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DOMAIN_PREREQUISITE_FAILURE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_DOMAIN_UNRESOLVABLE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_OTHER_PREREQUISITE_FAILURE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_OUT_OF_SCOPE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_PREREQUISITE_UNSCHEDULABLE_FAILURE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_PROCESSING_THREAD_KILLED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_ROBOTS_PRECLUDED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_ROBOTS_PREREQUISITE_FAILURE;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_RUNTIME_EXCEPTION;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_SERIOUS_ERROR;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_TIMEOUT;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_TOO_MANY_EMBED_HOPS;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_TOO_MANY_LINK_HOPS;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_TOO_MANY_RETRIES;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_UNATTEMPTED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_UNFETCHABLE_URI;
-import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_CONTENT_DIGEST_HISTORY;
-
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.archive.bdb.AutoKryo;
@@ -94,6 +38,16 @@ import org.archive.util.ReportUtils;
 import org.archive.util.Reporter;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.archive.modules.CoreAttributeConstants.*;
+import static org.archive.modules.SchedulingConstants.NORMAL;
+import static org.archive.modules.fetcher.FetchStatusCodes.*;
+import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_CONTENT_DIGEST_HISTORY;
 
 
 /**
@@ -1156,6 +1110,13 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
         }
     }
 
+    /**
+     * Returns the IP address the request was fetched against or null if unavailable.
+     */
+    public String getServerIP() {
+        return (String) data.get(A_SERVER_IP);
+    }
+
     public long getFetchBeginTime() {
         if (containsDataKey(CoreAttributeConstants.A_FETCH_BEGAN_TIME)) {
             return (Long)getData().get(CoreAttributeConstants.A_FETCH_BEGAN_TIME);
@@ -1202,6 +1163,10 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
 
     public void setDNSServerIPLabel(String label) {
         getData().put(A_DNS_SERVER_IP_LABEL, label);
+    }
+
+    public void setServerIP(String serverIP) {
+        getData().put(A_SERVER_IP, serverIP);
     }
 
     public void setError(String msg) {

--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -1099,21 +1099,12 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
             return null;
         }
     }
-    
-
-
-    public String getDNSServerIPLabel() {
-        if (data == null) {
-            return null;
-        } else {
-            return (String)data.get(A_DNS_SERVER_IP_LABEL);
-        }
-    }
 
     /**
      * Returns the IP address the request was fetched against or null if unavailable.
      */
     public String getServerIP() {
+        if (data == null) return null;
         return (String) data.get(A_SERVER_IP);
     }
 
@@ -1158,11 +1149,6 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
         // FIXME: Previous code automatically added annotation when "localized error"
         // was added, override collection to implement that?
         return list;
-    }
-
-
-    public void setDNSServerIPLabel(String label) {
-        getData().put(A_DNS_SERVER_IP_LABEL, label);
     }
 
     public void setServerIP(String serverIP) {

--- a/modules/src/main/java/org/archive/modules/deciderules/IpAddressSetDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/IpAddressSetDecideRule.java
@@ -1,7 +1,5 @@
 package org.archive.modules.deciderules;
 
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
-
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Set;
@@ -78,13 +76,11 @@ public class IpAddressSetDecideRule extends PredicatedDecideRule {
      * @return String of IP address or null if unable to determine IP address
      */
     protected String getHostAddress(CrawlURI curi) {
-        // special handling for DNS URIs: want address of DNS server
-        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
-            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        // if possible use the exact IP the fetcher stashed in curi
+        if (curi.getServerIP() != null) {
+            return curi.getServerIP();
         }
-        // otherwise, host referenced in URI
-        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
-        // use that rather than inferred by CrawlHost lookup 
+        // otherwise, consult the cache
         String addr = null;
         try {
 	        CrawlHost crlh = getServerCache().getHostFor(curi.getUURI());

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -239,7 +239,7 @@ public class FetchDNS extends Processor {
         try {
         	recordDNS(curi, rrecordSet);
             curi.setFetchStatus(S_DNS_SUCCESS);
-            curi.setDNSServerIPLabel(ResolverConfig.getCurrentConfig().server().toString());
+            curi.setServerIP(ResolverConfig.getCurrentConfig().server().getAddress().getHostAddress());
         } catch (IOException e) {
         	logger.log(Level.SEVERE, "Failed store of DNS Record for " +
         		curi.toString(), e);

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
@@ -435,6 +435,8 @@ public class FetchFTP extends Processor  {
                 // clear
                 recorder.getRecordedInput().setDigest((MessageDigest)null);
             }
+
+            curi.setServerIP(socket.getInetAddress().getHostAddress());
                     
             try {
                 saveToRecorder(curi, socket, recorder);

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -600,7 +600,7 @@ public class FetchHTTPRequest {
                         DEFAULT_BUFSIZE, chardecoder, charencoder,
                         cconfig.getMessageConstraints(), null, null,
                         DefaultHttpRequestWriterFactory.INSTANCE,
-                        DefaultHttpResponseParserFactory.INSTANCE);
+                        DefaultHttpResponseParserFactory.INSTANCE, curi);
             }
         };
         BasicHttpClientConnectionManager connMan = new BasicHttpClientConnectionManager(
@@ -618,6 +618,7 @@ public class FetchHTTPRequest {
 
         private static final AtomicLong COUNTER = new AtomicLong();
         private String id;
+        private final CrawlURI curi;
 
         public RecordingHttpClientConnection(
                 final int buffersize,
@@ -628,15 +629,17 @@ public class FetchHTTPRequest {
                 final ContentLengthStrategy incomingContentStrategy,
                 final ContentLengthStrategy outgoingContentStrategy,
                 final HttpMessageWriterFactory<HttpRequest> requestWriterFactory,
-                final HttpMessageParserFactory<HttpResponse> responseParserFactory) {
+                final HttpMessageParserFactory<HttpResponse> responseParserFactory, CrawlURI curi) {
             super(buffersize, fragmentSizeHint, chardecoder, charencoder,
                     constraints, incomingContentStrategy, outgoingContentStrategy,
                     requestWriterFactory, responseParserFactory);
             id = "recording-http-connection-" + Long.toString(COUNTER.getAndIncrement());
+            this.curi = curi;
         }
 
         @Override
         protected InputStream getSocketInputStream(final Socket socket) throws IOException {
+            curi.setServerIP(socket.getInetAddress().getHostAddress());
             Recorder recorder = Recorder.getHttpRecorder();
             if (recorder != null) {   // XXX || (isSecure() && isProxied())) {
                 return recorder.inputWrap(super.getSocketInputStream(socket));

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchWhois.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchWhois.java
@@ -334,10 +334,9 @@ public class FetchWhois extends Processor implements CoreAttributeConstants,
             }
 
             client.setSoTimeout(getSoTimeoutMs()); // must be after connect()
-            
-            curi.getData().put(CoreAttributeConstants.A_WHOIS_SERVER_IP, 
-                    client.getRemoteAddress().getHostAddress());
-            
+
+            curi.setServerIP(client.getRemoteAddress().getHostAddress());
+
             recorder.inputWrap(client.getInputStream(whoisQuery));
 
             // look for info about whois server in the response

--- a/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/BaseWARCRecordBuilder.java
@@ -1,28 +1,10 @@
 package org.archive.modules.warc;
 
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
-
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
-import org.archive.modules.CrawlURI;
-import org.archive.modules.net.CrawlHost;
-import org.archive.modules.net.ServerCache;
-import org.springframework.beans.factory.annotation.Autowired;
-
 public abstract class BaseWARCRecordBuilder implements WARCRecordBuilder {
-
-    transient protected ServerCache serverCache;
-    public ServerCache getServerCache() {
-        return this.serverCache;
-    }
-    @Autowired
-    public void setServerCache(ServerCache serverCache) {
-        this.serverCache = serverCache;
-    }
-    
     public static URI generateRecordID() {
         try {
             return new URI("urn:uuid:" + UUID.randomUUID());
@@ -30,37 +12,4 @@ public abstract class BaseWARCRecordBuilder implements WARCRecordBuilder {
             throw new RuntimeException(e); // impossible 
         }
     }
-    
-    /**
-     * Return IP address of given URI suitable for recording (as in a
-     * classic ARC 5-field header line).
-     * 
-     * @param curi CrawlURI
-     * @return String of IP address
-     */
-    protected String getHostAddress(CrawlURI curi) {
-        // special handling for DNS URIs: want address of DNS server
-        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
-            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
-        }
-        // otherwise, host referenced in URI
-        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
-        // use that rather than inferred by CrawlHost lookup 
-        CrawlHost h = getServerCache().getHostFor(curi.getUURI());
-        if (h == null) {
-            throw new NullPointerException("Crawlhost is null for " +
-                curi + " " + curi.getVia());
-        }
-        InetAddress a = h.getIP();
-        if (a == null) {
-            throw new NullPointerException("Address is null for " +
-                curi + " " + curi.getVia() + ". Address " +
-                ((h.getIpFetched() == CrawlHost.IP_NEVER_LOOKED_UP)?
-                     "was never looked up.":
-                     (System.currentTimeMillis() - h.getIpFetched()) +
-                         " ms ago."));
-        }
-        return h.getIP().getHostAddress();
-    }
-
 }

--- a/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
@@ -2,7 +2,6 @@ package org.archive.modules.warc;
 
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
 
 import java.io.IOException;
 import java.net.URI;
@@ -38,10 +37,9 @@ public class DnsResponseRecordBuilder extends BaseWARCRecordBuilder {
         
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
-        
-        String ip = (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
-        if (ip != null && ip.length() > 0) {
-            recordInfo.addExtraHeader(HEADER_KEY_IP, ip);
+
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
         
         ReplayInputStream ris =

--- a/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
@@ -13,7 +13,6 @@ import org.archive.format.warc.WARCConstants.WARCRecordType;
 import org.archive.io.warc.WARCRecordInfo;
 import org.archive.modules.CrawlURI;
 import org.archive.util.ArchiveUtils;
-import org.archive.util.anvl.ANVLRecord;
 
 public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
 
@@ -28,8 +27,6 @@ public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
                 ArchiveUtils.getLog14Date(curi.getFetchBeginTime());
         String controlConversation =
                 curi.getData().get(A_FTP_CONTROL_CONVERSATION).toString();
-        ANVLRecord headers = new ANVLRecord();
-        headers.addLabelValue(HEADER_KEY_IP, getHostAddress(curi));
 
         WARCRecordInfo recordInfo = new WARCRecordInfo();
         recordInfo.setRecordId(generateRecordID());
@@ -40,9 +37,12 @@ public class FtpControlConversationRecordBuilder extends BaseWARCRecordBuilder {
         recordInfo.setCreate14DigitDate(timestamp);
         recordInfo.setUrl(curi.toString());
         recordInfo.setMimetype(FTP_CONTROL_CONVERSATION_MIMETYPE);
-        recordInfo.setExtraHeaders(headers);
         recordInfo.setEnforceLength(true);
         recordInfo.setType(WARCRecordType.metadata);
+
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
+        }
         
         byte[] b = controlConversation.getBytes("UTF-8");
         

--- a/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
@@ -2,7 +2,6 @@ package org.archive.modules.warc;
 
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
 import static org.archive.format.warc.WARCConstants.HEADER_KEY_IP;
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,12 +38,11 @@ public class FtpResponseRecordBuilder extends BaseWARCRecordBuilder {
         
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
-        
-        String ip = (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
-        if (ip != null && ip.length() > 0) {
-            recordInfo.addExtraHeader(HEADER_KEY_IP, ip);
+
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
-        
+
         ReplayInputStream ris =
             curi.getRecorder().getRecordedInput().getReplayInputStream();
         recordInfo.setContentStream(ris);

--- a/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
@@ -1,12 +1,6 @@
 package org.archive.modules.warc;
 
-import static org.archive.format.warc.WARCConstants.HEADER_KEY_CONCURRENT_TO;
-import static org.archive.format.warc.WARCConstants.HEADER_KEY_PAYLOAD_DIGEST;
-import static org.archive.format.warc.WARCConstants.HEADER_KEY_TRUNCATED;
-import static org.archive.format.warc.WARCConstants.HTTP_RESPONSE_MIMETYPE;
-import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_HEAD;
-import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_LENGTH;
-import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_TIME;
+import static org.archive.format.warc.WARCConstants.*;
 import static org.archive.modules.CoreAttributeConstants.A_WARC_RESPONSE_HEADERS;
 import static org.archive.modules.CoreAttributeConstants.HEADER_TRUNC;
 import static org.archive.modules.CoreAttributeConstants.LENGTH_TRUNC;
@@ -53,6 +47,10 @@ public class HttpResponseRecordBuilder extends BaseWARCRecordBuilder {
         if (curi.getContentDigest() != null) {
             recordInfo.addExtraHeader(HEADER_KEY_PAYLOAD_DIGEST,
                     curi.getContentDigestSchemeString());
+        }
+
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
 
         // Check for truncated annotation

--- a/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+++ b/modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
@@ -38,9 +38,8 @@ public class WhoisResponseRecordBuilder extends BaseWARCRecordBuilder {
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
         
-        Object whoisServerIP = curi.getData().get(CoreAttributeConstants.A_WHOIS_SERVER_IP);
-        if (whoisServerIP != null) {
-            recordInfo.addExtraHeader(HEADER_KEY_IP, whoisServerIP.toString());
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
         
         ReplayInputStream ris =

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
@@ -32,7 +32,6 @@ import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_
 import static org.archive.format.warc.WARCConstants.NAMED_FIELD_TRUNCATED_VALUE_TIME;
 import static org.archive.format.warc.WARCConstants.PROFILE_REVISIT_IDENTICAL_DIGEST;
 import static org.archive.format.warc.WARCConstants.TYPE;
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
 import static org.archive.modules.CoreAttributeConstants.A_FTP_CONTROL_CONVERSATION;
 import static org.archive.modules.CoreAttributeConstants.A_FTP_FETCH_STATUS;
 import static org.archive.modules.CoreAttributeConstants.A_SOURCE_TAG;
@@ -221,10 +220,9 @@ public class WARCWriterProcessor extends BaseWARCWriterProcessor implements WARC
         
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
-        
-        String ip = (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
-        if (ip != null && ip.length() > 0) {
-            recordInfo.addExtraHeader(HEADER_KEY_IP, ip);
+
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
         
         ReplayInputStream ris =

--- a/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WARCWriterProcessor.java
@@ -251,9 +251,8 @@ public class WARCWriterProcessor extends BaseWARCWriterProcessor implements WARC
         recordInfo.setContentLength(curi.getRecorder().getRecordedInput().getSize());
         recordInfo.setEnforceLength(true);
         
-        Object whoisServerIP = curi.getData().get(CoreAttributeConstants.A_WHOIS_SERVER_IP);
-        if (whoisServerIP != null) {
-            recordInfo.addExtraHeader(HEADER_KEY_IP, whoisServerIP.toString());
+        if (curi.getServerIP() != null) {
+            recordInfo.addExtraHeader(HEADER_KEY_IP, curi.getServerIP());
         }
         
         ReplayInputStream ris =

--- a/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
@@ -19,7 +19,6 @@
 
 package org.archive.modules.writer;
 
-import static org.archive.modules.CoreAttributeConstants.A_DNS_SERVER_IP_LABEL;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_DNS_SUCCESS;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_WHOIS_SUCCESS;
 import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_WRITE_TAG;
@@ -376,13 +375,11 @@ implements Lifecycle, Checkpointable, WriterPoolSettings {
      */
     @Deprecated
     protected String getHostAddress(CrawlURI curi) {
-        // special handling for DNS URIs: want address of DNS server
-        if (curi.getUURI().getScheme().toLowerCase().equals("dns")) {
-            return (String)curi.getData().get(A_DNS_SERVER_IP_LABEL);
+        // if possible use the exact IP the fetcher stashed in curi
+        if (curi.getServerIP() != null) {
+            return curi.getServerIP();
         }
-        // otherwise, host referenced in URI
-        // TODO:FIXME: have fetcher insert exact IP contacted into curi,
-        // use that rather than inferred by CrawlHost lookup 
+        // otherwise, consult the cache
         CrawlHost h = getServerCache().getHostFor(curi.getUURI());
         if (h == null) {
             throw new NullPointerException("Crawlhost is null for " +

--- a/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/WriterPoolProcessor.java
@@ -372,7 +372,7 @@ implements Lifecycle, Checkpointable, WriterPoolSettings {
      * @param curi CrawlURI
      * @return String of IP address
      * 
-     * @deprecated WARCRecordBuilder instances use {@link BaseWARCRecordBuilder#getHostAddress(CrawlURI)}
+     * @deprecated WARCRecordBuilder instances use {@link CrawlURI#getServerIP()}
      */
     @Deprecated
     protected String getHostAddress(CrawlURI curi) {

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchFTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchFTPTest.java
@@ -18,14 +18,66 @@
  */
 package org.archive.modules.fetcher;
 
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.listener.ListenerFactory;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+import org.archive.modules.CrawlURI;
 import org.archive.modules.ProcessorTestBase;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author pjack
  *
  */
 public class FetchFTPTest extends ProcessorTestBase {
+    public void test() throws Exception {
+        FetchFTP fetchFTP = new FetchFTP();
+        fetchFTP.start();
 
-    // TODO TESTME!
-    
+        Path tmpDir = Files.createTempDirectory("heritrix-ftp-test");
+        byte[] payload = "hello world".getBytes(UTF_8);
+        Files.write(tmpDir.resolve("test.txt"), payload);
+
+        int port = allocatePort();
+        FtpServer server = startFtpServer(port, tmpDir);
+        try {
+            CrawlURI curi = makeCrawlURI("ftp://127.0.0.1:" + port + "/test.txt");
+            fetchFTP.process(curi);
+            assertEquals(payload.length, curi.getContentSize());
+            assertEquals(226, curi.getFetchStatus());
+        } finally {
+            server.stop();
+            Files.delete(tmpDir.resolve("test.txt"));
+            Files.delete(tmpDir);
+            fetchFTP.stop();
+        }
+    }
+
+    private FtpServer startFtpServer(int port, Path root) throws FtpException {
+        ListenerFactory listenerFactory = new ListenerFactory();
+        listenerFactory.setPort(port);
+        FtpServerFactory serverFactory = new FtpServerFactory();
+        serverFactory.addListener("default", listenerFactory.createListener());
+        BaseUser user = new BaseUser();
+        user.setName("anonymous");
+        user.setHomeDirectory(root.toString());
+        serverFactory.getUserManager().save(user);
+        FtpServer server = serverFactory.createServer();
+        server.start();
+        return server;
+    }
+
+    private int allocatePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
 }

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchFTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchFTPTest.java
@@ -53,6 +53,7 @@ public class FetchFTPTest extends ProcessorTestBase {
             fetchFTP.process(curi);
             assertEquals(payload.length, curi.getContentSize());
             assertEquals(226, curi.getFetchStatus());
+            assertEquals("127.0.0.1", curi.getServerIP());
         } finally {
             server.stop();
             Files.delete(tmpDir.resolve("test.txt"));

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -130,7 +130,8 @@ public class FetchHTTPTests extends ProcessorTestBase {
         assertEquals(DEFAULT_PAYLOAD_STRING.length(), curi.getContentLength());
         assertEquals(curi.getContentSize(), curi.getRecordedSize());
         
-        // check various 
+        // check various
+        assertNotNull(curi.getServerIP());
         assertEquals("sha1:TQ5R6YVOZLTQENRIIENVGXHOPX3YCRNJ", curi.getContentDigestSchemeString());
         if (!exclusions.contains("contentType")) {
             assertEquals("text/plain;charset=US-ASCII", curi.getContentType());


### PR DESCRIPTION
This fixes #396 by introducing a new protocol-agnostic server-ip attribute on CrawlURI. The HTTP, FTP, WHOIS and DNS fetch processors now write to it and the appropriate WARC record builders copy from it to populate WARC-IP-Address.

The old A_DNS_SERVER_IP_LABEL and A_WHOIS_SERVER_IP attributes are fully replaced by the new generic one.

The ServerCache lookup is kept as a fallback in IpAddressSetDecideRule.getHostAddress(curi) since unlike the WARC writer it needs to know the IP address before the URI has been fetched.