### PR TITLE
Upgrade maven-assembly-plugin to 3.3.0 to fix file permissions

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -114,7 +114,9 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>
@@ -127,7 +129,7 @@
 						<id>job.assembly.package</id>
 						<phase>package</phase>
 						<goals>
-							<goal>attached</goal>
+							<goal>single</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -40,7 +40,9 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>
@@ -56,7 +58,7 @@
 						<id>job.assembly.package</id>
 						<phase>package</phase>
 						<goals>
-							<goal>attached</goal>
+							<goal>single</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
The old default version of maven-assembly-plugin generates packages
containing dangerous world writable files.

Before:

    $ zipinfo dist/target/heritrix-3.4.0-SNAPSHOT-dist.zip | grep heritrix[^/]*.jar
    -rwsrwsrwt  2.0 unx   677008 b- defN 21-Jul-19 15:12 heritrix-3.4.0-SNAPSHOT/lib/heritrix-engine-3.4.0-SNAPSHOT.jar
    -rwsrwsrwt  2.0 unx   446139 b- defN 21-Jul-19 15:12 heritrix-3.4.0-SNAPSHOT/lib/heritrix-modules-3.4.0-SNAPSHOT.jar
    -rwsrwsrwt  2.0 unx   148876 b- defN 21-Jul-19 15:12 heritrix-3.4.0-SNAPSHOT/lib/heritrix-commons-3.4.0-SNAPSHOT.jar

After:

    $ zipinfo dist/target/heritrix-3.4.0-SNAPSHOT-dist.zip | grep heritrix[^/]*.jar
    -rw-r--r--  2.0 unx   677008 b- defN 21-Jul-19 15:23 heritrix-3.4.0-SNAPSHOT/lib/heritrix-engine-3.4.0-SNAPSHOT.jar
    -rw-r--r--  2.0 unx   446139 b- defN 21-Jul-19 15:23 heritrix-3.4.0-SNAPSHOT/lib/heritrix-modules-3.4.0-SNAPSHOT.jar
    -rw-r--r--  2.0 unx   148877 b- defN 21-Jul-19 15:23 heritrix-3.4.0-SNAPSHOT/lib/heritrix-commons-3.4.0-SNAPSHOT.jar

Fixes #413