### PR TITLE
ExtractorChrome: reduce request duplication between browser and frontier

### DIFF
--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorChrome.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorChrome.java
@@ -19,14 +19,12 @@
 
 package org.archive.modules.extractor;
 
+import org.apache.commons.io.IOUtils;
 import org.archive.crawler.event.CrawlURIDispositionEvent;
 import org.archive.crawler.framework.CrawlController;
 import org.archive.crawler.framework.Frontier;
 import org.archive.modules.CrawlURI;
-import org.archive.net.chrome.ChromeClient;
-import org.archive.net.chrome.ChromeProcess;
-import org.archive.net.chrome.ChromeRequest;
-import org.archive.net.chrome.ChromeWindow;
+import org.archive.net.chrome.*;
 import org.archive.spring.KeyedProperties;
 import org.archive.util.Recorder;
 import org.json.JSONArray;
@@ -37,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -46,11 +45,11 @@ import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Collections.enumeration;
-import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.WARNING;
+import static java.util.logging.Level.*;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.archive.crawler.event.CrawlURIDispositionEvent.Disposition.FAILED;
 import static org.archive.crawler.event.CrawlURIDispositionEvent.Disposition.SUCCEEDED;
+import static org.archive.modules.CoreAttributeConstants.A_HTTP_RESPONSE_HEADERS;
 import static org.archive.modules.CrawlURI.FetchType.*;
 
 /**
@@ -115,6 +114,12 @@ public class ExtractorChrome extends ContentExtractor {
      */
     private boolean captureRequests = true;
 
+    /**
+     * The maximum size response body that can be replayed to the browser. Setting this to -1 will cause all requests by
+     * the browser to be made against the live web.
+     */
+    private int maxReplayLength = 100 * 1024 * 1024;
+
     private Semaphore openWindowsSemaphore = null;
     private ChromeProcess process = null;
     private ChromeClient client = null;
@@ -149,6 +154,8 @@ public class ExtractorChrome extends ContentExtractor {
 
     private void visit(CrawlURI curi) throws InterruptedException {
         try (ChromeWindow window = client.createWindow(windowWidth, windowHeight)) {
+            window.interceptRequests(request -> handleInterceptedRequest(curi, request));
+
             if (captureRequests) {
                 window.captureRequests(request -> handleCapturedRequest(curi, request));
             }
@@ -170,7 +177,48 @@ public class ExtractorChrome extends ContentExtractor {
         }
     }
 
+    private void handleInterceptedRequest(CrawlURI curi, InterceptedRequest interceptedRequest) {
+        ChromeRequest request = interceptedRequest.getRequest();
+        if (request.getMethod().equals("GET") && request.getUrl().equals(curi.getURI())) {
+            replayResponseToBrowser(curi, interceptedRequest);
+        } else {
+            interceptedRequest.continueNormally();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void replayResponseToBrowser(CrawlURI curi, InterceptedRequest interceptedRequest) {
+        // There seems to be no easy way to stream the body to the browser so we slurp it into
+        // memory with a size limit. The one way I can see to achieve streaming is to have Heritrix
+        // serve the request over its HTTP server and pass a Heritrix URL to Fetch.fulfillRequest
+        // instead of the body directly. We might need to do that if memory pressure becomes a
+        // problem but for now just keep it simple.
+
+        long bodyLength = curi.getRecorder().getResponseContentLength();
+        if (bodyLength > maxReplayLength) {
+            logger.log(FINE, "Page body too large to replay: {0}", curi.getURI());
+            interceptedRequest.continueNormally();
+            return;
+        }
+
+        byte[] body = new byte[(int)bodyLength];
+        try (InputStream stream = curi.getRecorder().getContentReplayInputStream()) {
+            IOUtils.readFully(stream, body);
+        } catch (IOException e) {
+            logger.log(WARNING, "Error reading back page body: " + curi.getURI(), e);
+            interceptedRequest.continueNormally();
+            return;
+        }
+
+        Map<String,String> headers = (Map<String, String>) curi.getData().get(A_HTTP_RESPONSE_HEADERS);
+        interceptedRequest.fulfill(curi.getFetchStatus(), headers.entrySet(), body);
+    }
+
     private void handleCapturedRequest(CrawlURI via, ChromeRequest request) {
+        if (request.isResponseFulfilledByInterception()) {
+            return;
+        }
+
         Recorder recorder = new Recorder(controller.getScratchDir().getFile(),
                 controller.getRecorderOutBufferBytes(),
                 controller.getRecorderInBufferBytes());

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorChrome.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorChrome.java
@@ -275,6 +275,12 @@ public class ExtractorChrome extends ContentExtractor {
             Frontier frontier = controller.getFrontier();
             curi.getOverlayNames(); // for side-effect of creating the overlayNames list
 
+            // inform the frontier we've already seen this uri so it won't schedule it
+            // we only do this for GETs so a POST doesn't prevent scheduling a GET of the same URI
+            if (request.getMethod().equals("GET")) {
+                frontier.considerIncluded(curi);
+            }
+
             KeyedProperties.loadOverridesFrom(curi);
             try {
                 // perform link extraction

--- a/contrib/src/main/java/org/archive/net/chrome/ChromeRequest.java
+++ b/contrib/src/main/java/org/archive/net/chrome/ChromeRequest.java
@@ -33,6 +33,7 @@ public class ChromeRequest {
     private JSONObject rawResponseHeaders;
     private String responseHeadersText;
     private final long beginTime = System.currentTimeMillis();
+    private boolean responseFulfilledByInterception;
 
     public ChromeRequest(ChromeWindow window, String id) {
         this.window = window;
@@ -150,5 +151,13 @@ public class ChromeRequest {
 
     void setRequestJson(JSONObject requestJson) {
         this.requestJson = requestJson;
+    }
+
+    void setResponseFulfilledByInterception(boolean responseFulfilledByInterception) {
+        this.responseFulfilledByInterception = responseFulfilledByInterception;
+    }
+
+    public boolean isResponseFulfilledByInterception() {
+        return responseFulfilledByInterception;
     }
 }

--- a/contrib/src/main/java/org/archive/net/chrome/InterceptedRequest.java
+++ b/contrib/src/main/java/org/archive/net/chrome/InterceptedRequest.java
@@ -1,0 +1,78 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.chrome;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Map;
+
+public class InterceptedRequest {
+    private final String id;
+    private final ChromeRequest request;
+    private final ChromeWindow window;
+    private boolean handled;
+
+    public InterceptedRequest(ChromeWindow window, String id, ChromeRequest request) {
+        this.window = window;
+        this.id = id;
+        this.request = request;
+    }
+
+    public ChromeRequest getRequest() {
+        return request;
+    }
+
+    public void fulfill(int status, Collection<Map.Entry<String,String>> headers, byte[] body) {
+        setHandled();
+        JSONArray headerArray = new JSONArray();
+        for (Map.Entry<String,String> entry : headers) {
+            JSONObject object = new JSONObject();
+            object.put("name", entry.getKey());
+            object.put("value", entry.getValue());
+            headerArray.put(object);
+        }
+        String encodedBody = Base64.getEncoder().encodeToString(body);
+        request.setResponseFulfilledByInterception(true);
+        window.call("Fetch.fulfillRequest",
+                "requestId", id,
+                "responseCode", status,
+                "responseHeaders", headerArray,
+                "body", encodedBody);
+    }
+
+    public void continueNormally() {
+        setHandled();
+        window.call("Fetch.continueRequest", "requestId", id);
+    }
+
+    public boolean isHandled() {
+        return handled;
+    }
+
+    private void setHandled() {
+        if (handled) {
+            throw new IllegalStateException("intercepted request already handled");
+        }
+        handled = true;
+    }
+}


### PR DESCRIPTION
1. By intercepting the browser's request and fulfilling it using the response previously recorded by FetchHTTP we avoid the browser sending a duplicate request for the main CrawlURI to the web server.

2. By running the link extractors on subresources captured by the browser we can now also tell the frontier not to bother scheduling them for classic fetching.

Note: The browser will still make duplicate requests for previously downloaded subresources. Solving this will require implementing resource caching or some way to read back previously written WARC records.