### PR TITLE
JDK 16 compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk: [8, 11]
+        jdk: [8, 11, 16]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -31,8 +31,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
-			<version>1.6.3</version>
+			<artifactId>groovy-jsr223</artifactId>
+			<version>3.0.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-templates</artifactId>
+			<version>3.0.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
JDK 16 defaults to --illegal-access=deny which breaks the way we were calling KeyTool via reflection and also breaks our old version of Groovy. So this change runs keytool as a subprocess on JDK 16 (fixes #417)  and upgrades Groovy (fixes #419).