### PR TITLE
Don't extract data URIs

### DIFF
--- a/commons/src/main/java/org/archive/util/UriUtils.java
+++ b/commons/src/main/java/org/archive/util/UriUtils.java
@@ -88,6 +88,13 @@ import org.archive.url.LaxURLCodec;
 public class UriUtils {
     private static final Logger LOGGER = Logger.getLogger(UriUtils.class.getName());
 
+    /**
+     * Returns true when when given a CharSequence that looks like a data URI.
+     */
+    public static boolean isDataUri(CharSequence candidate) {
+        return TextUtils.matches("(?i)\\s*data:.*", candidate);
+    }
+
     // naive likely-uri test: 
     //    no '<' or '>' 
     //    at least one '.' or '/';

--- a/commons/src/test/java/org/archive/util/UriUtilsTest.java
+++ b/commons/src/test/java/org/archive/util/UriUtilsTest.java
@@ -66,6 +66,17 @@ public class UriUtilsTest extends TestCase {
         "images/photo.jpg", 
         "../../images/photo.jpg" };
 
+    public void testIsDataUri() {
+        assertTrue(UriUtils.isDataUri("data:,hello"));
+        assertTrue(UriUtils.isDataUri("data:text/plain,hello"));
+        assertTrue(UriUtils.isDataUri("   data:,hello"));
+        assertTrue(UriUtils.isDataUri("   dAtA:,hello//  "));
+        assertFalse(UriUtils.isDataUri(""));
+        assertFalse(UriUtils.isDataUri(" http://example.org/"));
+        assertFalse(UriUtils.isDataUri("http://example.org/"));
+        assertFalse(UriUtils.isDataUri("\0\1\2\3garbage"));
+    }
+
     /** check that plausible relative image URIs return true with legacy tests */
     public void xestLegacySimpleImageRelatives() {
         legacyTryAll(urisRelativeImages, true);

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorPDFContent.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorPDFContent.java
@@ -137,14 +137,7 @@ public class ExtractorPDFContent extends ContentExtractor {
         }
 
         for (String uri: uris) {
-            try {
-                LinkContext lc = LinkContext.NAVLINK_MISC;
-                Hop hop = Hop.NAVLINK;
-                CrawlURI out = curi.createCrawlURI(uri, lc, hop);
-                curi.getOutLinks().add(out);
-            } catch (URIException e1) {
-                logUriError(e1, curi.getUURI(), uri);
-            }
+            addOutlink(curi, uri, LinkContext.NAVLINK_MISC, Hop.NAVLINK);
         }
         
         numberOfLinksExtracted.addAndGet(uris.size());

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -227,14 +227,7 @@ public class ExtractorYoutubeDL extends Extractor
             }
 
             for (String pageUrl: results.pageUrls) {
-                try {
-                    UURI dest = UURIFactory.getInstance(uri.getUURI(), pageUrl);
-                    CrawlURI link = uri.createCrawlURI(dest, LinkContext.NAVLINK_MISC,
-                            Hop.NAVLINK);
-                    uri.getOutLinks().add(link);
-                } catch (URIException e1) {
-                    logUriError(e1, uri.getUURI(), pageUrl);
-                }
+                addOutlink(uri, pageUrl, LinkContext.NAVLINK_MISC, Hop.NAVLINK);
             }
 
             if (results.videoUrls.size() > 0) {
@@ -246,26 +239,21 @@ public class ExtractorYoutubeDL extends Extractor
     }
 
     protected void addVideoOutlink(CrawlURI uri, String videoUrl, int playlistIndex, int nEntries) {
-        try {
-            UURI dest = UURIFactory.getInstance(uri.getUURI(), videoUrl);
-            CrawlURI link = uri.createCrawlURI(dest, LinkContext.EMBED_MISC,
-                    Hop.EMBED);
-
-            // annotation
-            String annotation = "youtube-dl:" + (playlistIndex + 1) + "/" + nEntries;
-            link.getAnnotations().add(annotation);
-
-            // save info unambiguously identifying containing page capture
-            link.getData().put(YDL_CONTAINING_PAGE_URI, uri.toString());
-            link.getData().put(YDL_CONTAINING_PAGE_TIMESTAMP,
-                    ArchiveUtils.get17DigitDate(uri.getFetchBeginTime()));
-            link.getData().put(YDL_CONTAINING_PAGE_DIGEST,
-                    uri.getContentDigestSchemeString());
-
-            uri.getOutLinks().add(link);
-        } catch (URIException e) {
-            logUriError(e, uri.getUURI(), videoUrl);
+        CrawlURI link = addOutlink(uri, videoUrl, LinkContext.EMBED_MISC, Hop.EMBED);
+        if (link == null) {
+            return;
         }
+
+        // annotation
+        String annotation = "youtube-dl:" + (playlistIndex + 1) + "/" + nEntries;
+        link.getAnnotations().add(annotation);
+
+        // save info unambiguously identifying containing page capture
+        link.getData().put(YDL_CONTAINING_PAGE_URI, uri.toString());
+        link.getData().put(YDL_CONTAINING_PAGE_TIMESTAMP,
+                ArchiveUtils.get17DigitDate(uri.getFetchBeginTime()));
+        link.getData().put(YDL_CONTAINING_PAGE_DIGEST,
+                uri.getContentDigestSchemeString());
     }
 
     protected String findYdlAnnotation(CrawlURI uri) {

--- a/modules/src/main/java/org/archive/modules/extractor/Extractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/Extractor.java
@@ -134,19 +134,18 @@ public abstract class Extractor extends Processor {
 
     /**
      * Create and add a 'Link' to the CrawlURI with given URI/context/hop-type
-     * @param curi
-     * @param uri
-     * @param context
-     * @param hop
+     * @return the new outlink or null if it was not valid
      */
-    protected void addOutlink(CrawlURI curi, String uri, LinkContext context,
+    protected CrawlURI addOutlink(CrawlURI curi, String uri, LinkContext context,
             Hop hop) {
         try {
             UURI dest = UURIFactory.getInstance(curi.getUURI(), uri);
             CrawlURI link = curi.createCrawlURI(dest, context, hop);
             curi.getOutLinks().add(link);
+            return link;
         } catch (URIException e) {
             logUriError(e, curi.getUURI(), uri);
+            return null;
         }
     }
     

--- a/modules/src/main/java/org/archive/modules/extractor/Extractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/Extractor.java
@@ -196,11 +196,11 @@ public abstract class Extractor extends Processor {
      * @return the new outlink or null if the outlink was ignored
      */
     public static CrawlURI addRelativeToBase(CrawlURI uri, int max,
-            String newUri, LinkContext context, Hop hop) throws URIException {
+            CharSequence newUri, LinkContext context, Hop hop) throws URIException {
         if (UriUtils.isDataUri(newUri)) {
             return null;
         }
-        UURI dest = UURIFactory.getInstance(uri.getBaseURI(), newUri);
+        UURI dest = UURIFactory.getInstance(uri.getBaseURI(), newUri.toString());
         return add2(uri, max, dest, context, hop);
     }
 

--- a/modules/src/main/java/org/archive/modules/extractor/Extractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/Extractor.java
@@ -29,6 +29,7 @@ import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
+import org.archive.util.UriUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,10 +135,13 @@ public abstract class Extractor extends Processor {
 
     /**
      * Create and add a 'Link' to the CrawlURI with given URI/context/hop-type
-     * @return the new outlink or null if it was not valid
+     * @return the new outlink or null if it was invalid or ignored
      */
     protected CrawlURI addOutlink(CrawlURI curi, String uri, LinkContext context,
             Hop hop) {
+        if (UriUtils.isDataUri(uri)) {
+            return null;
+        }
         try {
             UURI dest = UURIFactory.getInstance(curi.getUURI(), uri);
             CrawlURI link = curi.createCrawlURI(dest, context, hop);
@@ -151,6 +155,9 @@ public abstract class Extractor extends Processor {
     
     protected void addOutlink(CrawlURI curi, UURI uuri, LinkContext context,
             Hop hop) {
+        if ("data".equalsIgnoreCase(uuri.getScheme())) {
+            return;
+        }
         try {
             CrawlURI link = curi.createCrawlURI(uuri, context, hop);
             curi.getOutLinks().add(link);
@@ -183,16 +190,29 @@ public abstract class Extractor extends Processor {
         ret.append("  " + numberOfLinksExtracted + " links from " + getURICount() +" CrawlURIs\n");
         return ret.toString();
     }
-    
+
+    /**
+     * Adds an outlink to uri relative to uri.getBaseURI().
+     * @return the new outlink or null if the outlink was ignored
+     */
     public static CrawlURI addRelativeToBase(CrawlURI uri, int max,
             String newUri, LinkContext context, Hop hop) throws URIException {
+        if (UriUtils.isDataUri(newUri)) {
+            return null;
+        }
         UURI dest = UURIFactory.getInstance(uri.getBaseURI(), newUri);
         return add2(uri, max, dest, context, hop);
     }
 
-    
+    /**
+     * Adds an outlink to uri relative to uri.getVia().
+     * @return the new outlink or null if the outlink was ignored
+     */
     public static CrawlURI addRelativeToVia(CrawlURI uri, int max, String newUri,
             LinkContext context, Hop hop) throws URIException {
+        if (UriUtils.isDataUri(newUri)) {
+            return null;
+        }
         UURI relTo = uri.getVia();
         if (relTo == null) {
             if (!uri.getAnnotations().contains("usedBaseForVia")) {

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -664,7 +664,7 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
             // ReplayCharSequence.
             HTMLLinkContext hc = HTMLLinkContext.get(context.toString());
             int max = getExtractorParameters().getMaxOutlinks();
-            addRelativeToBase(curi, max, uri.toString(), hc, hop);
+            addRelativeToBase(curi, max, uri, hc, hop);
         } catch (URIException e) {
             logUriError(e, curi.getUURI(), uri);
         }
@@ -687,22 +687,19 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
 				|| context.equals(HTMLLinkContext.IMG_DATA_SRCSET.toString())
 				|| context.equals(HTMLLinkContext.IMG_DATA_ORIGINAL_SET.toString())
 				|| context.equals(HTMLLinkContext.SOURCE_DATA_ORIGINAL_SET.toString())) {
-            logger.fine("Found srcset listing: " + value.toString());
+            logger.log(Level.FINE,"Found srcset listing: {0}", value);
 
             Matcher matcher = TextUtils.getMatcher("[\\s,]*(\\S*[^,\\s])(?:\\s(?:[^,(]+|\\([^)]*(?:\\)|$))*)?", value);
             while (matcher.lookingAt()) {
-                String link = matcher.group(1);
+                CharSequence link = value.subSequence(matcher.start(1), matcher.end(1));
                 matcher.region(matcher.end(), matcher.regionEnd());
-                logger.finer("Found " + link + " adding to outlinks.");
+                logger.log(Level.FINER, "Found {0} adding to outlinks.", link);
                 addLinkFromString(curi, link, context, hop);
                 numberOfLinksExtracted.incrementAndGet();
             }
             TextUtils.recycleMatcher(matcher);
         } else {
-            addLinkFromString(curi,
-                (value instanceof String)?
-                    (String)value: value.toString(),
-                context, hop);
+            addLinkFromString(curi, value, context, hop);
             numberOfLinksExtracted.incrementAndGet();
         }
     }

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
@@ -75,6 +75,10 @@ public class ExtractorRobotsTxt extends ContentExtractor {
                     CrawlURI newCuri = addRelativeToBase(curi, max, link,
                             LinkContext.MANIFEST_MISC, Hop.MANIFEST);
 
+                    if (newCuri == null) {
+                        continue;
+                    }
+
                     // Annotate as a Site Map:
                     newCuri.getAnnotations().add(
                             ExtractorRobotsTxt.ANNOTATION_IS_SITEMAP);

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
@@ -179,8 +179,7 @@ public class ExtractorSitemap extends ContentExtractor {
             // Count it:
             numberOfLinksExtracted.incrementAndGet();
         } catch (URIException e) {
-            LOGGER.log(Level.WARNING,
-                    "URIException when recording outlink " + newUri, e);
+            logUriError(e, curi.getUURI(), newUri.toString());
         }
 
     }

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
@@ -163,6 +163,10 @@ public class ExtractorSitemap extends ContentExtractor {
             CrawlURI newCuri = addRelativeToBase(curi, max, newUri.toString(),
                     LinkContext.MANIFEST_MISC, Hop.MANIFEST);
 
+            if (newCuri == null) {
+                return;
+            }
+
             if (isSitemap) {
                 // Annotate as a Site Map:
                 newCuri.getAnnotations().add(

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -268,6 +268,13 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
             }
         }));
     }
+
+    public void testDataUrisAreIgnored() throws URIException {
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance("http://www.example.com"));
+        CharSequence cs = "<img src='data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='>";
+        getExtractor().extract(curi, cs);
+        assertEquals(0, curi.getOutLinks().size());
+    }
     
     /**
      * Test that relative base href's are resolved correctly:
@@ -521,7 +528,6 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
         Arrays.sort(links);
 
         String[] dest = {
-                "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
                 "http://www.example.com/a,b,c",
                 "http://www.example.com/images/foo.jpg",
                 "http://www.example.com/images/foo1.jpg",


### PR DESCRIPTION
Partially addresses #422 by changing the outlink helper methods in the Extractor base class to ignore data URIs. Since data URIs can be very large this also tries to avoid copying them to the heap as Strings when possible.