### PR TITLE
UI: Refactor duplicate template rendering code

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
@@ -27,6 +27,11 @@ import org.restlet.resource.ServerResource;
  * @author nlevitt
  */
 public abstract class BaseResource extends ServerResource {
+    @Override
+    public EngineApplication getApplication() {
+        return (EngineApplication) super.getApplication();
+    }
+
     protected String getStaticRef(String resource) {
         String rootRef = getRequest().getRootRef().toString();
         return rootRef + "/engine/static/" + resource;

--- a/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
@@ -22,6 +22,7 @@ package org.archive.crawler.restlet;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import org.archive.crawler.framework.Engine;
 import org.archive.crawler.restlet.models.ViewModel;
 import org.restlet.data.MediaType;
 import org.restlet.representation.Representation;
@@ -41,6 +42,10 @@ public abstract class BaseResource extends ServerResource {
     @Override
     public EngineApplication getApplication() {
         return (EngineApplication) super.getApplication();
+    }
+
+    protected Engine getEngine() {
+        return getApplication().getEngine();
     }
 
     protected String getStaticRef(String resource) {

--- a/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BaseResource.java
@@ -19,7 +19,18 @@
 
 package org.archive.crawler.restlet;
 
+import freemarker.template.ObjectWrapper;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.archive.crawler.restlet.models.ViewModel;
+import org.restlet.data.MediaType;
+import org.restlet.representation.Representation;
+import org.restlet.representation.WriterRepresentation;
 import org.restlet.resource.ServerResource;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
 
 /**
  * Abstract {@code Resource} with common shared functionality. 
@@ -35,5 +46,37 @@ public abstract class BaseResource extends ServerResource {
     protected String getStaticRef(String resource) {
         String rootRef = getRequest().getRootRef().toString();
         return rootRef + "/engine/static/" + resource;
+    }
+
+    protected Representation render(String templateName, ViewModel viewModel) {
+        return render(templateName, viewModel, null);
+    }
+
+    protected Representation render(String templateName, ViewModel viewModel, ObjectWrapper objectWrapper) {
+        String baseRef = getRequest().getResourceRef().getBaseRef().toString();
+        if(!baseRef.endsWith("/")) {
+            baseRef += "/";
+        }
+        viewModel.put("baseRef", baseRef);
+        viewModel.setFlashes(Flash.getFlashes(getRequest()));
+
+        Template template;
+        try {
+            template = getApplication().getTemplateConfiguration().getTemplate(templateName);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error reading template " + templateName, e);
+        }
+
+        return new WriterRepresentation(MediaType.TEXT_HTML) {
+            @Override
+            public void write(Writer writer) throws IOException {
+                try {
+                    template.process(viewModel, writer, objectWrapper);
+                } catch (TemplateException e) {
+                    throw new RuntimeException(e);
+                }
+                writer.flush();
+            }
+        };
     }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
@@ -63,8 +63,7 @@ import freemarker.template.TemplateException;
  */
 public class BeanBrowseResource extends JobRelatedResource {
     protected PathSharingContext appCtx; 
-    protected String beanPath; 
-    private Configuration _templateConfiguration;
+    protected String beanPath;
 
     @Override
     public void init(Context ctx, Request req, Response res) throws ResourceException {
@@ -82,17 +81,6 @@ public class BeanBrowseResource extends JobRelatedResource {
         } else {
             beanPath = "";
         }
-        
-        Configuration tmpltCfg = new Configuration();
-        tmpltCfg.setClassForTemplateLoading(this.getClass(),"");
-        tmpltCfg.setObjectWrapper(ObjectWrapper.BEANS_WRAPPER);
-        setTemplateConfiguration(tmpltCfg);
-    }
-    public void setTemplateConfiguration(Configuration tmpltCfg) {
-        _templateConfiguration=tmpltCfg;
-    }
-    public Configuration getTemplateConfiguration(){
-        return _templateConfiguration;
     }
 
     @Override
@@ -225,7 +213,7 @@ public class BeanBrowseResource extends JobRelatedResource {
         if(!baseRef.endsWith("/")) {
             baseRef += "/";
         }
-        Configuration tmpltCfg = getTemplateConfiguration();
+        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
 
         ViewModel viewModel = new ViewModel();
         viewModel.setFlashes(Flash.getFlashes(getRequest()));

--- a/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BeanBrowseResource.java
@@ -33,7 +33,6 @@ import org.archive.crawler.restlet.models.BeansModel;
 import org.archive.crawler.restlet.models.ViewModel;
 import org.archive.spring.PathSharingContext;
 import org.restlet.Context;
-import org.restlet.data.CharacterSet;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
 import org.restlet.data.Reference;
@@ -46,11 +45,6 @@ import org.restlet.resource.ResourceException;
 import org.restlet.representation.Variant;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.BeansException;
-
-import freemarker.template.Configuration;
-import freemarker.template.ObjectWrapper;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
 
 /**
  * Restlet Resource which allows browsing the constructed beans in
@@ -129,24 +123,17 @@ public class BeanBrowseResource extends JobRelatedResource {
             throw new ResourceException(404);
         }
 
-        Representation representation;
         if (variant.getMediaType() == MediaType.APPLICATION_XML) {
-            representation = new WriterRepresentation(MediaType.APPLICATION_XML) {
+            return new WriterRepresentation(MediaType.APPLICATION_XML) {
                 public void write(Writer writer) throws IOException {
                     XmlMarshaller.marshalDocument(writer, "beans", makeDataModel());
                 }
             };
         } else {
-            representation = new WriterRepresentation(
-                    MediaType.TEXT_HTML) {
-                public void write(Writer writer) throws IOException {
-                    BeanBrowseResource.this.writeHtml(writer);
-                }
-            };
+            ViewModel viewModel = new ViewModel();
+            viewModel.put("model", makeDataModel());
+            return render("Beans.ftl", viewModel);
         }
-        // TODO: remove if not necessary in future?
-        representation.setCharacterSet(CharacterSet.UTF_8);
-        return representation;
     }
     
     /**
@@ -206,29 +193,5 @@ public class BeanBrowseResource extends JobRelatedResource {
                 target,
                 nestedNames);
 
-    }
-
-    protected void writeHtml(Writer writer) {
-        String baseRef = getRequest().getResourceRef().getBaseRef().toString();
-        if(!baseRef.endsWith("/")) {
-            baseRef += "/";
-        }
-        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
-
-        ViewModel viewModel = new ViewModel();
-        viewModel.setFlashes(Flash.getFlashes(getRequest()));
-        viewModel.put("baseRef",baseRef);
-        viewModel.put("model",makeDataModel());
-
-        try {
-            Template template = tmpltCfg.getTemplate("Beans.ftl");
-            template.process(viewModel, writer);
-            writer.flush();
-        } catch (IOException e) { 
-            throw new RuntimeException(e); 
-        } catch (TemplateException e) { 
-            throw new RuntimeException(e); 
-        }
-        
     }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import freemarker.template.Configuration;
+import freemarker.template.ObjectWrapper;
 import org.archive.crawler.framework.Engine;
 import org.archive.util.TextUtils;
 import org.restlet.Application;
@@ -48,12 +50,17 @@ import org.restlet.service.StatusService;
  * @author gojomo
  */
 public class EngineApplication extends Application {
-    protected Engine engine; 
+    protected Engine engine;
+    private final Configuration templateConfiguration;
+
     public EngineApplication(Engine engine) {
         this.engine = engine;
         getMetadataService().addExtension("log", MediaType.TEXT_PLAIN );
         getMetadataService().addExtension("cxml", MediaType.APPLICATION_XML );
         setStatusService(new EngineStatusService());
+        templateConfiguration = new Configuration();
+        templateConfiguration.setClassForTemplateLoading(getClass(), "");
+        templateConfiguration.setObjectWrapper(ObjectWrapper.BEANS_WRAPPER);
     }
 
     @Override
@@ -159,4 +166,7 @@ public class EngineApplication extends Application {
 
     }
 
+    public Configuration getTemplateConfiguration() {
+        return templateConfiguration;
+    }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
@@ -201,8 +201,4 @@ public class EngineResource extends BaseResource {
         
         return new EngineModel(getEngine(), baseRef);
     }
-
-    protected Engine getEngine() {
-        return ((EngineApplication)getApplication()).getEngine();
-    }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
@@ -58,25 +58,11 @@ import static org.restlet.data.MediaType.APPLICATION_XML;
  */
 public class EngineResource extends BaseResource {
 
-    private Configuration _templateConfiguration;
-
     @Override
     public void init(Context ctx, Request req, Response res) {
         super.init(ctx, req, res);
         getVariants().add(new Variant(MediaType.TEXT_HTML));
         getVariants().add(new Variant(APPLICATION_XML));
-        
-        Configuration tmpltCfg = new Configuration();
-        tmpltCfg.setClassForTemplateLoading(this.getClass(),"");        
-        tmpltCfg.setObjectWrapper(new DefaultObjectWrapper());
-        setTemplateConfiguration(tmpltCfg);
-    }
-
-    public void setTemplateConfiguration(Configuration tmpltCfg) {
-        _templateConfiguration=tmpltCfg;
-    }
-    public Configuration getTemplateConfiguration(){
-        return _templateConfiguration;
     }
 
     @Override
@@ -233,7 +219,7 @@ public class EngineResource extends BaseResource {
         if(!baseRef.endsWith("/")) {
             baseRef += "/";
         }
-        Configuration tmpltCfg = getTemplateConfiguration();
+        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
 
         ViewModel viewModel = new ViewModel();
         viewModel.setFlashes(Flash.getFlashes(getRequest()));

--- a/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobRelatedResource.java
@@ -72,10 +72,6 @@ public abstract class JobRelatedResource extends BaseResource {
         }
     }
 
-    protected Engine getEngine() {
-        return ((EngineApplication)getApplication()).getEngine();
-    }
-
     /**
      * Starting at (and including) the given object, adds nested Map
      * representations of named beans to the {@code namedBeans} Collection. The

--- a/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
@@ -138,10 +138,6 @@ public class JobResource extends BaseResource {
         return "../../anypath/" + fullPath;
     }
 
-    protected Engine getEngine() {
-        return ((EngineApplication) getApplication()).getEngine();
-    }
-
     @Override
     public Representation post(Representation entity, Variant variant)
             throws ResourceException {

--- a/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
@@ -61,7 +61,6 @@ import freemarker.template.TemplateException;
 public class JobResource extends BaseResource {
     public static final IOFileFilter EDIT_FILTER = FileUtils
             .getRegexFileFilter(".*\\.((c?xml)|(txt))$");
-    private Configuration _templateConfiguration;
 
     @SuppressWarnings("unused")
     private static final Logger logger = Logger.getLogger(JobResource.class
@@ -77,17 +76,6 @@ public class JobResource extends BaseResource {
         getVariants().add(new Variant(MediaType.APPLICATION_XML));
         cj = getEngine().getJob(
                 TextUtils.urlUnescape((String) req.getAttributes().get("job")));
-        
-        Configuration tmpltCfg = new Configuration();
-        tmpltCfg.setClassForTemplateLoading(this.getClass(),"");
-        tmpltCfg.setObjectWrapper(ObjectWrapper.BEANS_WRAPPER);
-        setTemplateConfiguration(tmpltCfg);
-    }
-    public void setTemplateConfiguration(Configuration tmpltCfg) {
-        _templateConfiguration=tmpltCfg;
-    }
-    public Configuration getTemplateConfiguration(){
-        return _templateConfiguration;
     }
 
     @Override
@@ -139,7 +127,7 @@ public class JobResource extends BaseResource {
         if(!baseRef.endsWith("/")) {
             baseRef += "/";
         }
-        Configuration tmpltCfg = getTemplateConfiguration();
+        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
 
         ViewModel viewModel = new ViewModel();
         viewModel.setFlashes(Flash.getFlashes(getRequest()));

--- a/engine/src/main/java/org/archive/crawler/restlet/ScriptResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/ScriptResource.java
@@ -19,39 +19,26 @@
 
 package org.archive.crawler.restlet;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineFactory;
-import javax.script.ScriptEngineManager;
-
 import org.apache.commons.lang.StringUtils;
 import org.archive.crawler.restlet.models.ScriptModel;
 import org.archive.crawler.restlet.models.ViewModel;
 import org.restlet.Context;
-import org.restlet.data.CharacterSet;
+import org.restlet.Request;
+import org.restlet.Response;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
 import org.restlet.data.Reference;
-import org.restlet.Request;
-import org.restlet.Response;
 import org.restlet.representation.Representation;
+import org.restlet.representation.Variant;
 import org.restlet.representation.WriterRepresentation;
 import org.restlet.resource.ResourceException;
-import org.restlet.representation.Variant;
 
-import freemarker.template.Configuration;
-import freemarker.template.ObjectWrapper;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.*;
 
 /**
  * Restlet Resource which runs an arbitrary script, which is supplied
@@ -114,23 +101,20 @@ public class ScriptResource extends JobRelatedResource {
 
     @Override
     public Representation get(Variant variant) throws ResourceException {
-        Representation representation;
         if (variant.getMediaType() == MediaType.APPLICATION_XML) {
-            representation = new WriterRepresentation(MediaType.APPLICATION_XML) {
+            return new WriterRepresentation(MediaType.APPLICATION_XML) {
                 public void write(Writer writer) throws IOException {
                     XmlMarshaller.marshalDocument(writer,"script", makeDataModel());
                 }
             };
         } else {
-            representation = new WriterRepresentation(MediaType.TEXT_HTML) {
-                public void write(Writer writer) throws IOException {
-                    ScriptResource.this.writeHtml(writer);
-                }
-            };
+            ViewModel viewModel = new ViewModel();
+            viewModel.put("baseResourceRef", getRequest().getRootRef().toString() + "/engine/static/");
+            viewModel.put("model", makeDataModel());
+            viewModel.put("selectedEngine", chosenEngine);
+            viewModel.put("staticRef", getStaticRef(""));
+            return render("Script.ftl", viewModel);
         }
-        // TODO: remove if not necessary in future?
-        representation.setCharacterSet(CharacterSet.UTF_8);
-        return representation;
     }
 
     protected Collection<Map<String,String>> getAvailableScriptEngines() {
@@ -164,33 +148,5 @@ public class ScriptResource extends JobRelatedResource {
                 getAvailableScriptEngines());
 
         return model;
-    }
-
-    protected void writeHtml(Writer writer) {
-        
-        String baseRef = getRequest().getResourceRef().getBaseRef().toString();
-        if(!baseRef.endsWith("/")) {
-            baseRef += "/";
-        }
-        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
-
-        ViewModel viewModel = new ViewModel();
-        viewModel.setFlashes(Flash.getFlashes(getRequest()));
-        viewModel.put("baseRef",baseRef);
-        viewModel.put("staticRef", getStaticRef(""));
-        viewModel.put("baseResourceRef",getRequest().getRootRef().toString()+"/engine/static/");
-        viewModel.put("model", makeDataModel());
-        viewModel.put("selectedEngine", chosenEngine);
-
-        try {
-            Template template = tmpltCfg.getTemplate("Script.ftl");
-            template.process(viewModel, writer);
-            writer.flush();
-        } catch (IOException e) { 
-            throw new RuntimeException(e); 
-        } catch (TemplateException e) { 
-            throw new RuntimeException(e); 
-        }
-
     }
 }

--- a/engine/src/main/java/org/archive/crawler/restlet/ScriptResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/ScriptResource.java
@@ -80,28 +80,16 @@ public class ScriptResource extends JobRelatedResource {
     }
     
     protected String chosenEngine = FACTORIES.isEmpty() ? "" : FACTORIES.getFirst().getNames().get(0);
-    private Configuration _templateConfiguration;
 
     @Override
     public void init(Context ctx, Request req, Response res) throws ResourceException {
         super.init(ctx, req, res);
         getVariants().add(new Variant(MediaType.TEXT_HTML));
         getVariants().add(new Variant(MediaType.APPLICATION_XML));
-        
-        Configuration tmpltCfg = new Configuration();
-        tmpltCfg.setClassForTemplateLoading(this.getClass(),"");
-        tmpltCfg.setObjectWrapper(ObjectWrapper.BEANS_WRAPPER);
-        setTemplateConfiguration(tmpltCfg);
 
         scriptingConsole = new ScriptingConsole(cj);
     }
-    public void setTemplateConfiguration(Configuration tmpltCfg) {
-        _templateConfiguration=tmpltCfg;
-    }
-    public Configuration getTemplateConfiguration(){
-        return _templateConfiguration;
-    }
-        
+
     private ScriptingConsole scriptingConsole;
     
     @Override
@@ -184,7 +172,7 @@ public class ScriptResource extends JobRelatedResource {
         if(!baseRef.endsWith("/")) {
             baseRef += "/";
         }
-        Configuration tmpltCfg = getTemplateConfiguration();
+        Configuration tmpltCfg = getApplication().getTemplateConfiguration();
 
         ViewModel viewModel = new ViewModel();
         viewModel.setFlashes(Flash.getFlashes(getRequest()));


### PR DESCRIPTION
While trying to add a new feature to the user interface I discovered that each of the Resource classes duplicates the same code for rendering Freemarker templates. Rather than creating yet another copy of it I'd prefer to first refactor and eliminate the duplication.

This replaces the various copies of the Freemarker configuration with one shared instance attached to the application object. It also introduces a render() helper in BaseResource that sets up the common view parameters and returns a HTML Representation.

I've removed the calls to representation.setCharacterSet(UTF_8) as WriterRepresentation's parent's constructor ends up calling that anyway.

Note that EngineResource uses DefaultObjectWrapper while the other pages use BeansWrapper, so I added an overload to render() to preserve that difference. It'd be nice if they used the same configuration but I'll leave tackling that for future.