### PR TITLE
Adding fixed versions and moving to Zulu builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
-        distribution: 'temurin'
+        distribution: 'zulu'
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk: [8, 11, 16]
+        jdk: [8, 8.0.192, 11, 11.0.3, 16, 16.0.2]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
It is good practice to do CI/CD against the latest version, e.g., 11, as well as a fixed version, e.g., 11.0.3, so that when the build fails on the latest version but passes on the fixed version, you'll know the problem is with the latest version and not with your source code. However, Adopt is no more, Temurin and Zulu are the two valid options, though Temurin is new and doesn't provide all the versions, while Zulu is more complete and can therefore support this solution.