### PR TITLE
FetchDNS: Keep dnsjava selector thread out of ToePool

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CrawlController.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlController.java
@@ -51,8 +51,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.support.AbstractApplicationContext;
-import org.xbill.DNS.DClass;
-import org.xbill.DNS.Lookup;
 
 /**
  * CrawlController collects all the classes which cooperate to
@@ -289,10 +287,6 @@ implements Serializable,
        
         sExit = CrawlStatus.FINISHED_ABNORMAL;
 
-        // force creation of DNS Cache now -- avoids CacheCleaner in toe-threads group
-        // also cap size at 1 (we never wanta cached value; 0 is non-operative)
-        Lookup.getDefaultCache(DClass.IN).setMaxEntries(1);
-        
         reserveMemory = new LinkedList<byte[]>();
         for(int i = 0; i < RESERVE_BLOCKS; i++) {
             reserveMemory.add(new byte[RESERVE_BLOCK_SIZE]);

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -66,6 +66,11 @@ public class FetchDNS extends Processor {
 
     private static Logger logger = Logger.getLogger(FetchDNS.class.getName());
 
+    static {
+        // cap size at 1 (we never want a cached value; 0 is non-operative)
+        Lookup.getDefaultCache(DClass.IN).setMaxEntries(1);
+    }
+
     // Defaults.
     private short ClassType = DClass.IN;
     private short TypeType = Type.A;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -69,6 +69,14 @@ public class FetchDNS extends Processor {
     static {
         // cap size at 1 (we never want a cached value; 0 is non-operative)
         Lookup.getDefaultCache(DClass.IN).setMaxEntries(1);
+
+        // do a dummy lookup to force the creation of dnsjava NIO selector thread
+        // ensures it doesn't end up in the toe-threads group
+        try {
+            new Lookup("localhost").run();
+        } catch (TextParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // Defaults.


### PR DESCRIPTION
Fixes #425, the dnsjava selector thread using 100% CPU because it was being created in the toe thread pool and then interrupted when the job was terminated. By doing a dummy lookup in a static block we ensure the selector thread is launched from a normal thread rather than from a toe thread.

There was an existing workaround in CrawlController for a similar problem with the dnsjava cache cleaner thread. This cleaner thread no longer exists in the current version of dnsjava but I assume we still want to set the cache size anyway. I moved this code to FetchDNS as well to keep the code that interfaces with dnsjava centralized. Since the cache is global it only needs to be configured once, not on every job launch.