### PR TITLE
Resolve gid too big

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -123,6 +123,7 @@
 							src/main/assembly/dist.xml
 						</descriptor>
 					</descriptors>
+					<tarLongFileMode>posix</tarLongFileMode>
 				</configuration>
 				<executions>
 					<execution>

--- a/contrib/src/main/assembly/dist.xml
+++ b/contrib/src/main/assembly/dist.xml
@@ -12,12 +12,17 @@
 	</dependencySets>
 	<fileSets>
 		<fileSet>
-			<directory>.</directory>
+			<directory>..</directory>
 			<outputDirectory>/</outputDirectory>
 			<includes>
-				<include>../dist/README.txt</include>
-				<include>../dist/LICENSE.txt</include>
-				<include>../dist/HOWTO-Launch-Heritrix.txt</include>
+				<include>README*</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>../dist</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>LICENSE.txt</include>
 			</includes>
 		</fileSet>
 		<fileSet>

--- a/dist/README.txt
+++ b/dist/README.txt
@@ -1,1 +1,0 @@
-../README.md

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -52,6 +52,7 @@
 							src/main/assembly/src.xml
 						</descriptor>
 					</descriptors>
+					<tarLongFileMode>posix</tarLongFileMode>
 				</configuration>
 				<executions>
 					<execution>

--- a/dist/src/main/assembly/dist.xml
+++ b/dist/src/main/assembly/dist.xml
@@ -12,13 +12,18 @@
     </dependencySet>
    </dependencySets>
    <fileSets>
+   <fileSet>
+     <directory>..</directory>
+     <outputDirectory>/</outputDirectory>
+     <includes>
+      <include>README*</include>
+     </includes>
+    </fileSet>
     <fileSet>
      <directory>.</directory>
      <outputDirectory>/</outputDirectory>
      <includes>
-      <include>README.txt</include>
       <include>LICENSE.txt</include>
-      <include>HOWTO-Launch-Heritrix.txt</include>
      </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
This should fix #447 by resolving the group id is too big build failure for dist and contrib on some platforms happening since the maven-assembly-plugin upgrade.

Also noticed while checking this, presumably also since the maven-assembly-plugin upgrade, the README and LICENSE files were no longer being included, so this also addresses that. Additionally the HOWTO-Launch-Heritrix.txt file no longer exists in the repo.