### PR TITLE
Fix issue#191: "RIS already open for ToeThread..." exception during https pages crawl over proxy

### DIFF
--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -189,7 +189,12 @@ public class FetchHTTPRequest {
         if (StringUtils.isNotEmpty(proxyHostname) && proxyPort != null) {
             this.proxyHost = new HttpHost(proxyHostname, proxyPort);
             this.requestConfigBuilder.setProxy(this.proxyHost);
-            requestLineUri = curi.getUURI().toString();
+            if ("https".equalsIgnoreCase(curi.getUURI().getScheme())) {
+                // with SSL connections the hostname is already send with the CONNECT
+                requestLineUri = curi.getUURI().getEscapedPathQuery();
+            } else {
+                requestLineUri = curi.getUURI().toString();
+            }
         } else {
             requestLineUri = curi.getUURI().getEscapedPathQuery();
         }
@@ -604,7 +609,7 @@ public class FetchHTTPRequest {
                         DEFAULT_BUFSIZE, chardecoder, charencoder,
                         cconfig.getMessageConstraints(), null, null,
                         DefaultHttpRequestWriterFactory.INSTANCE,
-                        DefaultHttpResponseParserFactory.INSTANCE, curi);
+                        DefaultHttpResponseParserFactory.INSTANCE, proxyHost, curi);
             }
         };
         BasicHttpClientConnectionManager connMan = new BasicHttpClientConnectionManager(
@@ -623,6 +628,9 @@ public class FetchHTTPRequest {
         private static final AtomicLong COUNTER = new AtomicLong();
         private String id;
         private final CrawlURI curi;
+        private final boolean isProxyConnect;
+        private boolean shouldWrapInput = true;
+        private boolean shouldWrapOutput = true;
 
         public RecordingHttpClientConnection(
                 final int buffersize,
@@ -633,21 +641,32 @@ public class FetchHTTPRequest {
                 final ContentLengthStrategy incomingContentStrategy,
                 final ContentLengthStrategy outgoingContentStrategy,
                 final HttpMessageWriterFactory<HttpRequest> requestWriterFactory,
-                final HttpMessageParserFactory<HttpResponse> responseParserFactory, CrawlURI curi) {
+                final HttpMessageParserFactory<HttpResponse> responseParserFactory,
+                final HttpHost proxy, CrawlURI curi) {
             super(buffersize, fragmentSizeHint, chardecoder, charencoder,
                     constraints, incomingContentStrategy, outgoingContentStrategy,
                     requestWriterFactory, responseParserFactory);
             id = "recording-http-connection-" + Long.toString(COUNTER.getAndIncrement());
             this.curi = curi;
+            // if we send HTTPS over a proxy, then the first connection should not be recorded,
+            // as it is only the "CONNECT" to open the SSL-tunnel for the actual connection
+            isProxyConnect = (proxy != null && "https".equalsIgnoreCase(curi.getBaseURI().getScheme()));
+            if (isProxyConnect) {
+                shouldWrapInput = shouldWrapOutput = false;
+            }
         }
 
         @Override
         protected InputStream getSocketInputStream(final Socket socket) throws IOException {
             curi.setServerIP(socket.getInetAddress().getHostAddress());
             Recorder recorder = Recorder.getHttpRecorder();
-            if (recorder != null) {   // XXX || (isSecure() && isProxied())) {
+
+            if (shouldWrapInput && recorder != null) { // means: !(isSecure() && isProxied()) {
                 return recorder.inputWrap(super.getSocketInputStream(socket));
             } else {
+                if (isProxyConnect) {
+                    shouldWrapInput = true;
+                }
                 return super.getSocketInputStream(socket);
             }
         }
@@ -655,9 +674,14 @@ public class FetchHTTPRequest {
         @Override
         protected OutputStream getSocketOutputStream(final Socket socket) throws IOException {
             Recorder recorder = Recorder.getHttpRecorder();
-            if (recorder != null) {   // XXX || (isSecure() && isProxied())) {
+
+            if (shouldWrapOutput && recorder != null) { // means: !(isSecure() && isProxied()) {
                 return recorder.outputWrap(super.getSocketOutputStream(socket));
             } else {
+                // for the next connection we want to record the contents
+                if (isProxyConnect) {
+                    shouldWrapOutput = true;
+                }
                 return super.getSocketOutputStream(socket);
             }
         }

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTests.java
@@ -501,6 +501,28 @@ public class FetchHTTPTests extends ProcessorTestBase {
             httpProxyServer.stop();
         }
     }
+
+    public void testHttpsProxy() throws Exception {
+        DefaultHttpProxyServer httpProxyServer = new DefaultHttpProxyServer(7877);
+        httpProxyServer.start(true, false);
+
+        try {
+            fetcher().setHttpProxyHost("localhost");
+            fetcher().setHttpProxyPort(7877);
+
+            CrawlURI curi = makeCrawlURI("https://localhost:7443/");
+            fetcher().process(curi);
+
+            String requestString = httpRequestString(curi);
+            assertTrue(requestString.contains("Host: localhost:7443\r\n"));
+            // in case of HTTPS we do not have a "Via" header in the recorded request
+            // as this is only present in the "CONNECT" that we do not record
+            assertNull(curi.getHttpResponseHeader("Via"));
+            runDefaultChecks(curi, "hostHeader");
+        } finally {
+            httpProxyServer.stop();
+        }
+    }
     
     public void testMaxFetchKBSec() throws Exception {
         CrawlURI curi = makeCrawlURI("http://localhost:7777/200k");


### PR DESCRIPTION
See [issue#191](https://github.com/internetarchive/heritrix3/issues/191) for the problem description.

### Description of the Change

When using a proxy, HTTPS-Requests are handled in two steps:

a) the client sends a request of the form:

    CONNECT <hostname>:<port> HTTP/1.1

  to the proxy. The proxy then opens an encrypted connection to
  the actual server and passes this to the client.

b) the client sends the data over the secure connection
   as plain HTTP-request like

    GET /some/path/name?param1=value1 HTTP/1.1

   and receives the response in plain, too (as it is tunneled via an encrypted connection)

To support this behavior, the current code in the `FetchHTTPRequest` is changed in two places:

a) in the constructor around line 189 do not use the full URI as data to be send after the verb
   if the method is HTTPS. Instead send the same line as without proxy

b) in the methods for the inner class `RecordingHttpClientConnection` check if we have an https request and a proxy in use. In that case do not wrap the first created input/output stream, but only the ones afterwards.

Here it would be better to check if the socket is the one used for the `CONNECT` or the one used to tunnel the actual request/response data (as the `XXX` comments suggests, which are already present in the code).
 However this information is not available inside this class, so instead make the assumption that the input / output streams for the `CONNECT` are created first, and the one for the data to be recorded afterwards.

This avoids trying to use the same RecordingInput/OutputStream twice without the need to remove the safety checks in these classes which prevents erroneous reuse.   


### Testing

There is one new test `testHttpsProxy` in the `FetchHTTPTests`, but I am not sure if that is sufficiently complete.

Additionally I tested the changes manually using Apache HTTPD as a proxy, running on the same host as the Herirtix crawler.

The following snippet was used as configuration file `/etc/apache2/sites-enabled/proxy-vhost.conf`:

```
Listen 8000

<VirtualHost *:8000>
  ProxyRequests On

  ProxyVia On

  SSLProxyVerify none
  SSLProxyCheckPeerCN off
  SSLProxyCheckPeerName off

  <Proxy "*">
    Require ip 127.0.0 192.168
  </Proxy>

  LogFormat "%h %l %u %t \"%r\" %>s %b [%D] \"%{User-agent}i\"" withduration
  CustomLog ${APACHE_LOG_DIR}/proxy_access.log withduration

</VirtualHost>
```

Enabled modules:

- `mod_proxy`
- `mod_ssl`
- `mod_proxy_http`
- `mod_proxy_connect`


The the `fetchHttp` bean in the heritirix config has the proxy configured in the usual way:


     <property name="httpProxyHost" value="127.0.0.1" />
     <property name="httpProxyPort" value="8000" />


The HTTPS-Server used as target for the crawl was also an apache httpd; as it turned out this server is not affected by the first change (it seems not to mind if you send it requests which looks like proxy requests). The second change was necessary to crawl any HTTPS-URIs via proxy at all and did not affect the crawling of HTTP-URIs.


If you have change requests, suggestions for improvements or any other questions/comments about the patch, please let me know.
