### PR TITLE
ExtractorHTML: Determine LINK tag type by parsing REL attribute

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -602,7 +602,7 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
     }
 
     // see: https://html.spec.whatwg.org/multipage/links.html#linkTypes
-    private void processLinkTagWithRel(CrawlURI curi, CharSequence href, CharSequence rel) {
+    protected void processLinkTagWithRel(CrawlURI curi, CharSequence href, CharSequence rel) {
         boolean emitAsNavLink = false;
         for (String keyword : ASCII_WHITESPACE.split(rel)) {
             String linkType = keyword.toLowerCase(Locale.ROOT);

--- a/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
@@ -137,8 +137,11 @@ public class JerichoExtractorHTML extends ExtractorHTML {
             CharSequence context = elementContext(elementName, attr
                     .getKey());
             if ("link".equals(elementName)) {
-                // <LINK> elements treated as embeds (css, ico, etc)
-                processEmbed(curi, attrValue, context);
+                // <LINK> elements treated as embeds (css, ico) or links (next, author) depending on rel
+                String rel = attributes.getValue("rel");
+                if (rel != null) {
+                    processLinkTagWithRel(curi, attrValue, rel);
+                }
             } else {
                 // other HREFs treated as links
                 processLink(curi, attrValue, context);

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -687,10 +687,40 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
 
         genericCrawl(curi, cs, dest);
         
-    }  
-    
-	      
-    
+    }
+
+    public void testLinkRel() throws URIException {
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance("https://www.example.org/"));
+
+        String html = "<link href='/pingback' rel='pingback'>" +
+                "<link href='/style.css' rel=stylesheet>" +
+                "<link rel='my stylesheet rocks' href=/style2.css>" +
+                "<link rel=icon href=/icon.ico>" +
+                "<link href='http://dns-prefetch.example.com/' rel=dns-prefetch>" +
+                "<link href=/without-rel>" +
+                "<link href=/empty-rel rel=>" +
+                "<link href=/just-spaces rel='   '>" +
+                "<link href=/canonical rel=canonical>" +
+                "<link href=/unknown rel=unknown>";
+
+        List<String> expectedLinks = Arrays.asList(
+                "E https://www.example.org/icon.ico",
+                "E https://www.example.org/style.css",
+                "E https://www.example.org/style2.css",
+                "L https://www.example.org/canonical",
+                "L https://www.example.org/unknown"
+        );
+
+        getExtractor().extract(curi, html);
+        List<String> actualLinks = new ArrayList<>();
+        for (CrawlURI link: curi.getOutLinks()) {
+            actualLinks.add(link.getLastHop() + " " + link.getURI());
+        }
+        Collections.sort(actualLinks);
+
+        assertEquals(expectedLinks, actualLinks);
+    }
+
     private void genericCrawl(CrawlURI curi, CharSequence cs,String[] dest){
         getExtractor().extract(curi, cs);
 


### PR DESCRIPTION
Only treat icons, stylesheets and (tentatively) resource preloads as embedded resources. Treat most other link types as navigation links.

Previously we were treating all link tags as embedded resources including links like 'next', 'prev', 'canonical', 'author' which could pull in resources that should normally be considered out of scope.

For example crawling a page containing an author link like:

```html
<link href="http://twitter.com/example" rel="author">
```

Would end up transitively pulling 200+ MB of Twitter profile pages in multiple languages into a crawl for which twitter.com is not even supposed to be in scope at all.

Fixes #263