### PR TITLE
TransclusionDecideRule: Don't treat sitemap links ('M') as transclusions

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/TransclusionDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/TransclusionDecideRule.java
@@ -93,7 +93,7 @@ public class TransclusionDecideRule extends PredicatedDecideRule {
         int specCount = 0; 
         for (int i = hopsPath.length() - 1; i >= 0; i--) {
             char c = hopsPath.charAt(i);
-            if (c == Hop.NAVLINK.getHopChar() || c == Hop.SUBMIT.getHopChar()) {
+            if (c == Hop.NAVLINK.getHopChar() || c == Hop.SUBMIT.getHopChar() || c == Hop.MANIFEST.getHopChar()) {
                 // end of hops counted here
                 break;
             } 


### PR DESCRIPTION
We should only crawl sitemaps and sitemap links if they are in the primary SURT scope. Otherwise we'll start crawling the sitemaps of every site an embedded resource is pulled in from even when they should be out of scope.

Fixes #469