### PR TITLE
Issue211: support dns over https if local DNS is not working / available

### DIFF
--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -558,6 +558,24 @@ Scripting Console
 [This section to be written. For now see the
 `Heritrix3 Useful Scripts <https://github.com/internetarchive/heritrix3/wiki/Heritrix3%20Useful%20Scripts>`_ wiki page.]
 
+
+Configuring HTTP Proxies
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two options to specify a proxy for crawling.
+
+The command line options ``--proxy-host`` and ``--proxy-port`` can be used to define a proxy for all jobs.
+If only the ``--proxy-host`` option is given, a default value of 8000 is used for the proxy port.
+These proxy settings are also used when connecting to a "DNS-over-HTTP(s)" server (see section below).
+
+Alternatively one can define a per-job proxy via a the ``httpProxyHost`` and ``httpProxyPort`` properties of the
+``fetchHttp`` bean. These settings, if both defined, will overwrite the global options. These setting also allow for
+a user and password in the ``httpProxyUser`` and ``httpProxyPassword`` properties, which the global options do not
+support, due to incompatibilities of the different supported Java versions.
+
+Also the optional "SOCKS5" proxy documented in the next section is used on a per-job basis; there are currently no
+global options to define it.
+
 Configuring SOCKS5 Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -580,10 +598,11 @@ If the local DNS on the server running Heritrix is not able to resolve the DNS n
 the server is sitting behind an enterprise firewall and can only resolve names of the local network, then using
 DNS-over-HTTP (DoH) might be an alternative to fetch DNS information.
 
-To activate this, one needs to set the ``enableDnsOverHttpResolves`` setting of the ``fetchDns`` bean to true, and set the
-``dnsOverHttpServer`` to the URL of an DoH server. If one has configured a proxy in the settings for the ``fetchHttp`` bean,
-this proxy settings will be used to contact the DoH server as well. However due to limitation of the library in use,
-username and password information for the proxy are not supported.
+To activate this, one needs to set the ``dnsOverHttpServer`` setting of the ``fetchDns`` bean to the URL of an DoH server.
+If one has configured a global proxy via the ``--proxy-host`` and ``--proxy-port`` command line options,
+these proxy settings will be used to contact the DoH server as well. However due to limitation of the library in use,
+username and password information for the proxy are not supported. Also any per-job defined proxy settings in the
+``fetchHttp`` bean are not used when contacting the DoH server.
 
 As the implementation relies on the corresponding client in the "dnsjava" library, which is currently labeled as
 experimental, this option comes with some limitations:
@@ -595,8 +614,8 @@ experimental, this option comes with some limitations:
 * For other Java versions, the connection to the DoH server will be closed when the garbage collector runs.
   Depending on the garbage collector used this will cause a delay of anything between a few seconds and several
   minutes before closing the connection. Also note that if the garbage collector is explicitely triggered via the
-  Heritrix UI one needs to add the ``-XX:-DisableExplicitGC`` option in the ``JAVA_OPTS`` for Java versions 13 and up as
-  otherwise this action has no effect.
+  Heritrix UI one needs to add the ``-XX:-DisableExplicitGC`` option in the ``JAVA_OPTS`` for Java versions 13 and up
+  as otherwise this action has no effect.
 
 Without making a recommendation the following DoH servers have been tested with the DoH feature:
 

--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -566,7 +566,8 @@ There are two options to specify a proxy for crawling.
 
 The command line options ``--proxy-host`` and ``--proxy-port`` can be used to define a proxy for all jobs.
 If only the ``--proxy-host`` option is given, a default value of 8000 is used for the proxy port.
-These proxy settings are also used when connecting to a "DNS-over-HTTP(s)" server (see section below).
+These proxy settings are also used when connecting to a "DNS-over-HTTP" server
+(see the `section on DNS-over-HTTP <#configuring-dns-over-http-doh>`_ below).
 
 Alternatively one can define a per-job proxy via a the ``httpProxyHost`` and ``httpProxyPort`` properties of the
 ``fetchHttp`` bean. These settings, if both defined, will overwrite the global options. These setting also allow for

--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -580,32 +580,32 @@ If the local DNS on the server running Heritrix is not able to resolve the DNS n
 the server is sitting behind an enterprise firewall and can only resolve names of the local network, then using
 DNS-over-HTTP (DoH) might be an alternative to fetch DNS information.
 
-To activate this, one needs to set the `enableDnsOverHttpResolves` setting of the `fetchDns` bean to true, and set the
-`dnsOverHttpServer` to the URL of an DoH server. If one has configured a proxy in the settings for the `fetchHttp` bean,
+To activate this, one needs to set the ``enableDnsOverHttpResolves`` setting of the ``fetchDns`` bean to true, and set the
+``dnsOverHttpServer`` to the URL of an DoH server. If one has configured a proxy in the settings for the ``fetchHttp`` bean,
 this proxy settings will be used to contact the DoH server as well. However due to limitation of the library in use,
 username and password information for the proxy are not supported.
 
-As the implementation relies on the corresponding client in the `dnsjava` library, which is currently labeled as
+As the implementation relies on the corresponding client in the "dnsjava" library, which is currently labeled as
 experimental, this option comes with some limitations:
 
-   * If you use Java 11 then due to a `well known bug <https://bugs.openjdk.java.net/browse/JDK-8221395>`_ it will not
-     close connections to the DoH server unless Heritrix shuts down.
-     As the DoH server might not accept new connections after some limits while these connections are still open, it is
-     not recommended to use this feature when running Heritrix with Java 11.
-   * For other Java versions, the connection to the DoH server will be closed when the garbage collector runs.
-     Depending on the garbage collector used this will cause a delay of anything between a few seconds and several
-     minutes before closing the connection. Also note that if the garbage collector is explicitely triggered via the
-     Heritrix UI one needs to add the `-XX:-DisableExplicitGC` option in the JAVA_OPTS for Java versions 13 and up as
-     otherwise this action has no effect.
+* If you use Java 11 then due to a `well known bug <https://bugs.openjdk.java.net/browse/JDK-8221395>`_ it will not
+  close connections to the DoH server unless Heritrix shuts down.
+  As the DoH server might not accept new connections after some limits while these connections are still open, it is
+  not recommended to use this feature when running Heritrix with Java 11.
+* For other Java versions, the connection to the DoH server will be closed when the garbage collector runs.
+  Depending on the garbage collector used this will cause a delay of anything between a few seconds and several
+  minutes before closing the connection. Also note that if the garbage collector is explicitely triggered via the
+  Heritrix UI one needs to add the ``-XX:-DisableExplicitGC`` option in the ``JAVA_OPTS`` for Java versions 13 and up as
+  otherwise this action has no effect.
 
 Without making a recommendation the following DoH servers have been tested with the DoH feature:
 
-   * https://dns.google/dns-query
-   * https://cloudflare-dns.com/dns-query
+* https://dns.google/dns-query
+* https://cloudflare-dns.com/dns-query
 
 However servers implementing the official `RFC 8484 <https://tools.ietf.org/html/rfc8484>`_ specification
 unfortunately do not work with the current implementation. This includes e.g. the following server:
 
-   * https://dns.digitale-gesellschaft.ch/dns-query
+* https://dns.digitale-gesellschaft.ch/dns-query
 
-This limitation might be overcome by a newer version of the `dnsjava` library.
+This limitation might be overcome by a newer version of the "dnsjava" library.

--- a/engine/src/main/java/org/archive/crawler/Heritrix.java
+++ b/engine/src/main/java/org/archive/crawler/Heritrix.java
@@ -141,11 +141,15 @@ public class Heritrix {
                 "web interface to bind to.");
         options.addOption("p", "web-port", true, "The port the web interface " +
                 "should listen on.");
-        options.addOption("r", "run-job", true, "Run a single job and then exit when it" +
-                "finishes.");
+        options.addOption("r", "run-job", true, "Run a single job and then exit " +
+                "when it finishes.");
         options.addOption("s", "ssl-params", true,  "Specify a keystore " +
                 "path, keystore password, and key password for HTTPS use. " +
                 "Separate with commas, no whitespace.");
+        options.addOption(null, "proxy-host", true, "Global http(s) proxy host " +
+                "to use for crawling.");
+        options.addOption(null, "proxy-port", true, "Global http(s) proxy port " +
+                "to use for crawling.");
         return options;
     }
     
@@ -307,6 +311,15 @@ public class Heritrix {
             useAdhocKeystore(startupOut); 
         }
 
+        if(cl.hasOption("proxy-host")) {
+            String proxyHost = cl.getOptionValue("proxy-host");
+            String proxyPort = cl.getOptionValue("proxy-port", "8000");
+            System.setProperty("http.proxyHost", proxyHost);
+            System.setProperty("http.proxyPort", proxyPort);
+            System.setProperty("https.proxyHost", proxyHost);
+            System.setProperty("https.proxyPort", proxyPort);
+        }
+
         // Restlet will reconfigure logging according to the system property
         // so we must set it for -l to work properly
         System.setProperty("java.util.logging.config.file", properties.getPath());
@@ -315,7 +328,7 @@ public class Heritrix {
             LogManager.getLogManager().readConfiguration(finp);
             finp.close();
         }
-        
+
         // Set timezone here.  Would be problematic doing it if we're running
         // inside in a container.
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));

--- a/engine/src/main/resources/org/archive/crawler/migrate/migrate-template-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/migrate/migrate-template-crawler-beans.cxml
@@ -215,6 +215,8 @@
   <!-- <property name="acceptNonDnsResolves" value="false" /> -->
   <!-- <property name="digestContent" value="true" /> -->
   <!-- <property name="digestAlgorithm" value="sha1" /> -->
+  <!-- <property name="enableDnsOverHttpResolves" value="false" /> -->
+  <!-- <property name="dnsOverHttpServer" value="https://dns.google/dns-query" /> -->
  </bean>
  <bean id="fetchHttp" class="org.archive.modules.fetcher.FetchHTTP">
   <!-- <property name="maxLengthBytes" value="0" /> -->

--- a/engine/src/main/resources/org/archive/crawler/migrate/migrate-template-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/migrate/migrate-template-crawler-beans.cxml
@@ -215,7 +215,6 @@
   <!-- <property name="acceptNonDnsResolves" value="false" /> -->
   <!-- <property name="digestContent" value="true" /> -->
   <!-- <property name="digestAlgorithm" value="sha1" /> -->
-  <!-- <property name="enableDnsOverHttpResolves" value="false" /> -->
   <!-- <property name="dnsOverHttpServer" value="https://dns.google/dns-query" /> -->
  </bean>
  <bean id="fetchHttp" class="org.archive.modules.fetcher.FetchHTTP">

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -245,7 +245,6 @@ http://example.example/example
   <!-- <property name="acceptNonDnsResolves" value="false" /> -->
   <!-- <property name="digestContent" value="true" /> -->
   <!-- <property name="digestAlgorithm" value="sha1" /> -->
-  <!-- <property name="enableDnsOverHttpResolves" value="false" /> -->
   <!-- <property name="dnsOverHttpServer" value="https://dns.google/dns-query" /> -->
  </bean>
  <!-- <bean id="fetchWhois" class="org.archive.modules.fetcher.FetchWhois">

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -245,6 +245,8 @@ http://example.example/example
   <!-- <property name="acceptNonDnsResolves" value="false" /> -->
   <!-- <property name="digestContent" value="true" /> -->
   <!-- <property name="digestAlgorithm" value="sha1" /> -->
+  <!-- <property name="enableDnsOverHttpResolves" value="false" /> -->
+  <!-- <property name="dnsOverHttpServer" value="https://dns.google/dns-query" /> -->
  </bean>
  <!-- <bean id="fetchWhois" class="org.archive.modules.fetcher.FetchWhois">
        <property name="specialQueryTemplates">

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -118,17 +118,6 @@ public class FetchDNS extends Processor {
         kp.put("disableJavaDnsResolves",disableJavaDnsResolves);
     }
 
-
-    /**
-     * Switch to DNS-over-HTTP(S) for DNS lookups.
-     * This can be useful if local DNS is limited or unavailable and a public
-     * DNS service needs to be used via HTTP or HTTPS, as other ports are blocked
-     * via an enterprise firewall on the gateway or the like.
-     */
-    public void setEnableDnsOverHttpResolves(boolean enableDnsOverHttpResolve) {
-        kp.put("enableDnsOverHttpResolve",enableDnsOverHttpResolve);
-    }
-
     public String getDnsOverHttpServer() {
         return (String) kp.get("dnsOverHttpServer");
     }

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -210,6 +210,16 @@ public class FetchHTTPRequest {
         // HTTP proxy settings
         String proxyHostname = (String) fetcher.getAttributeEither(curi, "httpProxyHost");
         Integer proxyPort = (Integer) fetcher.getAttributeEither(curi, "httpProxyPort");
+        if (!(StringUtils.isNotEmpty(proxyHostname) && proxyPort != null) && !this.useSocksProxy) {
+            String sysPropertyPrefix;
+            if ("https".equalsIgnoreCase(curi.getUURI().getScheme())) {
+                sysPropertyPrefix = "https";
+            } else {
+                sysPropertyPrefix = "http";
+            }
+            proxyHostname = System.getProperty(sysPropertyPrefix + ".proxyHost");
+            proxyPort = Integer.getInteger(sysPropertyPrefix + ".proxyPort");
+        }
         
         // use HTTP proxy settings if SOCKS5 has not already been specified
         String requestLineUri;


### PR DESCRIPTION
As per comment: https://github.com/internetarchive/heritrix3/issues/211#issuecomment-409925550 and in the hope that this PR is considered "decent": 

Add support for DNS-over-HTTPS lookups: 
 - use the "DohResolver" from the dnsjava library to make DoH lookups
 - to enable and configure it, add two new properties
    * "enableDnsOverHttpResolves" (boolean)
    * "dnsOverHttpServer" URL to the DoH Server
 - as one use case for DoH is being located behind a firewall, also support using a proxy to access the DoH server; the proxy from the FetchHTTP bean is reused in that case

Alternatively one could have introduced separate properties for the proxy to be used for DoH; if this is the preferred approach instead of making the `FetchDNS` bean factory aware to load the proxy settings from the `FetchHTTP` bean, please let me know so I can update the PR. 