### PR TITLE
ExtractorHTML: Fix srcset by normalizing elementContext() to lowercase

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -20,9 +20,12 @@
 package org.archive.modules.extractor;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Locale;
@@ -33,6 +36,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.Ascii;
 import org.apache.commons.httpclient.URIException;
+import org.apache.commons.io.IOUtils;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CoreAttributeConstants;
 import org.archive.modules.CrawlMetadata;
@@ -1091,6 +1095,30 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
      */
     public static CharSequence elementContext(CharSequence element, CharSequence attribute) {
         return attribute == null? "": (element + "/@" + attribute).toLowerCase(Locale.ROOT);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0 || args[0].equals("-h") || args[0].equals("--help")) {
+            System.err.println("Usage: ExtractorHTML URL");
+            System.err.println("Extracts and prints links from the given URL");
+            System.exit(1);
+        }
+
+        String url = args[0];
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance(url));
+
+        ExtractorHTML extractor = new ExtractorHTML();
+        extractor.setExtractorJS(new ExtractorJS());
+        extractor.afterPropertiesSet();
+
+        String content;
+        try (InputStream stream = new URL(url).openStream()) {
+            content = IOUtils.toString(stream, StandardCharsets.ISO_8859_1);
+        }
+        extractor.extract(curi, content);
+        for (CrawlURI link : curi.getOutLinks()) {
+            System.out.println(link.getURI() + " " + link.getLastHop() + " " + link.getViaContext());
+        }
     }
 }
 

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -1090,7 +1090,7 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
      * @return CharSequence context
      */
     public static CharSequence elementContext(CharSequence element, CharSequence attribute) {
-        return attribute == null? "": element + "/@" + attribute;
+        return attribute == null? "": (element + "/@" + attribute).toLowerCase(Locale.ROOT);
     }
 }
 

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -545,8 +545,8 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
 
         CharSequence cs = "<picture>"
                 + "<source media=\"(min-width: 992px)\" srcset=\"images/foo1.jpg\"> "
-                + "<source media=\"(min-width: 500px)\" srcset=\"images/foo2.jpg\"> "
-                + "<source media=\"(min-width: 0px)\" srcset=\"images/foo3.jpg\"> "
+                + "<source media=\"(min-width: 500px)\" SRCSET=\"images/foo2.jpg\"> "
+                + "<source media=\"(min-width: 0px)\" srcSet=\"images/foo3-1x.jpg 1x, images/foo3-2x.jpg 2x\"> "
                 + "<img src=\"images/foo.jpg\" alt=\"\"> "
                 + "</picture>";
 
@@ -559,7 +559,9 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
                 "http://www.example.com/images/foo.jpg",
                 "http://www.example.com/images/foo1.jpg",
                 "http://www.example.com/images/foo2.jpg",
-                "http://www.example.com/images/foo3.jpg" };
+                "http://www.example.com/images/foo3-1x.jpg",
+                "http://www.example.com/images/foo3-2x.jpg",
+        };
 
         for (int i = 0; i < links.length; i++) {
             assertEquals("outlink from picture", dest[i], links[i].getURI());


### PR DESCRIPTION
This ensures that when we later compare the context in processEmbed() we don't need to deal with variants like srcSet or SRCSET. Note that we're already sometimes lowercasing it in HTMLLinkContext.get().

The second commit adds a main() method to ExtractorHTML to run the extractor against a given URL without having to setup a full job configuration. This is something I find myself frequently reaching for when we encounter a crawl problem.

Fixes #477.