### PR TITLE
Add robotsTxtOnly robots policy

### DIFF
--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -76,11 +76,13 @@ Robots.txt Honoring Policy
 The valid values of "robotsPolicyName" are:
 
 obey
-    Obey robots.txt directives
+    Obey robots.txt directives and nofollow robots meta tags
 classic
     Same as "obey"
+robotsTxtOnly
+    Obey robots.txt directives but ignore robots meta tags
 ignore
-    Ignore robots.txt directives
+    Ignore robots.txt directives and robots meta tags
 
 .. code-block:: xml
 
@@ -89,6 +91,18 @@ ignore
        <property name="robotsPolicyName" value="obey"/>
    ...
    </bean>
+
+.. note::
+
+   Heritrix currently only supports wildcards (*) at the end of paths in robots.txt rules.
+
+   The only supported value for robots meta tags is "nofollow" which will cause the HTML extractor to stop processing
+   and ignore all links (including embeds like images and stylesheets). Heritrix does not support "rel=nofollow" on
+   individual links.
+
+   .. code-block:: html
+
+       <meta name="robots" content="nofollow"/>
 
 Crawl Scope
 -----------

--- a/modules/src/main/java/org/archive/modules/net/RobotsPolicy.java
+++ b/modules/src/main/java/org/archive/modules/net/RobotsPolicy.java
@@ -36,7 +36,8 @@ abstract public class RobotsPolicy {
         STANDARD_POLICIES.put("obey", ObeyRobotsPolicy.INSTANCE);
         // the obey policy has also historically been called 'classic'
         STANDARD_POLICIES.put("classic", ObeyRobotsPolicy.INSTANCE);
-        STANDARD_POLICIES.put("ignore", IgnoreRobotsPolicy.INSTANCE); 
+        STANDARD_POLICIES.put("ignore", IgnoreRobotsPolicy.INSTANCE);
+        STANDARD_POLICIES.put("robotsTxtOnly", RobotsTxtOnlyPolicy.INSTANCE);
     }
 
     public abstract boolean allows(String userAgent, CrawlURI curi, Robotstxt robotstxt);

--- a/modules/src/main/java/org/archive/modules/net/RobotsTxtOnlyPolicy.java
+++ b/modules/src/main/java/org/archive/modules/net/RobotsTxtOnlyPolicy.java
@@ -1,0 +1,31 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.modules.net;
+
+/**
+ * Policy to obey robots.txt but ignore meta nofollow.
+ */
+public class RobotsTxtOnlyPolicy extends ObeyRobotsPolicy {
+    public static RobotsPolicy INSTANCE = new RobotsTxtOnlyPolicy();
+
+    @Override
+    public boolean obeyMetaRobotsNofollow() {
+        return false;
+    }
+}


### PR DESCRIPTION
We're increasingly frequently encountering sites which fail to be archived properly due to usage of this meta tag but where the robots.txt file contains reasonable rules. In many cases it seems to be unintentional, and we've even had questions from webmasters asking why archiving was failing when they were explicitly allowing us in robots.txt.

```html
 <meta name="robots" content="nofollow">
```

Under the `obey` policy the HTML extractor to stops processing as soon as it encounters the above tag. Under the `ignore` policy both the robots.txt rules and the robots nofollow meta tag are ignored. This adds a new `robotsTxtOnly` policy where the robots nofollow meta tag will be ignored but robots.txt rules will still be obeyed.

Note that Heritrix does not support `rel="nofollow"` on individual links and this PR does not change that.

