### PR TITLE
fix(sec): upgrade hbase-client to 0.98.12.1

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>0.98.6-cdh5.3.5</version>
+			<version>0.98.12.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jets3t</artifactId>


### PR DESCRIPTION
Upgrade  hbase-client 0.98.6-cdh5.3.5 to 0.98.12.1 for vulnerability fix:
 - [CVE-2015-1836](https://www.oscs1024.com/hd/MPS-2015-6356)