### PR TITLE
fix(sec): upgrade org.apache.hbase:hbase-client to 0.98.12.1

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -16,7 +17,7 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>0.98.6-cdh5.3.5</version>
+			<version>0.98.12.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jets3t</artifactId>
@@ -137,6 +138,4 @@
 			</plugin>
 		</plugins>
 	</build>
-</project>
-
-<!-- vim: set ft=xml sw=8 noet: -->
+</project><!-- vim: set ft=xml sw=8 noet: -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hbase:hbase-client 0.98.6-cdh5.3.5
- [CVE-2015-1836](https://www.oscs1024.com/hd/CVE-2015-1836)


### What did I do？
Upgrade org.apache.hbase:hbase-client from 0.98.6-cdh5.3.5 to 0.98.12.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS