### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.10 to 0.10.2.2

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.10</artifactId>
-			<version>0.9.0.0</version>
+			<version>0.10.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.rethinkdb</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.10 0.9.0.0
- [CVE-2017-12610](https://www.oscs1024.com/hd/CVE-2017-12610)


### What did I do？
Upgrade org.apache.kafka:kafka_2.10 from 0.9.0.0 to 0.10.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS