### PR TITLE
fix(sec): upgrade com.itextpdf:itextpdf to 5.5.12

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.5.0</version>
+			<version>5.5.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.easymock</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.itextpdf:itextpdf 5.5.0
- [CVE-2017-9096](https://www.oscs1024.com/hd/CVE-2017-9096)


### What did I do？
Upgrade com.itextpdf:itextpdf from 5.5.0 to 5.5.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS