### PR TITLE
Don't warn for non authenticating calls

### DIFF
--- a/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
@@ -59,7 +59,7 @@ public class RateLimitGuard extends DigestAuthenticator {
                     // ignore
                 }
             }
-            lastFailureTime = now + sleepMs;
+            lastFailureTime = now;
         }
         return succeeded;
     }

--- a/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
@@ -45,7 +45,8 @@ public class RateLimitGuard extends DigestAuthenticator {
     @Override
     protected boolean authenticate(Request request, Response response) {
         boolean succeeded = super.authenticate(request, response);
-        if (!succeeded) {
+        String authHeader = request.getHeaders().getFirstValue("Authorization", true);
+        if (authHeader != null && !succeeded) {
             logger.warning("authentication failure "+request);
             // wait until at least LAG has passed from last failure
             // holding object lock the whole time, so no other checks


### PR DESCRIPTION
There's a warning in the `heritrix3_err.log` about failed authentication for every HTTP-request since Heritrix switched to digest authentication. That form of authentication requires an initial unauthenticated request in order to get the challenge for the subsequent authentication digest.
Also the RateLimitGuard wasn't actually limiting any authentication attempts until after many millions of failures.