### PR TITLE
BdbModule: Fix resource leak on job teardown if sync() throws

### DIFF
--- a/commons/src/main/java/org/archive/bdb/BdbModule.java
+++ b/commons/src/main/java/org/archive/bdb/BdbModule.java
@@ -376,6 +376,10 @@ public class BdbModule implements Lifecycle, Checkpointable, Closeable, Disposab
         Database db = dpc.database;
         try {
             db.sync();
+        } catch (DatabaseException e) {
+            LOGGER.log(Level.WARNING, "Error syncing when closing db " + name, e);
+        }
+        try {
             db.close();
         } catch (DatabaseException e) {
             LOGGER.log(Level.WARNING, "Error closing db " + name, e);
@@ -692,6 +696,11 @@ public class BdbModule implements Lifecycle, Checkpointable, Closeable, Disposab
 
         try {
             this.bdbEnvironment.sync();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error syncing when closing environment.", e);
+        }
+
+        try {
             this.bdbEnvironment.close();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Error closing environment.", e);


### PR DESCRIPTION
This change ensures that close() is always called by moving sync() to a separate try-block.

Often when a BDB error occurs it causes all subsequent operations including sync() also throw exceptions. Since we were calling sync() and close() in the same try-block, sync() throwing would prevent close() from ever being called and thus leak file handles and BDB worker threads.