### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<build.timestamp>${maven.build.timestamp}</build.timestamp>
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
-		<jetty.version>9.4.37.v20210219</jetty.version>
+		<jetty.version>11.0.3</jetty.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.release>8</maven.compiler.release>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.37.v20210219
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.37.v20210219 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS