### PR TITLE
Job Status description  now shows that a job is not running anymore

### DIFF
--- a/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
@@ -971,6 +971,10 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
         if(!hasApplicationContext()) {
             return "Unbuilt";
         } else if(isRunning()) {
+            if (!getCrawlController().isRunning()) {
+                return "Not running: " + 
+			getCrawlController().getCrawlExitStatus();
+            }
             return "Active: "+getCrawlController().getState();
         } else if(isLaunchable()){
             return "Ready";


### PR DESCRIPTION

 In case of a crashed job, the crawlsummaryreport-log says: "Finished - Abnormal exit from crawl while the ApplicationContext still reports running==true. So the console shows "Job is ACTIVE - Running", while the process crashed  This change reports the exit status in this case.


