### PR TITLE
Remove the archive.org repositories, for #481

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,9 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 	</mailingLists>
 
 	<pluginRepositories>
-		<pluginRepository>
-			<id>builds.archive.org,maven2</id>
-			<url>http://builds.archive.org/maven2</url>
-		</pluginRepository>
 	</pluginRepositories>
 
 	<repositories>
-		<repository>
-			<id>builds.archive.org,maven2</id>
-			<url>http://builds.archive.org/maven2</url>
-		</repository>
         <repository>
             <id>oracleReleases</id>
             <name>Oracle Released Java Packages</name>


### PR DESCRIPTION
It seems we no longer need to depend on the archive.org Maven repository. The builds on this PR should verify this. See #481