### PR TITLE
fix yt-dlp format sort params

### DIFF
--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -442,8 +442,8 @@ public class ExtractorYoutubeDL extends Extractor
          * with video and audio.
          * https://github.com/ytdl-org/youtube-dl/blob/master/README.md#format-selection
          */
-        ProcessBuilder pb = new ProcessBuilder("youtube-dl", "--ignore-config",
-                "--simulate", "--dump-single-json", "--format=best[height <=? 576]",
+        ProcessBuilder pb = new ProcessBuilder("nice", "-n", Integer.toString(NICE_MOD), "yt-dlp", "--ignore-config",
+                "--simulate", "--dump-single-json", "-S vcodec:h264,res:576,acodec:aac",
                 "--no-cache-dir", "--no-playlist",
                 "--playlist-end=" + MAX_VIDEOS_PER_PAGE, uri.toString());
         logger.info("running: " + String.join(" ", pb.command()));

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -439,7 +439,7 @@ public class ExtractorYoutubeDL extends Extractor
          * updated for yt-dlp v.2023.07.06 and higher
          * Download the best video with best vcodec no better than h264 and
          * the best audio with best acodec no better than aac and
-         * with neither height nor width larger than 576.
+         * with the smallest dimension no larger than 720.
          */
         ProcessBuilder pb = new ProcessBuilder("yt-dlp", "--ignore-config",
                 "--simulate", "--dump-single-json", "-S vcodec:h264,res:720,acodec:aac",

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -442,7 +442,7 @@ public class ExtractorYoutubeDL extends Extractor
          * with video and audio.
          * https://github.com/ytdl-org/youtube-dl/blob/master/README.md#format-selection
          */
-        ProcessBuilder pb = new ProcessBuilder("nice", "-n", Integer.toString(NICE_MOD), "yt-dlp", "--ignore-config",
+        ProcessBuilder pb = new ProcessBuilder("yt-dlp", "--ignore-config",
                 "--simulate", "--dump-single-json", "-S vcodec:h264,res:576,acodec:aac",
                 "--no-cache-dir", "--no-playlist",
                 "--playlist-end=" + MAX_VIDEOS_PER_PAGE, uri.toString());


### PR DESCRIPTION
note: this update should support captures of single-file, video-plus-audio, downloads from youtube.com and other sources, at 720p.