### PR TITLE
Update to kryo 5.6.0

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -145,20 +145,7 @@
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
-			<version>1.01</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.esotericsoftware</groupId>
-			<artifactId>reflectasm</artifactId>
-			<version>0.8</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.esotericsoftware</groupId>
-			<artifactId>minlog</artifactId>
-			<version>1.2</version>
-			<scope>runtime</scope>
+			<version>5.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/commons/src/main/java/org/archive/bdb/KryoBinding.java
+++ b/commons/src/main/java/org/archive/bdb/KryoBinding.java
@@ -1,8 +1,8 @@
 /*
  *  This file is part of the Heritrix web crawler (crawler.archive.org).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual 
- *  contributors. 
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -18,69 +18,71 @@
  */
 package org.archive.bdb;
 
-import java.lang.ref.WeakReference;
-
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.ObjectBuffer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.util.Pool;
 import com.sleepycat.bind.EntryBinding;
 import com.sleepycat.je.DatabaseEntry;
 
 /**
  * Binding for use with BerkeleyDB-JE that uses Kryo serialization rather
  * than BDB's (custom version of) Java serialization.
- * 
+ *
  * @author gojomo
  */
 public class KryoBinding<K> implements EntryBinding<K> {
+    private static final int POOL_SIZE = 8;
 
-    protected Class<K> baseClass;
-    protected AutoKryo kryo = new AutoKryo(); 
-    protected ThreadLocal<WeakReference<ObjectBuffer>> threadBuffer = new ThreadLocal<WeakReference<ObjectBuffer>>() {
-        @Override
-        protected WeakReference<ObjectBuffer> initialValue() {
-            return new WeakReference<ObjectBuffer>(new ObjectBuffer(kryo,16*1024,Integer.MAX_VALUE));
+    protected final Class<K> baseClass;
+
+    Pool<AutoKryo> kryoPool = new Pool<AutoKryo>(true, false, POOL_SIZE) {
+        protected AutoKryo create () {
+            AutoKryo kryo = new AutoKryo();
+            kryo.autoregister(baseClass);
+            kryo.setRegistrationRequired(false);
+            kryo.setWarnUnregisteredClasses(true);
+            return kryo;
         }
     };
-    
-    /**
-     * Constructor. Save parameters locally, as superclass 
-     * fields are private. 
-     * 
-     * @param baseClass is the base class for serialized objects stored using
-     * this binding
-     */
+
+    Pool<Output> outputPool = new Pool<Output>(true, false, POOL_SIZE) {
+        protected Output create () {
+            return new Output(16 * 1024, -1);
+        }
+    };
+
     public KryoBinding(Class<K> baseClass) {
         this.baseClass = baseClass;
-        kryo.autoregister(baseClass);
-        // TODO: reevaluate if explicit registration should be required
-        kryo.setRegistrationOptional(true);
     }
 
-    public Kryo getKryo() {
-        return kryo;
-    }
-    
-    private ObjectBuffer getBuffer() {
-        WeakReference<ObjectBuffer> ref = threadBuffer.get();
-        ObjectBuffer ob = ref.get();
-        if (ob == null) {
-            ob = new ObjectBuffer(kryo,16*1024,Integer.MAX_VALUE);
-            threadBuffer.set(new WeakReference<ObjectBuffer>(ob));
-        }
-        return ob;        
-    }
-    
     /**
      * Copies superclass simply to allow different source for FastOoutputStream.
-     * 
+     *
      * @see com.sleepycat.bind.serial.SerialBinding#entryToObject
      */
     public void objectToEntry(K object, DatabaseEntry entry) {
-        entry.setData(getBuffer().writeObjectData(object));
+        AutoKryo kryo = kryoPool.obtain();
+        try {
+            Output output = outputPool.obtain();
+            try {
+                kryo.writeObject(output, object);
+                entry.setData(output.toBytes());
+            } finally {
+                outputPool.free(output);
+            }
+        } finally {
+            kryoPool.free(kryo);
+        }
     }
 
     @Override
     public K entryToObject(DatabaseEntry entry) {
-        return getBuffer().readObjectData(entry.getData(), baseClass);
+        AutoKryo kryo = kryoPool.obtain();
+        try {
+            return kryo.readObject(new Input(entry.getData()), baseClass);
+        } finally {
+            kryoPool.free(kryo);
+        }
     }
 }

--- a/commons/src/main/java/org/archive/util/Histotable.java
+++ b/commons/src/main/java/org/archive/util/Histotable.java
@@ -41,7 +41,14 @@ import java.util.TreeSet;
  */
 public class Histotable<K> extends TreeMap<K,Long> {    
     private static final long serialVersionUID = 310306238032568623L;
-    
+
+    public Histotable() {
+    }
+
+    protected Histotable(Comparator<K> comparator) {
+        super(comparator);
+    }
+
     /**
      * Record one more occurrence of the given object key.
      * 

--- a/commons/src/test/java/org/archive/util/IdentityCacheableWrapper.java
+++ b/commons/src/test/java/org/archive/util/IdentityCacheableWrapper.java
@@ -69,6 +69,5 @@ public class IdentityCacheableWrapper<K> implements IdentityCacheable {
     //
     public static void autoregisterTo(AutoKryo kryo) {
         kryo.register(IdentityCacheableWrapper.class);
-        kryo.setRegistrationOptional(true); 
     }
 }

--- a/engine/src/main/java/org/archive/crawler/frontier/BdbWorkQueue.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/BdbWorkQueue.java
@@ -178,6 +178,5 @@ implements Serializable {
         kryo.autoregister(HashSet.class);
         kryo.autoregister(SimplePrecedenceProvider.class);
         kryo.autoregister(byte[].class);
-        kryo.setRegistrationOptional(true); 
     }
 }

--- a/modules/src/main/java/org/archive/crawler/util/CrawledBytesHistotable.java
+++ b/modules/src/main/java/org/archive/crawler/util/CrawledBytesHistotable.java
@@ -19,6 +19,7 @@
 
 package org.archive.crawler.util;
 
+import java.util.Comparator;
 import java.util.Map;
 
 import org.archive.io.warc.WARCWriter;
@@ -49,6 +50,10 @@ implements CoreAttributeConstants {
 
     public CrawledBytesHistotable() {
         super();
+    }
+
+    protected CrawledBytesHistotable(Comparator<String> comparator) {
+        super(comparator);
     }
 
     @SuppressWarnings("unchecked")

--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -1705,7 +1705,6 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
         kryo.autoregister(org.apache.commons.httpclient.NameValuePair.class);
         kryo.autoregister(org.apache.commons.httpclient.NameValuePair[].class);
         kryo.autoregister(FetchType.class);
-        kryo.setRegistrationOptional(true);
     }
     
     /**

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchStats.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchStats.java
@@ -20,6 +20,7 @@ package org.archive.modules.fetcher;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -62,6 +63,15 @@ public class FetchStats extends CrawledBytesHistotable implements Serializable, 
     }
 
     protected long lastSuccessTime;
+
+    public FetchStats() {
+        super();
+    }
+
+    // Kryo constructor
+    public FetchStats(Comparator<String> comparator) {
+        super(comparator);
+    }
 
     public synchronized void tally(CrawlURI curi, Stage stage) {
         switch(stage) {

--- a/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
+++ b/modules/src/main/java/org/archive/modules/forms/HTMLForm.java
@@ -19,6 +19,7 @@
 
 package org.archive.modules.forms;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -165,7 +166,7 @@ public class HTMLForm {
         }
     }
 
-    public static class NameValue {
+    public static class NameValue implements Serializable {
         public String name, value;
         public NameValue(String name, String value) {
             this.name = name;

--- a/modules/src/main/java/org/archive/modules/net/CrawlHost.java
+++ b/modules/src/main/java/org/archive/modules/net/CrawlHost.java
@@ -29,6 +29,9 @@ import java.nio.ByteBuffer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.archive.bdb.AutoKryo;
 import org.archive.modules.fetcher.FetchStats;
 import org.archive.util.IdentityCacheable;
@@ -75,7 +78,7 @@ public class CrawlHost implements Serializable, FetchStats.HasFetchStats, Identi
 
     // Used when bandwith constraint are used
     private long earliestNextURIEmitTime = 0;
-    
+
     /** 
      * Create a new CrawlHost object.
      *
@@ -245,26 +248,24 @@ public class CrawlHost implements Serializable, FetchStats.HasFetchStats, Identi
          * holds hostname, but heritrix doesn't use that; and retrieving it can
          * result in dns lookup, so we don't serialize it.
          */
-        kryo.register(Inet4Address.class, new Serializer() {
+        kryo.register(Inet4Address.class, new Serializer<Inet4Address>() {
+
             @Override
-            public void writeObjectData(ByteBuffer buffer, Object object) {
-                Inet4Address i4a = (Inet4Address) object;
-                kryo.writeObject(buffer, i4a.getAddress());
+            public void write(Kryo kryo, Output output, Inet4Address inet4Address) {
+                kryo.writeObject(output, inet4Address.getAddress());
             }
-            
+
             @Override
-            @SuppressWarnings("unchecked")
-            public <T> T readObjectData(ByteBuffer buffer, Class<T> type) {
-                byte[] address = kryo.readObject(buffer, byte[].class);
+            public Inet4Address read(Kryo kryo, Input input, Class<? extends Inet4Address> aClass) {
+                byte[] address = kryo.readObject(input, byte[].class);
                 try {
-                    return (T) InetAddress.getByAddress(address);
+                    return (Inet4Address) InetAddress.getByAddress(address);
                 } catch (UnknownHostException e) {
                     throw new RuntimeException(e);
                 }
             }
         });
         kryo.autoregister(byte[].class);
-        kryo.setRegistrationOptional(true);
     }
     
     //

--- a/modules/src/main/java/org/archive/modules/net/CrawlServer.java
+++ b/modules/src/main/java/org/archive/modules/net/CrawlServer.java
@@ -320,7 +320,6 @@ public class CrawlServer implements Serializable, FetchStats.HasFetchStats, Iden
         kryo.register(CrawlServer.class);
         kryo.autoregister(FetchStats.class); 
         kryo.autoregister(Robotstxt.class);
-        kryo.setRegistrationOptional(true); 
     }
     
     //

--- a/modules/src/main/java/org/archive/modules/net/RobotsDirectives.java
+++ b/modules/src/main/java/org/archive/modules/net/RobotsDirectives.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.archive.bdb.AutoKryo;
 
-import com.esotericsoftware.kryo.serialize.ReferenceFieldSerializer;
 
 /**
  * Represents the directives that apply to a user-agent (or set of
@@ -83,9 +82,9 @@ public class RobotsDirectives implements Serializable {
     
     // Kryo support
     public static void autoregisterTo(AutoKryo kryo) {
-        kryo.register(RobotsDirectives.class, new ReferenceFieldSerializer(kryo, RobotsDirectives.class));
+        kryo.register(RobotsDirectives.class);
+        kryo.useReferencesFor(RobotsDirectives.class);
         kryo.autoregister(ConcurrentSkipListSet.class); // now used instead of PrefixSet in RobotsDirectives
-        kryo.setRegistrationOptional(true); 
     }
 
 }

--- a/modules/src/main/java/org/archive/modules/net/Robotstxt.java
+++ b/modules/src/main/java/org/archive/modules/net/Robotstxt.java
@@ -261,6 +261,5 @@ public class Robotstxt implements Serializable {
         kryo.autoregister(HashMap.class);
         kryo.autoregister(LinkedList.class);
         kryo.autoregister(RobotsDirectives.class);
-        kryo.setRegistrationOptional(true); 
     }
 }

--- a/modules/src/test/java/org/archive/modules/net/CrawlHostTest.java
+++ b/modules/src/test/java/org/archive/modules/net/CrawlHostTest.java
@@ -22,8 +22,9 @@ package org.archive.modules.net;
 import java.io.ByteArrayInputStream;
 import java.io.ObjectInputStream;
 import java.net.InetAddress;
-import java.nio.ByteBuffer;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import junit.framework.TestCase;
 
 import org.archive.bdb.AutoKryo;
@@ -56,11 +57,10 @@ public class CrawlHostTest extends TestCase {
         CrawlHost crawlHost0 = new CrawlHost(localhost.getHostName());
         crawlHost0.setIP(localhost, 431243);
 
-        ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
+        Output buffer = new Output(1024, -1);
         kryo.writeObject(buffer, crawlHost0);
-        buffer.flip();
-        
-        CrawlHost crawlHost1 = kryo.readObject(buffer, CrawlHost.class);
+
+        CrawlHost crawlHost1 = kryo.readObject(new Input(buffer.toBytes()), CrawlHost.class);
 
         TestCase.assertEquals(crawlHost0.getClass(), crawlHost1.getClass());
         TestCase.assertEquals(crawlHost0, crawlHost1);

--- a/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
+++ b/modules/src/test/java/org/archive/modules/net/RobotstxtTest.java
@@ -22,8 +22,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.ByteBuffer;
 
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import junit.framework.TestCase;
 
 import org.archive.bdb.AutoKryo;
@@ -192,10 +193,9 @@ public class RobotstxtTest extends TestCase {
             RobotsDirectives db = rt.getDirectivesFor("b", false);
             assertTrue("user-agent a and b shares the same RobotsDirectives before serialization", da == db);
         }
-        ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
+        Output buffer = new Output(1024, -1);
         kryo.writeObject(buffer, rt);
-        buffer.flip();
-        Robotstxt rt2 = kryo.readObject(buffer, Robotstxt.class);
+        Robotstxt rt2 = kryo.readObject(new Input(buffer.toBytes()), Robotstxt.class);
         assertNotNull(rt2);
         {
             RobotsDirectives da = rt2.getDirectivesFor("a", false);


### PR DESCRIPTION
This eliminates a few more very old dependencies that aren't in Maven Central.

Our direct usage of the unsupported sun.reflect.ReflectionFactory JDK API (which newer compilers complain about) is no longer needed as Kryo now has a SerializingInstantiatorStrategy that does roughly the same thing.