### PR TITLE
Add a more general support for inferred path discovery

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTTP.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTTP.java
@@ -19,6 +19,9 @@
 
 package org.archive.modules.extractor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.httpclient.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.CrawlURI.FetchType;
@@ -39,15 +42,33 @@ public class ExtractorHTTP extends Extractor {
     }
 
     /** should all HTTP URIs be used to infer a link to the site's root? */
-    protected boolean inferRootPage = false; 
+    protected boolean inferRootPage = false;
+    /**
+     * @deprecated Deprecated in favor of {@link #getInferPaths()} which allows the specification of arbitrary
+     *             paths and can be overridden with sheets. 
+     */
     public boolean getInferRootPage() {
         return inferRootPage;
     }
+    /**
+     * @deprecated Deprecated in favor of {@link #setInferPaths(List)} which allows the specification of arbitrary
+     *             paths and can be overridden with sheets. 
+     */
     public void setInferRootPage(boolean inferRootPage) {
         this.inferRootPage = inferRootPage;
     }
 
-
+    {
+    	setInferPaths(new ArrayList<>());
+    }
+    @SuppressWarnings("unchecked")
+    public List<String> getInferPaths() {
+    	return (List<String>) kp.get("inferPaths");
+    }
+    public void setInferPaths(List<String> inferPaths) {
+        kp.put("inferPaths", inferPaths);
+    }
+    
     @Override
     protected boolean shouldProcess(CrawlURI uri) {
         if (uri.getFetchStatus() <= 0) {
@@ -67,8 +88,11 @@ public class ExtractorHTTP extends Extractor {
 
         // try /favicon.ico for every HTTP(S) URI
         addOutlink(curi, "/favicon.ico", LinkContext.INFERRED_MISC, Hop.INFERRED);
-        if(getInferRootPage()) {
+        if (getInferRootPage()) {
             addOutlink(curi, "/", LinkContext.INFERRED_MISC, Hop.INFERRED);
+        }
+        for (String inferPath : getInferPaths()) {
+            addOutlink(curi, inferPath, LinkContext.INFERRED_MISC, Hop.INFERRED);
         }
     }
 


### PR DESCRIPTION
ExtractorHTTP already extracts per-host favicon.ico by inference and can be set to also discover hosts' root page (```/```). This PR adds a list of paths that should be inferred to exist for each host.

The motivation for this was the need to check if a site has a sitemap (```/sitemap.xml```) even when one isn't listed in the ```robots.txt``` file. We've encountered several instances of this. Rather than just adding in one more hard-coded path, it seems better to make this configurable.

The existing config for discovering the root path has been marked deprecated in favor of this new setting, but it continues to function as before. So, existing configuration should not be affected by any of these changes.

Given that discovery of the ```favicon.ico``` is hard-coded in and not configurable, it remains unaffected. I judge the impact of changing this as too disruptive, but ideally these inferences could all be managed through this new list. Indeed, if not for the ```favicon.ico``` legacy, I might instead suggest that this functionality be broken off into a new "ExtractorInference" as all this is unrelated to the extraction of links in the HTTP response headers.