### PR TITLE
Reset CrawlURI status for hasPrerequisite() so that it isn't preserved between attempts

### DIFF
--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -813,6 +813,7 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
         this.httpRecorder = null;
         this.fetchStatus = S_UNATTEMPTED;
         this.setPrerequisite(false);
+        this.clearPrerequisiteUri();
         this.contentSize = UNCALCULATED;
         this.contentLength = UNCALCULATED;
         // Clear 'links extracted' flag.


### PR DESCRIPTION
This was merged into our internal prod branch for some time but the merge to master was forgotten. This fixes the behavior of the `CrawlURI.hasPrerequisite()` check which incorrectly only tells us whether a CrawlURI ever had a prerequisite, instead of whether there is a pending prerequisite.