### PR TITLE
Remove joda-time

### DIFF
--- a/commons/src/main/java/org/archive/io/Arc2Warc.java
+++ b/commons/src/main/java/org/archive/io/Arc2Warc.java
@@ -23,6 +23,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -50,10 +52,6 @@ import org.archive.uid.RecordIDGenerator;
 import org.archive.uid.UUIDGenerator;
 import org.archive.util.FileUtils;
 import org.archive.util.anvl.ANVLRecord;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.ISODateTimeFormat;
-
 
 /**
  * Convert ARCs to (sortof) WARCs.
@@ -61,6 +59,8 @@ import org.joda.time.format.ISODateTimeFormat;
  * @version $Date$ $Revision$
  */
 public class Arc2Warc {
+    private static final DateTimeFormatter ARC_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+            .withZone(ZoneOffset.UTC);
     protected RecordIDGenerator generator = new UUIDGenerator();
     
     private static void usage(HelpFormatter formatter, Options options,
@@ -156,10 +156,8 @@ public class Arc2Warc {
 
        // convert ARC date to WARC-Date format
        String arcDateString = r.getHeader().getDate();
-       String warcDateString = DateTimeFormat.forPattern("yyyyMMddHHmmss")
-           .withZone(DateTimeZone.UTC)
-               .parseDateTime(arcDateString)
-                   .toString(ISODateTimeFormat.dateTimeNoMillis());
+
+       String warcDateString = DateTimeFormatter.ISO_DATE_TIME.format(ARC_DATE_FORMAT.parse(arcDateString));
        recordInfo.setCreate14DigitDate(warcDateString);
 
        ANVLRecord ar = new ANVLRecord();

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -70,11 +70,6 @@
 			<artifactId>org.restlet.ext.crypto</artifactId>
 			<version>2.4.0</version>
 		</dependency>
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>1.6</version>
-		</dependency>
 		<!-- jaxb is no longer included in jdk11+ -->
 		<dependency>
 			<groupId>javax.xml.bind</groupId>

--- a/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
@@ -148,7 +148,7 @@ public class CrawlJobModel extends LinkedHashMap<String, Object> implements Seri
     }
     public String getLastLaunchTime(){
         long ago = System.currentTimeMillis()
-                - crawlJob.getLastLaunch().getMillis();
+                - crawlJob.getLastLaunch().toEpochMilli();
         return ArchiveUtils.formatMillisecondsToConventional(ago, 2);
     }
     /*


### PR DESCRIPTION
joda-time has been deprecated since the release of the Java Time API (JSR-310) in JDK 8. It was only used in two classes and these usages are trivially replaced with their java.time equivalents.