### PR TITLE
Remove maven.restlet.com repository

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -11,13 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Heritrix 3: 'engine' subproject</name>
 
-	<repositories>
-		<repository>
-			<id>maven-restlet</id>
-			<url>https://maven.restlet.com</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.archive.heritrix</groupId>


### PR DESCRIPTION
It seems to have moved to maven.restlet.talend.com but the restlet artifacts are in Central anyway so we don't need it.