### PR TITLE
Set default value for ConfigurableExtractorJS strict property

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
@@ -43,6 +43,9 @@ public class ConfigurableExtractorJS extends ExtractorJS {
     public void setStrict(boolean strict) {
         kp.put("strictMode", strict);
     }
+    {
+    	setStrict(false);
+    }
 
     /** Maximum length of extracted potential URLs */
     public int getMaximumCandidateLength() {


### PR DESCRIPTION
As is crawls will run normally if the strict value is set explicitly, but if it is omitted (intending default behavior) the extractor is rendered effectively inoperative.