### PR TITLE
Bump kafka from 0.9.0.0 to kafka-clients 3.8.0

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -70,8 +70,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_2.10</artifactId>
-			<version>0.9.0.0</version>
+			<artifactId>kafka-clients</artifactId>
+			<version>3.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.rethinkdb</groupId>


### PR DESCRIPTION
Direct vulnerabilities:
[CVE-2018-1288](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1288)

Vulnerabilities from dependencies:
[CVE-2023-44981](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44981)
[CVE-2019-0201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-0201)
[CVE-2018-8012](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8012)
[CVE-2017-5637](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5637)