### PR TITLE
Force strict if URL matching regex.

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
@@ -7,29 +7,38 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.archive.modules.CrawlURI;
+
 /**
  * <p>Subclasses the standard ExtractorJS to add some configuration option. All options default to
- * the standard behavior of {@link ExtractorJS}. All configuration options can be overridden on
- * a per-sheet basis.</p>
+ * the standard behavior of {@link ExtractorJS}. 
  * 
  * <p>
  * The configuration options are:
  * <ul>
  *   <li>
  *   	<b>strict</b>: Enables strict mode where only non-relative URLs are extracted. Any 
- *      extracted potential URLs not starting with a scheme are ignored.
+ *      extracted potential URLs not starting with a scheme are ignored. Can be overriden on a per-sheet 
+ *      basis.
  *   </li>
  *   <li>
  *   	<b>maximumCandidateLength</b>: Maximum length of extracted potential URLs. Any string longer than
- *      this will be ignored. 
+ *      this will be ignored. Can be overriden on a per-sheet basis.
  *   </li>
  *   <li>
  *   	<b>rejectRelativeIgnoreSet</b>: A set of literal strings that should never be considered.
- *      Any extracted potential URLs matching a value in this set will be ignored. 
+ *      Any extracted potential URLs matching a value in this set will be ignored. Can not be overriden
+ *      on a per-sheet basis. 
  *   </li>
  *   <li>
  *   	<b>rejectRelativeMatchingRegexList</b>: A list of regular expressions. Any extracted 
- *      potential URLs matching a regular expression on this list will be ignored. 
+ *      potential URLs matching a regular expression on this list will be ignored. Can not be overriden
+ *      on a per-sheet basis. 
+ *   </li>
+ *   <li>
+ *   	<b>forceStrictIfUrlMatchingRegexList</b>: A list of regular expressions. Any URL that matches 
+ *      one or more of the regular expressions on this list will be processed in strict mode, with only 
+ *      absolute URLs extracted, not any relative ones. Can not be overriden on a per-sheet basis. 
  *   </li>
  * </ul>
  * </p> 
@@ -60,7 +69,7 @@ public class ConfigurableExtractorJS extends ExtractorJS {
      * The list of regular expressions to evalute potential <em>relative</em> url against, rejecting any that match.
      */
     private List<String> rejectRelativeMatchingRegexList = new ArrayList<>();
-    private List<Pattern> rejectRelativeMatchingRegexListPatterns;
+    private List<Pattern> rejectRelativeMatchingRegexListPatterns = new ArrayList<>();
 
     public List<String> getRejectRelativeMatchingRegexList() {
         return rejectRelativeMatchingRegexList;
@@ -76,6 +85,27 @@ public class ConfigurableExtractorJS extends ExtractorJS {
 		rejectRelativeMatchingRegexListPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
     }
     
+
+    /**
+     * Any URL that matches any of the regular expressions on this list will
+     * be processed in strict mode, with only absolute URL extracted, not any relative ones. 
+     */
+    private List<String> forceStrictIfUrlMatchingRegexList = new ArrayList<>();
+    private List<Pattern> forceStrictIfUrlMatchingRegexListPatterns = new ArrayList<>();
+
+    public List<String> getForceStrictIfUrlMatchingRegexList() {
+        return forceStrictIfUrlMatchingRegexList;
+    }
+    public void setforceStrictIfUrlMatchingRegexList(List<String> patterns) {
+    	forceStrictIfUrlMatchingRegexList = patterns;
+    	forceStrictIfUrlMatchingRegexListPatterns = new ArrayList<>();
+    	for (String p : patterns) {
+    		forceStrictIfUrlMatchingRegexListPatterns.add(Pattern.compile(p, Pattern.CASE_INSENSITIVE));
+    	}
+    }
+    public void addForceStrictIfUrlMatchingRegex(String pattern) {
+    	forceStrictIfUrlMatchingRegexListPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
+    }
 
 
     /**
@@ -96,10 +126,10 @@ public class ConfigurableExtractorJS extends ExtractorJS {
     
     
     @Override
-    protected boolean shouldAddUri(String candidate) {
+    protected boolean shouldAddUri(CrawlURI curi, String candidate) {
     	return passesMaxLength(candidate) &&
-    			passesStrictMode(candidate) && 
-    			super.shouldAddUri(candidate) &&  
+    			passesStrictMode(curi, candidate) && 
+    			super.shouldAddUri(curi, candidate) &&  
         		!isOnRejectList(candidate);
     }
     
@@ -109,8 +139,19 @@ public class ConfigurableExtractorJS extends ExtractorJS {
     	return max <= 0 || candidate.length() <= max;
     }
     
-    protected boolean passesStrictMode(String candidate) {
-    	return !getStrict() || hasScheme(candidate);
+    protected boolean passesStrictMode(CrawlURI curi, String candidate) {
+    	boolean strict = getStrict();
+    	if (!strict) {
+    		for (Pattern p : forceStrictIfUrlMatchingRegexListPatterns) {
+    			if (p.matcher(curi.getURI()).matches()) {
+    				// Force strict
+    				strict = true;
+    				break;
+    			}
+    		}
+    	}
+    	
+    	return !strict || hasScheme(candidate);
     }
     
     protected boolean hasScheme(String candidate) {

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
@@ -173,7 +173,7 @@ public class ExtractorJS extends ContentExtractor {
         }
         candidate = UriUtils.speculativeFixup(candidate, curi.getUURI());
 
-        if (shouldAddUri(candidate)) {
+        if (shouldAddUri(curi, candidate)) {
             try {
                 int max = ext.getExtractorParameters().getMaxOutlinks();
                 if (handlingJSFile) {
@@ -193,7 +193,7 @@ public class ExtractorJS extends ContentExtractor {
         return false;
     }
     
-    protected boolean shouldAddUri(String candidate) {
+    protected boolean shouldAddUri(CrawlURI curi, String candidate) {
     	return UriUtils.isVeryLikelyUri(candidate);
     }
     


### PR DESCRIPTION
Adds a list of regular expressions that URLs being processed by the ConfigurableExtractorJS are evaluated against. If they match the extraction is performed in strict mode, even if strict mode is not set.

This requires a minor modification to ExtractorJS so that the CrawlURI is passed to the shouldAddUri method that ConfigurableExtractorJS overrides.

This PR was motivated by common Wordpress JSON files like: https://frettatiminn.is/wp-json/wp/v2/media/52942

They contain many absolute URLs, so excluding them may well cause missed content, but they also list filename etc. that can not be resolved relative to the JSON file itself and should just be ignored.

Adding a regex of ```^.*/wp-json/.*$``` to the new setting will address this.

It may also be of value to be able to apply this rule based on content-type.

