### PR TITLE
Upgrade to Spring 6.1 (and Java 17 minimum)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk: [8, 11, 17, 21, 23]
+        jdk: [17, 21, 23]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -212,6 +212,6 @@
 	</build>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.version>5.3.39</spring.version>
+		<spring.version>6.1.15</spring.version>
 	</properties>
 </project>

--- a/commons/src/main/java/org/archive/bdb/AutoKryo.java
+++ b/commons/src/main/java/org/archive/bdb/AutoKryo.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
-import org.objenesis.strategy.SerializingInstantiatorStrategy;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /**
  * Extensions to Kryo to let classes control their own registration, suggest
@@ -23,7 +23,7 @@ public class AutoKryo extends Kryo {
 
     public AutoKryo() {
         super();
-        setInstantiatorStrategy(new DefaultInstantiatorStrategy(new SerializingInstantiatorStrategy()));
+        setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
     }
 
     public void autoregister(Class<?> type) {

--- a/commons/src/main/java/org/archive/checkpointing/Checkpoint.java
+++ b/commons/src/main/java/org/archive/checkpointing/Checkpoint.java
@@ -30,11 +30,11 @@ import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.archive.spring.ConfigPath;
+import org.archive.spring.Required;
 import org.archive.util.ArchiveUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Required;
 
 /**
  * Represents a single checkpoint, by its name and main store directory.

--- a/commons/src/main/java/org/archive/spring/ConfigPath.java
+++ b/commons/src/main/java/org/archive/spring/ConfigPath.java
@@ -41,7 +41,6 @@ import java.io.Serializable;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import org.springframework.beans.factory.annotation.Required;
 
 /**
  * A filesystem path, as a bean, for the convenience of configuration

--- a/commons/src/main/java/org/archive/spring/PathSharingContext.java
+++ b/commons/src/main/java/org/archive/spring/PathSharingContext.java
@@ -68,18 +68,28 @@ public class PathSharingContext extends FileSystemXmlApplicationContext {
 
     public PathSharingContext(String configLocation) throws BeansException {
         super(configLocation);
+        init();
     }
     public PathSharingContext(String[] configLocations, ApplicationContext parent) throws BeansException {
         super(configLocations, parent);
+        init();
     }
     public PathSharingContext(String[] configLocations, boolean refresh, ApplicationContext parent) throws BeansException {
         super(configLocations, refresh, parent);
+        init();
     }
     public PathSharingContext(String[] configLocations, boolean refresh) throws BeansException {
         super(configLocations, refresh);
+        init();
     }
     public PathSharingContext(String[] configLocations) throws BeansException {
         super(configLocations);
+        init();
+    }
+
+    private void init() {
+        // enforce @Required annotation
+        addBeanFactoryPostProcessor(beanFactory -> beanFactory.addBeanPostProcessor(new RequiredAnnotationBeanPostProcessor()));
     }
 
     public String getPrimaryConfigurationPath() {
@@ -201,4 +211,6 @@ public class PathSharingContext extends FileSystemXmlApplicationContext {
         }
         return data;
     }
+
+
 }

--- a/commons/src/main/java/org/archive/spring/Required.java
+++ b/commons/src/main/java/org/archive/spring/Required.java
@@ -1,0 +1,16 @@
+package org.archive.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Replacement for the removed Spring @Required annotation. Do not use this in new beans,
+ * use constructor injection instead. This only exists to avoid breaking existing crawl profiles.
+ */
+@Deprecated
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Required {
+}

--- a/commons/src/main/java/org/archive/spring/RequiredAnnotationBeanPostProcessor.java
+++ b/commons/src/main/java/org/archive/spring/RequiredAnnotationBeanPostProcessor.java
@@ -1,0 +1,40 @@
+package org.archive.spring;
+
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import java.lang.reflect.Method;
+
+public class RequiredAnnotationBeanPostProcessor implements BeanPostProcessor {
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeanInitializationException {
+        for (Method method : bean.getClass().getMethods()) {
+            if (method.isAnnotationPresent(Required.class)) {
+                Method getter;
+
+                if (method.getName().startsWith("set")) {
+                    String getterName = "get" + method.getName().substring(3);
+                    try {
+                        getter = bean.getClass().getMethod(getterName);
+                    } catch (NoSuchMethodException e) {
+                        throw new BeanInitializationException("Missing getter for @Required property on bean: " +
+                                                              beanName + " for method: " + method.getName());
+                    }
+                } else {
+                    getter = method;
+                }
+
+                try {
+                    Object value = getter.invoke(bean);
+                    if (value == null) {
+                        throw new BeanInitializationException("Property not set for bean: " + beanName +
+                                                              " on method: " + method.getName());
+                    }
+                } catch (Exception e) {
+                    throw new BeanInitializationException("Error processing @Required for bean: " + beanName, e) {};
+                }
+            }
+        }
+        return bean;
+    }
+}

--- a/commons/src/main/java/org/archive/spring/Sheet.java
+++ b/commons/src/main/java/org/archive/spring/Sheet.java
@@ -28,8 +28,6 @@ import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.beans.factory.annotation.Required;
-
 
 /**
  * Collection of overrides: alternative values for object properties

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -6,8 +6,8 @@ System Requirements
 
 Heritrix is primarily used on Linux. It may run on other platforms but is not regularly tested or supported on them.
 
-Heritrix requires Java 8 or 11. We recommend using your Linux distribution's OpenJDK 11 packages. Alternatively up to
-date builds of OpenJDK 8 and 11 for several platforms are available from `Adoptium <https://adoptium.net/>`__.
+Heritrix requires 17 or later. We recommend using your Linux distribution's OpenJDK packages. Alternatively up to
+date builds of OpenJDK for several platforms are available from `Adoptium <https://adoptium.net/>`__.
 
 The default Java heap for Heritrix is 256MB RAM, which is usually suitable for crawls that range over hundreds of
 hosts.  Assign more of your available RAM to the heap if you are crawling thousands of hosts or experience Java

--- a/engine/src/main/java/org/archive/crawler/spring/DecideRuledSheetAssociation.java
+++ b/engine/src/main/java/org/archive/crawler/spring/DecideRuledSheetAssociation.java
@@ -20,8 +20,8 @@
 package org.archive.crawler.spring;
 
 import org.archive.modules.deciderules.DecideRule;
+import org.archive.spring.Required;
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.core.Ordered;
 
 /**

--- a/engine/src/main/java/org/archive/crawler/spring/SurtPrefixesSheetAssociation.java
+++ b/engine/src/main/java/org/archive/crawler/spring/SurtPrefixesSheetAssociation.java
@@ -19,9 +19,9 @@
  
 package org.archive.crawler.spring;
 
-import java.util.List;
+import org.archive.spring.Required;
 
-import org.springframework.beans.factory.annotation.Required;
+import java.util.List;
 
 /**
  * SheetAssociation applied on the basis of matching SURT prefixes. 

--- a/modules/src/main/java/org/archive/modules/ScriptedProcessor.java
+++ b/modules/src/main/java/org/archive/modules/ScriptedProcessor.java
@@ -29,10 +29,10 @@ import javax.script.ScriptException;
 
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReadSource;
+import org.archive.spring.Required;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 

--- a/modules/src/main/java/org/archive/modules/deciderules/ScriptedDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/ScriptedDecideRule.java
@@ -30,10 +30,10 @@ import javax.script.ScriptException;
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReadSource;
 import org.archive.modules.CrawlURI;
+import org.archive.spring.Required;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 

--- a/modules/src/main/java/org/archive/modules/deciderules/ViaSurtPrefixedDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/ViaSurtPrefixedDecideRule.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.archive.modules.CrawlURI;
+import org.archive.spring.Required;
 import org.archive.util.SurtPrefixSet;
-import org.springframework.beans.factory.annotation.Required;
 
 /**
  * Rule applies the configured decision for any URI which has a 'via' whose

--- a/modules/src/main/java/org/archive/modules/seeds/TextSeedModule.java
+++ b/modules/src/main/java/org/archive/modules/seeds/TextSeedModule.java
@@ -36,12 +36,12 @@ import org.archive.modules.CrawlURI;
 import org.archive.modules.SchedulingConstants;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
+import org.archive.spring.Required;
 import org.archive.spring.WriteTarget;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.DevUtils;
 import org.archive.util.iterator.LineReadingIterator;
 import org.archive.util.iterator.RegexLineIterator;
-import org.springframework.beans.factory.annotation.Required;
 
 /**
  * Module that announces a list of seeds from a text source (such

--- a/pom.xml
+++ b/pom.xml
@@ -395,9 +395,9 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<jetty.version>9.4.56.v20240826</jetty.version>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,16 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+				<configuration>
+					<!-- Retain method parameter names. This is required for some autowiring like AbstractFrontier.setScope()
+					https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.1-Release-Notes#parameter-name-retention -->
+					<parameters>true</parameters>
+				</configuration>
+			</plugin>
+			<plugin>
 				<!-- install source jars to maven repo
 				http://maven.apache.org/plugins/maven-source-plugin/usage.html -->
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Spring 5 is no longer receiving open source security updates. Spring 6 requires Java 17 so we may as well set that as the new source version level.

The `@Required` annotation has been removed and they suggest using constructor injection instead. But changing to that would break existing Heritrix crawl XML files. We could just live without it but it's nice having the error message enforced at config load time rather than risking the job crashing with a more cryptic error later so I reimplemented an equivalent annotation, but marked deprecated to avoid in new beans.