### PR TITLE
Bump slf4j from 1.6.6 to 2.0.16 and include adapter to fix startup warning

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -85,13 +85,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.6</version>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.6.6</version>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -86,13 +86,11 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 			<version>${slf4j.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -64,13 +64,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.6</version>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.6.6</version>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<jetty.version>9.4.56.v20240826</jetty.version>
+		<slf4j.version>2.0.16</slf4j.version>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.release>17</maven.compiler.release>


### PR DESCRIPTION
Heritrix doesn't use slf4j itself but some dependencies like crawlercommons do. Since we weren't including a slf4j adapter, it would print an annoying warning on startup.

This updates to the latest version and includes the slf4j to java.util.logging adapter in the build which eliminates the warning message and should ensure anything logged to slf4j is controllable through Heritrix's logging config.