### PR TITLE
Bump restlet from 2.4.0 to 2.5.0-rc1 and remove restlet repository

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -44,14 +44,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.restlet.jse</groupId>
+            <groupId>org.restlet</groupId>
             <artifactId>org.restlet</artifactId>
-            <version>2.4.0</version>
+            <version>${restlet.version}</version>
         </dependency>
 		<dependency>
-			<groupId>org.restlet.jse</groupId>
+			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet.ext.jetty</artifactId>
-			<version>2.4.0</version>
+			<version>${restlet.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.eclipse.jetty</groupId>
@@ -60,15 +60,15 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.restlet.jse</groupId>
+			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet.ext.xml</artifactId>
-			<version>2.4.0</version>
+			<version>${restlet.version}</version>
 		</dependency>
 		<dependency>
 			<!-- for HTTP Digest auth -->
-			<groupId>org.restlet.jse</groupId>
+			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet.ext.crypto</artifactId>
-			<version>2.4.0</version>
+			<version>${restlet.version}</version>
 		</dependency>
 		<!-- jaxb is no longer included in jdk11+ -->
 		<dependency>
@@ -118,5 +118,6 @@
 	</build>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<restlet.version>2.5.0-rc1</restlet.version>
 	</properties>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -11,13 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Heritrix 3: 'engine' subproject</name>
 
-	<repositories>
-		<repository>
-			<id>maven-restlet</id>
-			<url>https://maven.restlet.talend.com</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.archive.heritrix</groupId>

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
@@ -137,7 +137,7 @@ public class EngineApplication extends Application {
     protected class EngineStatusService extends StatusService {
 
         @Override
-        public Representation getRepresentation(Status status, Request request, Response response) {
+        public Representation toRepresentation(Status status, Request request, Response response) {
             StringWriter st = new StringWriter();
             PrintWriter pw = new PrintWriter(st);
             if(status.getCode()==404){


### PR DESCRIPTION
We're getting very close to having all Heritrix dependencies in Maven Central.