### PR TITLE
ExtractorHTML: Add obeyRelNofollow option

### DIFF
--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -306,6 +306,7 @@ http://example.example/example
   <!-- <property name="maxElementLength" value="1024" /> -->
   <!-- <property name="maxAttributeNameLength" value="1024" /> -->
   <!-- <property name="maxAttributeValueLength" value="16384" /> -->
+  <!-- <property name="obeyRelNofollow" value="false" /> -->
  </bean>
  <bean id="extractorCss" class="org.archive.modules.extractor.ExtractorCSS">
  </bean> 

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.groovy
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.groovy
@@ -281,6 +281,7 @@ http://example.example/example
         // maxElementLength = 1024
         // maxAttributeNameLength = 1024
         // maxAttributeValueLength = 16384
+        // obeyRelNofollow = false
     }
     extractorCss(ExtractorCSS)
     extractorJs(ExtractorJS)

--- a/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
@@ -142,6 +142,13 @@ public class JerichoExtractorHTML extends ExtractorHTML {
                 if (rel != null) {
                     processLinkTagWithRel(curi, attrValue, rel);
                 }
+            } else if ("a".equals(elementName)) {
+                String rel = attributes.getValue("rel");
+                if (rel != null && getObeyRelNofollow() && TextUtils.matches("(?i).*\\bnofollow\\b.*", rel)) {
+                    if (logger.isLoggable(Level.FINEST)) logger.finest("ignoring nofollow link: " + attrValue);
+                } else {
+                    processLink(curi, attrValue, context);
+                }
             } else {
                 // other HREFs treated as links
                 processLink(curi, attrValue, context);

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -19,11 +19,8 @@
 
 package org.archive.modules.extractor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
@@ -721,6 +718,31 @@ public class ExtractorHTMLTest extends StringExtractorTestBase {
         Collections.sort(actualLinks);
 
         assertEquals(expectedLinks, actualLinks);
+    }
+
+    public void testDisobeyRelNofollow() throws URIException {
+        String html = "<a href=/normal><a href=/nofollow rel=nofollow><a href=/both><a href=/both rel=nofollow>";
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance("https://www.example.org/"));
+        getExtractor().setObeyRelNofollow(false);
+        getExtractor().extract(curi, html);
+        Set<String> links = curi.getOutLinks().stream().map(CrawlURI::getURI).collect(Collectors.toSet());
+        assertEquals(Set.of("https://www.example.org/both",
+                "https://www.example.org/normal",
+                "https://www.example.org/nofollow"), links);
+    }
+
+    public void testRelNofollow() throws URIException {
+        String html = "<a href=/normal></a><a href=/nofollow rel=nofollow></a><a href=/both></a>" +
+                      "<a href=/both rel=nofollow></a>" +
+                      "<a href=/multi1 rel='noopener nofollow'></a>" +
+                      "<a href=/multi2 rel=\"nofollow nopener\"></a>" +
+                      "<a href=/multi3 rel='noopener nofollow noentry'></a>";
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance("https://www.example.org/"));
+        getExtractor().setObeyRelNofollow(true);
+        getExtractor().extract(curi, html);
+        Set<String> links = curi.getOutLinks().stream().map(CrawlURI::getURI).collect(Collectors.toSet());
+        assertEquals(Set.of("https://www.example.org/both",
+                "https://www.example.org/normal"), links);
     }
 
     private void genericCrawl(CrawlURI curi, CharSequence cs,String[] dest){


### PR DESCRIPTION
When enabled this option causes regular links annotated with rel=nofollow to not be extracted. This is useful for sites that use rel=nofollow to hint crawler traps.