### PR TITLE
Suppress 'WARNING Cookie rejected' messages in job.log

### DIFF
--- a/dist/src/main/conf/logging.properties
+++ b/dist/src/main/conf/logging.properties
@@ -4,6 +4,7 @@
 .level = WARNING
 # ...and even less from the too-chatty-with-WARNINGs HttpClient library...
 org.apache.commons.httpclient.level = SEVERE
+org.apache.http.client.protocol.ResponseProcessCookies.level = SEVERE
 org.restlet.Component.LogFilter.level = SEVERE
 org.eclipse.jetty.log.level = SEVERE
 org.apache.pdfbox = SEVERE


### PR DESCRIPTION
These log messages started unhelpfully being copied into job.log in 3.6.0 due to the slf4j fix. They indicate the server sent a set-cookie header with an incorrect domain. It's correct for Heritrix to reject them. They're very common and not an indication of a problem with Heritrix itself so it's unnecessarily alarming to log them as job warnings.

Fixes: 533d762db53e ("Include slf4j-jdk14 in heritrix-engine ...")