### PR TITLE
fix: ObjectIdentityBdbManualCacheTest.java fails with -DrunSlowTests=…

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -204,7 +204,7 @@
 					<excludes>
 						<exclude>**/Test*.java</exclude>
 					</excludes>
-					<argLine>-Xmx1g</argLine>
+					<argLine>-Xmx1g --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -204,7 +204,7 @@
 					<excludes>
 						<exclude>**/Test*.java</exclude>
 					</excludes>
-					<argLine>-Xmx1g --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED</argLine>
+					<argLine>-Xmx1g</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/commons/src/main/java/org/archive/bdb/KryoBinding.java
+++ b/commons/src/main/java/org/archive/bdb/KryoBinding.java
@@ -21,9 +21,12 @@ package org.archive.bdb;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import com.esotericsoftware.kryo.util.Pool;
 import com.sleepycat.bind.EntryBinding;
 import com.sleepycat.je.DatabaseEntry;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Binding for use with BerkeleyDB-JE that uses Kryo serialization rather
@@ -39,6 +42,7 @@ public class KryoBinding<K> implements EntryBinding<K> {
     Pool<AutoKryo> kryoPool = new Pool<AutoKryo>(true, false, POOL_SIZE) {
         protected AutoKryo create () {
             AutoKryo kryo = new AutoKryo();
+            kryo.addDefaultSerializer(AtomicInteger.class, DefaultSerializers.AtomicIntegerSerializer.class);
             kryo.autoregister(baseClass);
             kryo.setRegistrationRequired(false);
             kryo.setWarnUnregisteredClasses(true);


### PR DESCRIPTION
…true on Java 9+

Accessibility changed in Java 9 and prevents the AtomicInteger used in this test from being accessed. The test appears to be valid, but the implementation won't work without additional JVM options. See also: https://stackoverflow.com/a/41265267