### PR TITLE
feat: Add serializer for Histotable used by HighestUriPrecedenceProvider

### DIFF
--- a/commons/src/main/java/org/archive/bdb/KryoBinding.java
+++ b/commons/src/main/java/org/archive/bdb/KryoBinding.java
@@ -22,9 +22,11 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.util.Pool;
 import com.sleepycat.bind.EntryBinding;
 import com.sleepycat.je.DatabaseEntry;
+import org.archive.util.Histotable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -43,6 +45,8 @@ public class KryoBinding<K> implements EntryBinding<K> {
         protected AutoKryo create () {
             AutoKryo kryo = new AutoKryo();
             kryo.addDefaultSerializer(AtomicInteger.class, DefaultSerializers.AtomicIntegerSerializer.class);
+            kryo.addDefaultSerializer(Histotable.class, FieldSerializer.class);
+            kryo.register(org.archive.util.Histotable.class);
             kryo.autoregister(baseClass);
             kryo.setRegistrationRequired(false);
             kryo.setWarnUnregisteredClasses(true);


### PR DESCRIPTION
This fixes an issue when using the `HighestUriPrecedenceProvider` where the nested generics in the `Histotable` fail to serialize properly. 

Sample config:
```
  <bean id="frontier" class="org.archive.crawler.frontier.BdbFrontier">
    <property name="queuePrecedencePolicy">
      <bean class="org.archive.crawler.frontier.precedence.HighestUriQueuePrecedencePolicy"/>
    </property>
    <property name="maxRetries" value="40"/>
    <property name="retryDelaySeconds" value="180"/>
    <property name="dumpPendingAtClose" value="true"/>
  </bean>
  ```