### PR TITLE
Update to Jetty 12.0.16 and Restlet 2.6.0-M2

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -31,8 +31,8 @@
 			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-servlet</artifactId>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-servlet</artifactId>
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
@@ -45,12 +45,6 @@
 			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet.ext.jetty</artifactId>
 			<version>${restlet.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-client</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.restlet</groupId>
@@ -109,6 +103,6 @@
 	</build>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<restlet.version>2.5.0</restlet.version>
+		<restlet.version>2.6.0-m2</restlet.version>
 	</properties>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -45,6 +45,14 @@
 			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet.ext.jetty</artifactId>
 			<version>${restlet.version}</version>
+			<exclusions>
+				<!-- exclude quiche native library as it's very large and we don't use Restlet's
+				HTTP/3 support currently -->
+				<exclusion>
+					<groupId>org.mortbay.jetty.quiche</groupId>
+					<artifactId>jetty-quiche-native</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.restlet</groupId>

--- a/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/JobResource.java
@@ -135,7 +135,8 @@ public class JobResource extends BaseResource {
         // conditional on whether /anypath/ service is present?
         String fullPath = f.getAbsolutePath();
         fullPath = fullPath.replace(File.separatorChar, '/');
-        return "../../anypath/" + fullPath;
+        if (!fullPath.startsWith("/")) fullPath = "/" + fullPath;
+        return "../../anypath" + fullPath;
     }
 
     @Override

--- a/engine/src/main/java/org/archive/crawler/restlet/NoSniHostCheckHttpsServerHelper.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/NoSniHostCheckHttpsServerHelper.java
@@ -1,0 +1,38 @@
+package org.archive.crawler.restlet;
+
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.ServerConnector;
+import org.restlet.Server;
+import org.restlet.ext.jetty.HttpsServerHelper;
+
+/**
+ * Subclass of HttpServerHelper which disables the SNI host check. This is to main backwards
+ * compatibility with the existing Heritrix ad-hoc certificates that don't include a hostname.
+ */
+public class NoSniHostCheckHttpsServerHelper extends HttpsServerHelper {
+    public NoSniHostCheckHttpsServerHelper(Server server) {
+        super(server);
+    }
+
+    @Override
+    protected org.eclipse.jetty.server.Server getWrappedServer() {
+        org.eclipse.jetty.server.Server wrappedServer = super.getWrappedServer();
+        disableSniHostCheck(wrappedServer);
+        return wrappedServer;
+    }
+
+    private static void disableSniHostCheck(org.eclipse.jetty.server.Server jettyServer) {
+        for (var connector : jettyServer.getConnectors()) {
+            if (connector instanceof ServerConnector serverConnector) {
+                var connectionFactory = serverConnector.getConnectionFactory(HttpConnectionFactory.class);
+                if (connectionFactory != null) {
+                    var secureRequestCustomizer = connectionFactory.getHttpConfiguration().getCustomizer(SecureRequestCustomizer.class);
+                    if (secureRequestCustomizer != null) {
+                        secureRequestCustomizer.setSniHostCheck(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/models/CrawlJobModel.java
@@ -17,6 +17,7 @@ import org.archive.checkpointing.Checkpoint;
 import org.archive.crawler.framework.CrawlController.State;
 import org.archive.crawler.framework.CrawlJob;
 import org.archive.crawler.reporting.Report;
+import org.archive.crawler.restlet.JobResource;
 import org.archive.spring.ConfigPath;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.FileUtils;
@@ -134,10 +135,16 @@ public class CrawlJobModel extends LinkedHashMap<String, Object> implements Seri
             }
         }
         this.put("checkpointFiles",checkpointFiles);
-        if (crawlJob.hasApplicationContext())
-            this.put("alertLogFilePath",crawlJob.getCrawlController().getLoggerModule().getAlertsLogPath().getFile().getAbsolutePath());
-        if(crawlJob.isRunning() || (crawlJob.hasApplicationContext() && !crawlJob.isLaunchable()))
-            this.put("crawlLogFilePath",crawlJob.getCrawlController().getLoggerModule().getCrawlLogPath().getFile().getAbsolutePath());
+        if (crawlJob.hasApplicationContext()) {
+            File file = crawlJob.getCrawlController().getLoggerModule().getAlertsLogPath().getFile();
+            this.put("alertLogFilePath", file.getAbsolutePath());
+            this.put("alertLogFileUrl", JobResource.getHrefPath(file, crawlJob));
+        }
+        if(crawlJob.isRunning() || (crawlJob.hasApplicationContext() && !crawlJob.isLaunchable())) {
+            File file = crawlJob.getCrawlController().getLoggerModule().getCrawlLogPath().getFile();
+            this.put("crawlLogFilePath", file.getAbsolutePath());
+            this.put("crawlLogFileUrl", JobResource.getHrefPath(file, crawlJob));
+        }
         this.put("reports", generateReports());
     }
     public String formatBytes(Long bytes){
@@ -209,7 +216,7 @@ public class CrawlJobModel extends LinkedHashMap<String, Object> implements Seri
             configMap.put("key", key);
             configMap.put("name", cp.getName());
             configMap.put("path",FileUtils.tryToCanonicalize(cp.getFile()).getAbsolutePath());
-            configMap.put("url",baseRef+"engine/anypath/"+configMap.get("path"));
+            configMap.put("url", baseRef + JobResource.getHrefPath(cp.getFile(), crawlJob));
             configMap.put("editable", EDIT_FILTER.accept(cp.getFile()));
             referencedPaths.add(configMap);
         }

--- a/engine/src/main/resources/org/archive/crawler/restlet/Job.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Job.ftl
@@ -190,7 +190,7 @@
 							<i>none</i>
 							<#else>
 							${job.alertCount}
-							<a href="/engine/anypath/${job.alertLogFilePath}?format=paged&amp;pos=-1&amp;lines=-128">tail alert log...</a></li>
+							<a href="${job.alertLogFileUrl}?format=paged&amp;pos=-1&amp;lines=-128">tail alert log...</a></li>
 							</#if>
 						</td>
 					</tr>
@@ -272,7 +272,7 @@
 <#if (job.isRunning || (job.hasApplicationContext && !job.isLaunchable))>
 <div class="row">
 	<div class="large-12 columns">
-		<h3>Crawl Log <a href="/engine/anypath/${job.crawlLogFilePath}?format=paged&amp;pos=-1&amp;lines=-128&amp;reverse=y">more</a></h3>
+		<h3>Crawl Log <a href="${job.crawlLogFileUrl}?format=paged&amp;pos=-1&amp;lines=-128&amp;reverse=y">more</a></h3>
 		<div class="row">
 			<div class="large-12 columns">
 				<div class="log-viewer" >
@@ -306,7 +306,7 @@
 						</td>
 						<td>
 							<#if config.path??>
-							<a href='/engine/anypath/${config.path}<#if config.path?ends_with("log")>?format=paged&amp;pos=-1&amp;lines=-128&amp;reverse=y</#if>'>${config.path}</a><#if config.editable> [<a href="/engine/anypath/${config.path}?format=textedit">edit</a>]</#if>
+							<a href='${config.url}<#if config.path?ends_with("log")>?format=paged&amp;pos=-1&amp;lines=-128&amp;reverse=y</#if>'>${config.path}</a><#if config.editable> [<a href="${config.url}?format=textedit">edit</a>]</#if>
 							<#else>
 							<i>unset</i>
 							</#if>

--- a/engine/src/test/java/org/archive/crawler/selftest/CheckpointSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/CheckpointSelfTest.java
@@ -22,10 +22,11 @@ package org.archive.crawler.selftest;
 import java.io.IOException;
 
 import org.archive.crawler.framework.CrawlJob;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 
 
 /**
@@ -89,8 +90,6 @@ public class CheckpointSelfTest extends SelfTestBase {
         sc.setHost(HOST);
         sc.setPort(port);
         server.addConnector(sc);
-        ServletHandler servletHandler = new ServletHandler();
-        server.setHandler(servletHandler);
 
         RandomServlet random = new RandomServlet();
         random.setHost(HOST);
@@ -99,8 +98,10 @@ public class CheckpointSelfTest extends SelfTestBase {
         random.setMaxHops(MAX_HOPS);
         random.setPathRoot("random");
 
-        ServletHolder holder = new ServletHolder(random);
-        servletHandler.addServletWithMapping(holder, "/random/*");
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.addServlet(random, "/random/*");
+        server.setHandler(contextHandler);
+
         server.start();
         return server;
     }

--- a/engine/src/test/java/org/archive/crawler/selftest/FormAuthSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/FormAuthSelfTest.java
@@ -19,14 +19,15 @@
 
 package org.archive.crawler.selftest;
 
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,19 +67,16 @@ public class FormAuthSelfTest
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
-        rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
-        
-        ServletHandler servletHandler = new ServletHandler();
-        
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] {
-                rhandler, 
-                servletHandler,
-                new DefaultHandler() });
-        server.setHandler(handlers);
-        
-        ServletHolder holder = new ServletHolder(new FormAuthServlet());
-        servletHandler.addServletWithMapping(holder, "/login/*");
+        ResourceFactory resourceFactory = ResourceFactory.of(server);
+        rhandler.setBaseResource(resourceFactory.newResource(getSrcHtdocs().toPath().toAbsolutePath()));
+
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.addServlet(FormAuthServlet.class, "/login/*");
+
+        server.setHandler(new Handler.Sequence(
+                rhandler,
+                contextHandler,
+                new DefaultHandler()));
 
         this.httpServer = server;
         this.httpServer.start();

--- a/engine/src/test/java/org/archive/crawler/selftest/FormAuthServlet.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/FormAuthServlet.java
@@ -18,12 +18,12 @@
  */
 package org.archive.crawler.selftest;
 
-import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 
 /**
@@ -36,8 +36,8 @@ public class FormAuthServlet extends HttpServlet {
 
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) 
-    throws ServletException, IOException {
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException {
         String username = req.getParameter("username");
         String password = req.getParameter("password");
         if (username.equals("Mr. Happy Pants") && password.equals("xyzzy")) {

--- a/engine/src/test/java/org/archive/crawler/selftest/FormLoginSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/FormLoginSelfTest.java
@@ -19,14 +19,13 @@
 
 package org.archive.crawler.selftest;
 
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,20 +64,14 @@ public class FormLoginSelfTest
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
-        rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
-        
-        ServletHandler servletHandler = new ServletHandler();
-        
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] {
-                rhandler, 
-                servletHandler,
-                new DefaultHandler() });
-        server.setHandler(handlers);
-        
-        ServletHolder holder = new ServletHolder(new FormAuthServlet());
-        servletHandler.addServletWithMapping(holder, "/login/*");
+        ResourceFactory resourceFactory = ResourceFactory.of(server);
+        rhandler.setBaseResource(resourceFactory.newResource(getSrcHtdocs().toPath().toAbsolutePath()));
 
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.addServlet(FormAuthServlet.class, "/login/*");
+
+        server.setHandler(new Handler.Sequence(rhandler, contextHandler, new DefaultHandler()));
+        
         this.httpServer = server;
         this.httpServer.start();
     }

--- a/engine/src/test/java/org/archive/crawler/selftest/HttpAuthSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/HttpAuthSelfTest.java
@@ -24,15 +24,16 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
+import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
+import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.*;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.security.Password;
 
 /**
@@ -64,10 +65,7 @@ public class HttpAuthSelfTest
     protected void startHttpServer() throws Exception {
         Server server = new Server();
         
-        Constraint constraint = new Constraint();
-        constraint.setName(Constraint.__BASIC_AUTH);;
-        constraint.setRoles(new String[]{"user","admin","moderator"});
-        constraint.setAuthenticate(true);
+        Constraint constraint = Constraint.from("user","admin","moderator");
 
         ConstraintMapping cm = new ConstraintMapping();
         cm.setConstraint(constraint);
@@ -87,17 +85,13 @@ public class HttpAuthSelfTest
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
-        rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
+        ResourceFactory resourceFactory = ResourceFactory.of(server);
+        rhandler.setBaseResource(resourceFactory.newResource(getSrcHtdocs().toPath().toAbsolutePath()));
         
-        ServletHandler servletHandler = new ServletHandler();
-        
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] {
-                securityHandler, 
-                rhandler, 
-                servletHandler,
-                new DefaultHandler() });
-        server.setHandler(handlers);
+        server.setHandler(new Handler.Sequence(
+                securityHandler,
+                rhandler,
+                new DefaultHandler()));
 
         this.httpServer = server;
         this.httpServer.start();

--- a/engine/src/test/java/org/archive/crawler/selftest/RandomServlet.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/RandomServlet.java
@@ -18,14 +18,14 @@
  */
 package org.archive.crawler.selftest;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Random;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 
 /**
@@ -104,8 +104,8 @@ public class RandomServlet extends HttpServlet {
 
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) 
-    throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException {
         resp.setContentType("text/html");
         RandomServletLinkWriter rslw = new RandomServletLinkWriter();
      

--- a/engine/src/test/java/org/archive/crawler/selftest/SelfTestBase.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/SelfTestBase.java
@@ -41,9 +41,11 @@ import org.archive.util.TmpDirTestCase;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 
 /**
  * Base class for 'self tests', integrations tests formatted as unit 
@@ -187,11 +189,10 @@ public abstract class SelfTestBase extends TmpDirTestCase {
         sc.setPort(7777);
         server.addConnector(sc);
         ResourceHandler rhandler = new ResourceHandler();
-        rhandler.setResourceBase(getSrcHtdocs().getAbsolutePath());
-        
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] { rhandler, new DefaultHandler() });
-        server.setHandler(handlers);
+        ResourceFactory resourceFactory = ResourceFactory.of(server);
+        rhandler.setBaseResource(resourceFactory.newResource(getSrcHtdocs().toPath().toAbsolutePath()));
+
+        server.setHandler(new Handler.Sequence(rhandler, new DefaultHandler()));
         
         this.httpServer = server;
         server.start();

--- a/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/StatisticsSelfTest.java
@@ -48,12 +48,12 @@ public class StatisticsSelfTest extends SelfTestBase {
         StatisticsTracker stats = heritrix.getEngine().getJob("selftest-job").getCrawlController().getStatisticsTracker();
         assertNotNull(stats);
         assertEquals(13, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(7999, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
+        assertEquals(7960, (long) stats.getCrawledBytes().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES) - stats.getBytesPerHost("dns:"));
 
         assertEquals(3, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(2216, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(2202, (long) stats.getServerCache().getHostFor("127.0.0.1").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(10, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
-        assertEquals(5783, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
+        assertEquals(5758, (long) stats.getServerCache().getHostFor("localhost").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_CONTENT_BYTES));
         assertEquals(0, (long) stats.getServerCache().getHostFor("dns:").getSubstats().get(CrawledBytesHistotable.WARC_NOVEL_URLS));
     }
 
@@ -66,17 +66,17 @@ public class StatisticsSelfTest extends SelfTestBase {
         sourceStats = stats.getSourceStats("http://127.0.0.1:7777/a.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(2216l, (long) sourceStats.get("novel"));
+        assertEquals(2202l, (long) sourceStats.get("novel"));
         assertEquals(3l, (long) sourceStats.get("novelCount"));
-        assertEquals(2216l, (long) sourceStats.get("warcNovelContentBytes"));
+        assertEquals(2202l, (long) sourceStats.get("warcNovelContentBytes"));
         assertEquals(3l, (long) sourceStats.get("warcNovelUrls"));
 
         sourceStats = stats.getSourceStats("http://localhost:7777/b.html");
         assertNotNull(sourceStats);
         assertEquals(4, sourceStats.keySet().size());
-        assertEquals(5783l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
+        assertEquals(5758l, (long) sourceStats.get("novel") - stats.getBytesPerHost("dns:"));
         assertEquals(11l, (long) sourceStats.get("novelCount"));
-        assertEquals(5783l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
+        assertEquals(5758l, (long) sourceStats.get("warcNovelContentBytes") - stats.getBytesPerHost("dns:"));
         assertEquals(10l, (long) sourceStats.get("warcNovelUrls"));
     }
 

--- a/engine/src/test/java/org/archive/crawler/selftest/UserAgentServlet.java
+++ b/engine/src/test/java/org/archive/crawler/selftest/UserAgentServlet.java
@@ -19,13 +19,13 @@
  
 package org.archive.crawler.selftest;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Enumeration;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author pjack
@@ -37,8 +37,8 @@ public class UserAgentServlet extends HttpServlet {
     private String from;
     
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) 
-    throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException {
         Enumeration<?> e = req.getHeaderNames();
         while (e.hasMoreElements()) {
             String name = (String)e.nextElement();

--- a/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
+++ b/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
@@ -27,10 +27,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import junit.framework.TestCase;
 
 import org.apache.commons.httpclient.URIException;
@@ -44,19 +44,18 @@ import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.util.Recorder;
 import org.archive.util.TmpDirTestCase;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.SessionHandler;
+import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
+import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.*;
 import org.eclipse.jetty.security.authentication.FormAuthenticator;
-import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.handler.RequestLogHandler;
-import org.eclipse.jetty.server.session.DefaultSessionCache;
-import org.eclipse.jetty.server.session.NullSessionDataStore;
-import org.eclipse.jetty.server.session.SessionCache;
-import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.session.DefaultSessionCache;
+import org.eclipse.jetty.session.NullSessionDataStore;
+import org.eclipse.jetty.session.SessionCache;
 import org.eclipse.jetty.util.security.Password;
 
 /* Somewhat redundant to org.archive.crawler.selftest.FormAuthSelfTest, but 
@@ -169,7 +168,7 @@ public class FormAuthTest extends TestCase {
         getFetcher().process(curi);
         logger.info('\n' + httpRequestString(curi) + "\n\n" + rawResponseString(curi));
         assertEquals(302, curi.getFetchStatus());
-        assertTrue(curi.getHttpResponseHeader("Location").startsWith("http://localhost:7779/login.html"));
+        assertTrue(curi.getHttpResponseHeader("Location").startsWith("/login.html"));
 
         PreconditionEnforcer preconditionEnforcer = new PreconditionEnforcer();
         preconditionEnforcer.setServerCache(getFetcher().getServerCache());
@@ -188,7 +187,7 @@ public class FormAuthTest extends TestCase {
         getFetcher().process(loginUri);
         logger.info('\n' + httpRequestString(loginUri) + "\n\n" + rawResponseString(loginUri));
         assertEquals(302, loginUri.getFetchStatus()); // 302 on successful login
-        assertEquals("http://localhost:7779/auth/1", loginUri.getHttpResponseHeader("location"));
+        assertEquals("/auth/1", loginUri.getHttpResponseHeader("location"));
 
         curi = makeCrawlURI("http://localhost:7779/auth/1");
         getFetcher().process(curi);
@@ -206,29 +205,28 @@ public class FormAuthTest extends TestCase {
             + "<div> <input type='submit' /> </div>" + "</form>" + "</body>"
             + "</html>";
 
-    protected static class FormAuthTestHandler extends SessionHandler {
+    protected static class FormAuthTestServlet extends HttpServlet {
 
-        public FormAuthTestHandler() {
+        public FormAuthTestServlet() {
             super();
         }
 
         @Override
-        public void doHandle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            String target = request.getRequestURI();
             if (target.endsWith("/set-cookie")) {
-                response.addCookie(new javax.servlet.http.Cookie("test-cookie-name", "test-cookie-value"));
+                response.addCookie(new Cookie("test-cookie-name", "test-cookie-value"));
             }
             
             if (target.equals("/login.html")) {
                 response.setContentType("text/html;charset=US-ASCII");
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.getOutputStream().write(LOGIN_HTML.getBytes("US-ASCII"));
-                ((Request)request).setHandled(true);
             } else {
                 response.setContentType("text/plain;charset=US-ASCII");
                 response.setDateHeader("Last-Modified", 0);
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.getOutputStream().write(DEFAULT_PAYLOAD_STRING.getBytes("US-ASCII"));
-                ((Request)request).setHandled(true);
             }
         }
     }
@@ -236,9 +234,7 @@ public class FormAuthTest extends TestCase {
     protected static SecurityHandler makeAuthWrapper(Authenticator authenticator,
             final String role, String realm, final String login,
             final String password) {
-        Constraint constraint = new Constraint();
-        constraint.setRoles(new String[] { role });
-        constraint.setAuthenticate(true);
+        Constraint constraint = Constraint.from(role);
 
         ConstraintMapping constraintMapping = new ConstraintMapping();
         constraintMapping.setConstraint(constraint);
@@ -266,27 +262,19 @@ public class FormAuthTest extends TestCase {
         sc.setHost("127.0.0.1");
         sc.setPort(7779);
         server.addConnector(sc);
-        
-        HandlerCollection handlers = new HandlerCollection();
-        handlers.addHandler(new FormAuthTestHandler());
-        RequestLogHandler requestLogHandler = new RequestLogHandler();
-        NCSARequestLog requestLog = new NCSARequestLog();
-        requestLogHandler.setRequestLog(requestLog);
-        handlers.addHandler(requestLogHandler);
-        
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        context.addServlet(FormAuthTestServlet.class, "/");
+
         FormAuthenticator formAuthenticatrix = new FormAuthenticator("/login.html", null, false);
 
         SecurityHandler authWrapper = makeAuthWrapper(formAuthenticatrix,
                 FORM_AUTH_ROLE, FORM_AUTH_REALM, FORM_AUTH_LOGIN,
                 FORM_AUTH_PASSWORD);
-        authWrapper.setHandler(handlers);
 
-        SessionHandler sessionHandler = new SessionHandler();
-        SessionCache cache = new DefaultSessionCache(sessionHandler);
-        cache.setSessionDataStore(new NullSessionDataStore());
-        sessionHandler.setSessionCache(cache);
-        sessionHandler.setHandler(authWrapper);
-        server.setHandler(sessionHandler);
+        context.setSecurityHandler(authWrapper);
+        server.setHandler(context);
         
         server.start();
     }

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -49,8 +49,14 @@
 			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-servlet</artifactId>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-servlet</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-proxy</artifactId>
 			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
@@ -41,10 +41,10 @@ import java.util.logging.Logger;
 
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.NoHttpResponseException;
@@ -63,12 +63,12 @@ import org.archive.net.UURIFactory;
 import org.archive.util.Recorder;
 import org.archive.util.TmpDirTestCase;
 import org.bbottema.javasocksproxyserver.SocksServer;
-import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.proxy.ConnectHandler;
-import org.eclipse.jetty.proxy.ProxyServlet;
+import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.ee10.proxy.ProxyServlet;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.junit.*;
 
 public class FetchHTTPTest {
@@ -270,7 +270,7 @@ public class FetchHTTPTest {
 
         // check that we got the expected response and the fetcher did its thing
         assertEquals(401, curi.getFetchStatus());
-        assertEquals("basic realm=\"basic-auth-realm\"", curi.getHttpResponseHeader("WWW-Authenticate"));
+        assertEquals("Basic realm=\"basic-auth-realm\"", curi.getHttpResponseHeader("WWW-Authenticate"));
         assertTrue(curi.getCredentials().contains(basicAuthCredential));
         assertTrue(curi.getHttpAuthChallenges() != null && curi.getHttpAuthChallenges().containsKey("basic"));
         
@@ -461,8 +461,9 @@ public class FetchHTTPTest {
         Server httpProxyServer = new Server(new InetSocketAddress("localhost", 7877));
         ConnectHandler connectHandler = new ConnectHandler();
         httpProxyServer.setHandler(connectHandler);
-        ServletContextHandler context = new ServletContextHandler(connectHandler, "/",
-                ServletContextHandler.SESSIONS);
+        ServletContextHandler context = new ServletContextHandler( "/", ServletContextHandler.SESSIONS);
+        connectHandler.setHandler(context);
+
         ServletHolder proxyServlet = new ServletHolder(TestProxyServlet.class);
         context.addServlet(proxyServlet, "/*");
         context.setAttribute("proxy-user", user);

--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 		<doclint>none</doclint>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<groovy.version>4.0.26</groovy.version>
-		<jetty.version>9.4.57.v20241219</jetty.version>
+		<jetty.version>12.0.16</jetty.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
The Jetty API has changed, which mostly affects test code.

Jetty now does a strict SNI host check which unfortunately causes it to return "Error 400 Invalid SNI" for our existing ad-hoc certificates. For now, I've disabled it to avoid breaking existing deployments but added a --sni-host-check command-line option so you can re-enable it if you've configured your own certificate appropriately.