### PR TITLE
Upgrade webarchive-commons from 1.3.0 to 2.0.1 (removes httpclient 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,22 @@
   incompatibilities, allowing CodeMirror’s own find function to be re-enabled for reliable text search of content far
   outside the viewport.
 
+#### Removals
+
+- **Removed Apache HttpClient 3**: If you have custom Heritrix modules you may need to update the following
+  class references in your code:
+  
+  | Removed                                                   | Replacement                          |
+  |-----------------------------------------------------------|--------------------------------------|
+  | `org.apache.commons.httpclient.URIException`              | `org.archive.url.URIException`       |
+  | `org.apache.commons.httpclient.Header`                    | `org.archive.format.http.HttpHeader` |
+
+  Note that Apache HttpClient 4 (`org.apache.http`) was not removed.
+
 #### Dependency Upgrades
 
 - **codemirror**: 2.23 → 6.0.1
+- **webarchive-commons**: 1.3.0 → 2.0.1
 
 ## [3.9.0](https://github.com/internetarchive/heritrix3/releases/tag/3.9.0)
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -145,13 +145,7 @@
 		<dependency>
 			<groupId>org.netpreserve.commons</groupId>
 			<artifactId>webarchive-commons</artifactId>
-			<version>1.3.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>2.0.1</version>
 		</dependency>
 
 		<dependency>

--- a/commons/src/main/java/org/archive/io/Arc2Warc.java
+++ b/commons/src/main/java/org/archive/io/Arc2Warc.java
@@ -38,7 +38,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.archive.io.arc.ARCConstants;
+import org.archive.format.arc.ARCConstants;
 import org.archive.io.arc.ARCReader;
 import org.archive.io.arc.ARCReaderFactory;
 import org.archive.io.arc.ARCRecord;

--- a/commons/src/main/java/org/archive/io/Warc2Arc.java
+++ b/commons/src/main/java/org/archive/io/Warc2Arc.java
@@ -37,7 +37,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.archive.io.arc.ARCWriter;
 import org.archive.io.arc.WriterPoolSettingsData;
-import org.archive.io.warc.WARCConstants;
+import org.archive.format.warc.WARCConstants;
 import org.archive.io.warc.WARCReader;
 import org.archive.io.warc.WARCReaderFactory;
 import org.archive.io.warc.WARCRecord;

--- a/commons/src/main/java/org/archive/net/UURI.java
+++ b/commons/src/main/java/org/archive/net/UURI.java
@@ -26,7 +26,7 @@ import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.url.UsableURI;
 
 import com.esotericsoftware.kryo.Kryo;

--- a/commons/src/main/java/org/archive/net/UURIFactory.java
+++ b/commons/src/main/java/org/archive/net/UURIFactory.java
@@ -18,7 +18,7 @@
  */
 package org.archive.net;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.url.UsableURI;
 import org.archive.url.UsableURIFactory;
 

--- a/commons/src/main/java/org/archive/surt/SURTTokenizer.java
+++ b/commons/src/main/java/org/archive/surt/SURTTokenizer.java
@@ -18,7 +18,7 @@
  */
 package org.archive.surt;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.archive.util.ArchiveUtils;

--- a/commons/src/main/java/org/archive/util/UriUtils.java
+++ b/commons/src/main/java/org/archive/util/UriUtils.java
@@ -32,9 +32,9 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
 import org.apache.commons.codec.DecoderException;
-import org.apache.commons.httpclient.URIException;
 import org.archive.net.UURI;
 import org.archive.url.LaxURLCodec;
+import org.archive.url.URIException;
 
 
 /**

--- a/commons/src/test/java/org/archive/surt/SURTTokenizerTest.java
+++ b/commons/src/test/java/org/archive/surt/SURTTokenizerTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.surt;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
+++ b/contrib/src/main/java/org/archive/crawler/frontier/AMQPUrlReceiver.java
@@ -32,7 +32,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.event.AMQPUrlReceivedEvent;
 import org.archive.crawler.event.CrawlStateEvent;
 import org.archive.crawler.postprocessor.CandidatesProcessor;

--- a/contrib/src/main/java/org/archive/modules/AMQPPublishProcessor.java
+++ b/contrib/src/main/java/org/archive/modules/AMQPPublishProcessor.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.event.AMQPUrlPublishedEvent;
 import org.archive.crawler.frontier.AMQPUrlReceiver;
 import org.archive.modules.fetcher.FetchHTTP;

--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -46,7 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.framework.CrawlController;
 import org.archive.crawler.frontier.AMQPUrlReceiver;
 import org.archive.crawler.reporting.CrawlerLoggerModule;

--- a/contrib/src/main/java/org/archive/modules/extractor/KnowledgableExtractorJS.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/KnowledgableExtractorJS.java
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.exception.NestableRuntimeException;
 import org.archive.modules.CrawlURI;

--- a/contrib/src/test/java/org/archive/modules/extractor/ExtractorPDFContentTest.java
+++ b/contrib/src/test/java/org/archive/modules/extractor/ExtractorPDFContentTest.java
@@ -25,7 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;

--- a/contrib/src/test/java/org/archive/modules/extractor/ExtractorYoutubeFormatStreamTest.java
+++ b/contrib/src/test/java/org/archive/modules/extractor/ExtractorYoutubeFormatStreamTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/engine/src/main/java/org/archive/crawler/frontier/AbstractFrontier.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/AbstractFrontier.java
@@ -48,8 +48,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.URIException;
+import org.apache.http.HttpStatus;
 import org.archive.crawler.datamodel.UriUniqFilter.CrawlUriReceiver;
 import org.archive.crawler.event.CrawlStateEvent;
 import org.archive.crawler.framework.CrawlController;
@@ -68,6 +67,7 @@ import org.archive.modules.seeds.SeedListener;
 import org.archive.modules.seeds.SeedModule;
 import org.archive.spring.HasKeyedProperties;
 import org.archive.spring.KeyedProperties;
+import org.archive.url.URIException;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.ReportUtils;
 import org.archive.util.iterator.LineReadingIterator;

--- a/engine/src/main/java/org/archive/crawler/frontier/FrontierJournal.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/FrontierJournal.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.framework.Frontier;
 import org.archive.io.CrawlerJournal;
 import org.archive.modules.CrawlURI;

--- a/engine/src/main/java/org/archive/crawler/frontier/HostnameQueueAssignmentPolicy.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/HostnameQueueAssignmentPolicy.java
@@ -19,7 +19,7 @@
 
 package org.archive.crawler.frontier;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;

--- a/engine/src/main/java/org/archive/crawler/postprocessor/CandidatesProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/postprocessor/CandidatesProcessor.java
@@ -23,7 +23,7 @@ package org.archive.crawler.postprocessor;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_DEFERRED;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_PREREQUISITE_UNSCHEDULABLE_FAILURE;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.framework.Frontier;
 import org.archive.crawler.reporting.CrawlerLoggerModule;
 import org.archive.crawler.spring.SheetOverlaysManager;

--- a/engine/src/main/java/org/archive/crawler/postprocessor/DispositionProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/postprocessor/DispositionProcessor.java
@@ -30,7 +30,7 @@ import static org.archive.modules.fetcher.FetchStatusCodes.S_DEFERRED;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlMetadata;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;

--- a/engine/src/main/java/org/archive/crawler/prefetch/PreconditionEnforcer.java
+++ b/engine/src/main/java/org/archive/crawler/prefetch/PreconditionEnforcer.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.reporting.CrawlerLoggerModule;
 import org.archive.modules.CrawlMetadata;
 import org.archive.modules.CrawlURI;

--- a/engine/src/main/java/org/archive/crawler/reporting/CrawlerLoggerModule.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/CrawlerLoggerModule.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.checkpointing.Checkpoint;
 import org.archive.checkpointing.Checkpointable;
 import org.archive.crawler.framework.Engine;

--- a/engine/src/test/java/org/archive/crawler/datamodel/CrawlURITest.java
+++ b/engine/src/test/java/org/archive/crawler/datamodel/CrawlURITest.java
@@ -26,7 +26,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Path;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.SchedulingConstants;
 import org.archive.modules.extractor.LinkContext.SimpleLinkContext;

--- a/engine/src/test/java/org/archive/crawler/frontier/BdbMultipleWorkQueuesTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/BdbMultipleWorkQueuesTest.java
@@ -20,7 +20,7 @@ package org.archive.crawler.frontier;
 
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.SchedulingConstants;
 import org.archive.net.UURIFactory;

--- a/engine/src/test/java/org/archive/crawler/frontier/FrontierJournalTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/FrontierJournalTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.crawler.frontier;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/engine/src/test/java/org/archive/crawler/prefetch/QuotaEnforcerTest.java
+++ b/engine/src/test/java/org/archive/crawler/prefetch/QuotaEnforcerTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.BlockingQueue;
 
 import javax.management.openmbean.CompositeData;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.framework.CrawlerProcessorTestBase;
 import org.archive.crawler.framework.Frontier;
 import org.archive.crawler.framework.Frontier.FrontierGroup;

--- a/engine/src/test/java/org/archive/crawler/util/BdbUriUniqFilterTest.java
+++ b/engine/src/test/java/org/archive/crawler/util/BdbUriUniqFilterTest.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.FileUtils;
 import org.archive.crawler.datamodel.UriUniqFilter;
 import org.archive.modules.CrawlURI;

--- a/engine/src/test/java/org/archive/crawler/util/BloomUriUniqFilterTest.java
+++ b/engine/src/test/java/org/archive/crawler/util/BloomUriUniqFilterTest.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.datamodel.UriUniqFilter;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/engine/src/test/java/org/archive/crawler/util/FPUriUniqFilterTest.java
+++ b/engine/src/test/java/org/archive/crawler/util/FPUriUniqFilterTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.crawler.datamodel.UriUniqFilter;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/engine/src/test/java/org/archive/crawler/util/TopNSetTest.java
+++ b/engine/src/test/java/org/archive/crawler/util/TopNSetTest.java
@@ -19,7 +19,7 @@
  
 package org.archive.crawler.util;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
+++ b/engine/src/test/java/org/archive/modules/fetcher/FormAuthTest.java
@@ -33,7 +33,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.crawler.prefetch.PreconditionEnforcer;
 import org.archive.modules.CrawlMetadata;

--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -19,7 +19,7 @@
  
 package org.archive.modules;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.archive.bdb.AutoKryo;
 import org.archive.modules.credential.Credential;
@@ -1708,8 +1708,8 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
         kryo.autoregister(java.util.HashMap[].class); 
         kryo.autoregister(org.archive.modules.credential.HttpAuthenticationCredential.class);
         kryo.autoregister(org.archive.modules.credential.HtmlFormCredential.class);
-        kryo.autoregister(org.apache.commons.httpclient.NameValuePair.class);
-        kryo.autoregister(org.apache.commons.httpclient.NameValuePair[].class);
+        kryo.autoregister(org.apache.http.NameValuePair.class);
+        kryo.autoregister(org.apache.http.NameValuePair[].class);
         kryo.autoregister(FetchType.class);
     }
     

--- a/modules/src/main/java/org/archive/modules/Processor.java
+++ b/modules/src/main/java/org/archive/modules/Processor.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.archive.checkpointing.Checkpoint;
 import org.archive.checkpointing.Checkpointable;
 import org.archive.modules.credential.Credential;
@@ -31,6 +31,7 @@ import org.archive.modules.credential.HttpAuthenticationCredential;
 import org.archive.modules.deciderules.AcceptDecideRule;
 import org.archive.modules.deciderules.DecideResult;
 import org.archive.modules.deciderules.DecideRule;
+import org.archive.modules.fetcher.FetchStatusCodes;
 import org.archive.net.UURI;
 import org.archive.spring.HasKeyedProperties;
 import org.archive.spring.KeyedProperties;

--- a/modules/src/main/java/org/archive/modules/credential/HtmlFormCredential.java
+++ b/modules/src/main/java/org/archive/modules/credential/HtmlFormCredential.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;

--- a/modules/src/main/java/org/archive/modules/deciderules/AddRedirectFromRootServerToScope.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/AddRedirectFromRootServerToScope.java
@@ -19,7 +19,7 @@
 package org.archive.modules.deciderules;
 
 import java.util.logging.Logger;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;
 

--- a/modules/src/main/java/org/archive/modules/deciderules/ExternalGeoLocationDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/ExternalGeoLocationDecideRule.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.net.CrawlHost;
 import org.archive.modules.net.ServerCache;

--- a/modules/src/main/java/org/archive/modules/deciderules/ResourceNoLongerThanDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/ResourceNoLongerThanDecideRule.java
@@ -18,10 +18,8 @@
  */
 package org.archive.modules.deciderules;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.HttpMethod;
 import org.archive.modules.CrawlURI;
 
 /**

--- a/modules/src/main/java/org/archive/modules/extractor/Extractor.java
+++ b/modules/src/main/java/org/archive/modules/extractor/Extractor.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;
 import org.archive.net.UURI;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorCSS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorCSS.java
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorDOC.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorDOC.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReplayInputStream;
 import org.archive.io.SeekReader;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -35,7 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Ascii;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CoreAttributeConstants;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTTP.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTTP.java
@@ -22,7 +22,7 @@ package org.archive.modules.extractor;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.CrawlURI.FetchType;
 import org.archive.net.UURI;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorImpliedURI.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorImpliedURI.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.exception.NestableRuntimeException;
 import org.archive.io.ReplayCharSequence;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorMultipleRegex.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorMultipleRegex.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.fetcher.FetchStatusCodes;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorPDF.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorPDF.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.io.SinkHandlerLogThread;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
@@ -10,7 +10,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 
 public class ExtractorRobotsTxt extends ContentExtractor {

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
@@ -7,7 +7,7 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.ContentExtractor;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorURI.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorURI.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
 import org.apache.commons.codec.DecoderException;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.url.LaxURLCodec;
 import org.archive.net.UURI;

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorXML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorXML.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CrawlURI;

--- a/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.archive.modules.CoreAttributeConstants;

--- a/modules/src/main/java/org/archive/modules/extractor/UriErrorLoggerModule.java
+++ b/modules/src/main/java/org/archive/modules/extractor/UriErrorLoggerModule.java
@@ -19,7 +19,7 @@
 
 package org.archive.modules.extractor;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 
 /**

--- a/modules/src/main/java/org/archive/modules/fetcher/AbstractCookieStore.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/AbstractCookieStore.java
@@ -34,7 +34,7 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.CookieStore;
 import org.apache.http.cookie.Cookie;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 
 import javax.net.SocketFactory;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPCommand;
 import org.archive.io.RecordingInputStream;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP2.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP2.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.fetcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.http.client.CookieStore;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPCookieStore.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPCookieStore.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.fetcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.http.client.CookieStore;
 import org.archive.modules.CrawlURI;
 

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTPRequest.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchSFTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchSFTP.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.io.RecordingInputStream;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CrawlURI;

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchWhois.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchWhois.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.net.whois.WhoisClient;
 import org.archive.bdb.BdbModule;
 import org.archive.modules.CoreAttributeConstants;

--- a/modules/src/main/java/org/archive/modules/forms/FormLoginProcessor.java
+++ b/modules/src/main/java/org/archive/modules/forms/FormLoginProcessor.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.archive.checkpointing.Checkpointable;
 import org.archive.modules.CoreAttributeConstants;

--- a/modules/src/main/java/org/archive/modules/net/CrawlServer.java
+++ b/modules/src/main/java/org/archive/modules/net/CrawlServer.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.bdb.AutoKryo;
 import org.archive.modules.CrawlURI;

--- a/modules/src/main/java/org/archive/modules/net/RobotsPolicy.java
+++ b/modules/src/main/java/org/archive/modules/net/RobotsPolicy.java
@@ -21,7 +21,7 @@ package org.archive.modules.net;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 
 /**

--- a/modules/src/main/java/org/archive/modules/net/ServerCache.java
+++ b/modules/src/main/java/org/archive/modules/net/ServerCache.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.collections.Closure;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 
 /**

--- a/modules/src/main/java/org/archive/modules/seeds/TextSeedModule.java
+++ b/modules/src/main/java/org/archive/modules/seeds/TextSeedModule.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReadSource;
 import org.archive.modules.CrawlURI;

--- a/modules/src/main/java/org/archive/modules/writer/ARCWriterProcessor.java
+++ b/modules/src/main/java/org/archive/modules/writer/ARCWriterProcessor.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
-import org.archive.io.ArchiveFileConstants;
+import org.archive.format.ArchiveFileConstants;
 import org.archive.io.ReplayInputStream;
 import org.archive.io.WriterPoolMember;
 import org.archive.io.arc.ARCWriter;

--- a/modules/src/main/java/org/archive/state/ModuleTestBase.java
+++ b/modules/src/main/java/org/archive/state/ModuleTestBase.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Path;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.SerializationUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/canonicalize/FixupQueryStringTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/FixupQueryStringTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/RegexRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/RegexRuleTest.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 
 import javax.management.InvalidAttributeValueException;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/RulesCanonicalizationPolicyTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/RulesCanonicalizationPolicyTest.java
@@ -19,7 +19,7 @@
 
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/StripSessionCFIDsTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/StripSessionCFIDsTest.java
@@ -1,6 +1,6 @@
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.canonicalize.StripSessionCFIDs;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;

--- a/modules/src/test/java/org/archive/modules/canonicalize/StripSessionIDsTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/StripSessionIDsTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/StripUserinfoRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/StripUserinfoRuleTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/StripWWWNRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/StripWWWNRuleTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/canonicalize/StripWWWRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/canonicalize/StripWWWRuleTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.canonicalize;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.state.ModuleTestBase;
 import org.junit.jupiter.api.Test;
 

--- a/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/MatchesListRegexDecideRuleTest.java
@@ -1,6 +1,6 @@
 package org.archive.modules.deciderules;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURIFactory;
 import org.junit.jupiter.api.Test;

--- a/modules/src/test/java/org/archive/modules/deciderules/MatchesStatusCodeDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/MatchesStatusCodeDecideRuleTest.java
@@ -1,6 +1,6 @@
 package org.archive.modules.deciderules;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.LinkContext;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/deciderules/NotMatchesStatusCodeDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/NotMatchesStatusCodeDecideRuleTest.java
@@ -1,7 +1,6 @@
 package org.archive.modules.deciderules;
 
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.LinkContext;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/deciderules/ViaSurtPrefixedDecideRuleTest.java
+++ b/modules/src/test/java/org/archive/modules/deciderules/ViaSurtPrefixedDecideRuleTest.java
@@ -4,7 +4,7 @@ package org.archive.modules.deciderules;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.LinkContext;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/ExtractorHTMLTest.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlMetadata;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
+++ b/modules/src/test/java/org/archive/modules/extractor/JerichoExtractorHTMLTest.java
@@ -22,7 +22,7 @@ package org.archive.modules.extractor;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlMetadata;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURI;

--- a/modules/src/test/java/org/archive/modules/extractor/UnitTestUriLoggerModule.java
+++ b/modules/src/test/java/org/archive/modules/extractor/UnitTestUriLoggerModule.java
@@ -3,7 +3,7 @@ package org.archive.modules.extractor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 
 /**

--- a/modules/src/test/java/org/archive/modules/fetcher/CookieFetchHTTPIntegrationTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/CookieFetchHTTPIntegrationTest.java
@@ -32,7 +32,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections.Closure;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.FileUtils;
 import org.archive.bdb.BdbModule;
 import org.archive.modules.CrawlMetadata;

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
@@ -39,7 +39,7 @@ import javax.net.ssl.SSLException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.NoHttpResponseException;
 import org.archive.httpclient.ConfigurableX509TrustManager.TrustLevel;

--- a/modules/src/test/java/org/archive/modules/forms/FormLoginProcessorTest.java
+++ b/modules/src/test/java/org/archive/modules/forms/FormLoginProcessorTest.java
@@ -27,7 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.util.EntityUtils;

--- a/modules/src/test/java/org/archive/modules/net/ServerCacheTest.java
+++ b/modules/src/test/java/org/archive/modules/net/ServerCacheTest.java
@@ -18,7 +18,7 @@
  */
 package org.archive.modules.net;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.fetcher.DefaultServerCache;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;

--- a/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
+++ b/modules/src/test/java/org/archive/modules/recrawl/ContentDigestHistoryTest.java
@@ -49,7 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.FileUtils;
 import org.archive.bdb.BdbModule;
 import org.archive.format.warc.WARCConstants.WARCRecordType;


### PR DESCRIPTION
HttpClient 3 was discontinued in 2007 and triggers dependency security alerts. It's a bit painful to remove though, because UURI is built on it and URIException appears everywhere.

HttpClient 4 switched to java.net.URI which Heritrix has never been able to use because it disallows some URLs that browsers accept. For now I've just copied the old HttpClient URI implementation into webarchive-commons as a package-private class, with some minor tweaks so that it works without the other bits of HttpClient. We'll probably eventually need to replace the parser with one that follows the algorithm described in the WHATWG URL spec.