### PR TITLE
Add Browser processor using WebDriver BiDi

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -158,6 +158,11 @@
 			<artifactId>groovy</artifactId>
 			<version>${groovy.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-proxy</artifactId>
+			<version>${jetty.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/commons/src/main/java/org/archive/net/MitmProxy.java
+++ b/commons/src/main/java/org/archive/net/MitmProxy.java
@@ -1,0 +1,183 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.proxy.ProxyHandler;
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.handler.ConnectHandler;
+import org.eclipse.jetty.util.Callback;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.util.Map;
+
+import static org.eclipse.jetty.http.HttpHeader.ACCEPT_ENCODING;
+
+/**
+ * An HTTP proxy server which intercepts TLS and records or replays responses.
+ */
+public class MitmProxy {
+    private final SslConnectionFactory sslConnectionFactory = new SslConnectionFactory();
+    private final Server server = new Server(0);
+    private final RequestHandler requestHandler;
+
+    public MitmProxy(RequestHandler requestHandler) {
+        this.requestHandler = requestHandler;
+        sslConnectionFactory.getSslContextFactory().setKeyStorePath("adhoc.keystore");
+        sslConnectionFactory.getSslContextFactory().setKeyStorePassword("password");
+    }
+
+    public int getPort() {
+        try {
+            return ((InetSocketAddress) ((ServerSocketChannel) server.getConnectors()[0].getTransport())
+                    .getLocalAddress()).getPort();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void start() throws Exception {
+        sslConnectionFactory.start();
+
+        server.setHandler(new Handler.Sequence(
+                new SslConnectHandler(),
+                new MitmProxyHandler()));
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+        sslConnectionFactory.stop();
+    }
+
+    public record Request(org.eclipse.jetty.server.Request request, Response response, Callback callback) {
+        public String url() {
+            return request().getHttpURI().asString();
+        }
+
+        public void setListener(ExchangeListener listener) {
+            request.setAttribute(ExchangeListener.class.getName(), listener);
+        }
+
+        public void sendResponse(int status, Map<String,String> headers, InputStream body) throws IOException {
+            response.setStatus(status);
+            headers.forEach((k,v) -> response.getHeaders().put(k, v));
+            body.transferTo(Content.Sink.asOutputStream(response));
+            callback().succeeded();
+        }
+    }
+
+    public interface RequestHandler {
+        /**
+         * Handles a request to the proxy server. Must either:
+         * <ul>
+         *     <li>write an immediate response, in which case the proxy won't make an upstream request
+         *     <li>return an {@link ExchangeListener} to record the exchange with the upstream server
+         *     <li>return null to let the proxy make an upstream request without recording it
+         * </ul>
+         */
+        void handle(Request request) throws IOException;
+    }
+
+    public interface ExchangeListener extends
+            org.eclipse.jetty.client.Request.BeginListener,
+            org.eclipse.jetty.client.Request.HeadersListener,
+            org.eclipse.jetty.client.Request.ContentListener,
+            org.eclipse.jetty.client.Response.ContentListener,
+            org.eclipse.jetty.client.Response.HeadersListener,
+            org.eclipse.jetty.client.Response.CompleteListener {
+    }
+
+    private class MitmProxyHandler extends ProxyHandler.Forward {
+        @Override
+        protected HttpClient newHttpClient() {
+            HttpClient httpClient = super.newHttpClient();
+            httpClient.setMaxConnectionsPerDestination(6);
+            httpClient.setFollowRedirects(false);
+            httpClient.setUserAgentField(null);
+            return httpClient;
+        }
+
+        @Override
+        public boolean handle(org.eclipse.jetty.server.Request request, Response response, Callback callback) {
+            try {
+                requestHandler.handle(new Request(request, response, callback));
+                if (response.isCommitted()) return true;
+                return super.handle(request, response, callback);
+            } catch (Throwable t) {
+                callback.failed(t);
+                return true;
+            }
+        }
+
+        @Override
+        protected HttpURI rewriteHttpURI(org.eclipse.jetty.server.Request clientToProxyRequest) {
+            HttpURI uri = super.rewriteHttpURI(clientToProxyRequest);
+            String string = uri.asString();
+            // HttpClient uses Java URI which unlike WHATWG URL doesn't allow "|" so percent encode it
+            if (string.contains("|")) {
+                return HttpURI.from(string.replace("|", "%7C"));
+            } else {
+                return uri;
+            }
+        }
+
+        @Override
+        protected void addProxyHeaders(org.eclipse.jetty.server.Request clientToProxyRequest, org.eclipse.jetty.client.Request proxyToServerRequest) {
+            proxyToServerRequest.headers(headers -> {
+                // Ensure we only get the encodings we support
+                headers.put(ACCEPT_ENCODING, "gzip");
+
+                // Host header is not allowed in HTTP/2
+                headers.remove(HttpHeader.HOST);
+            });
+            var listener = (ExchangeListener)clientToProxyRequest.getAttribute(ExchangeListener.class.getName());
+            if (listener != null) {
+                proxyToServerRequest.onRequestHeaders(listener);
+                proxyToServerRequest.onRequestContent(listener);
+                proxyToServerRequest.onResponseHeaders(listener);
+                proxyToServerRequest.onResponseContent(listener);
+                proxyToServerRequest.onComplete(listener);
+            }
+        }
+    }
+
+    /**
+     * Handles the CONNECT method by upgrading the connection to SSL.
+     */
+    private class SslConnectHandler extends ConnectHandler {
+        @Override
+        protected void handleConnect(org.eclipse.jetty.server.Request request, Response response, Callback callback, String serverAddress) {
+            EndPoint clientEP = request.getTunnelSupport().getEndPoint();
+            var sslConnection = sslConnectionFactory.newConnection(server.getConnectors()[0], clientEP);
+            request.setAttribute(HttpStream.UPGRADE_CONNECTION_ATTRIBUTE, sslConnection);
+            response.setStatus(200);
+            callback.succeeded();
+        }
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/BiDiEvent.java
+++ b/commons/src/main/java/org/archive/net/webdriver/BiDiEvent.java
@@ -1,0 +1,23 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+interface BiDiEvent {
+}

--- a/commons/src/main/java/org/archive/net/webdriver/BiDiJson.java
+++ b/commons/src/main/java/org/archive/net/webdriver/BiDiJson.java
@@ -1,0 +1,210 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPropertyName;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Utility methods for mapping Webdriver BiDi JSON to Java records.
+ */
+class BiDiJson {
+    /**
+     * Maps Java records to a BiDi JSON tree.
+     */
+    static Object toJson(Object value) {
+        if (value == null) return null;
+        if (value instanceof String) return value;
+        if (value instanceof Number) return value;
+        if (value instanceof Boolean) return value;
+        if (value instanceof JSONObject) return value;
+        if (value instanceof Identifier identifier) return identifier.id();
+        if (value instanceof Enum<?> enumValue) return enumValue.name();
+        if (value instanceof Map<?, ?>) {
+            var map = new JSONObject();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                map.put(entry.getKey().toString(), toJson(entry.getValue()));
+            }
+            return map;
+        }
+        if (value instanceof Collection) {
+            var list = new JSONArray();
+            for (Object item : (Collection<?>) value) {
+                list.put(toJson(item));
+            }
+            return list;
+        }
+        if (value.getClass().isRecord()) {
+            var object = new JSONObject();
+            TypeName typeName = value.getClass().getAnnotation(TypeName.class);
+            if (typeName != null) object.put("type", typeName.value());
+            for (RecordComponent component : value.getClass().getRecordComponents()) {
+                try {
+                    Object item = toJson(component.getAccessor().invoke(value));
+                    if (item != null) {
+                        String name = component.getName();
+                        var annotation = component.getDeclaredAnnotation(PropertyName.class);
+                        if (annotation != null) name = annotation.value();
+                        object.put(name, item);
+                    }
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return object;
+        }
+        if (value instanceof byte[] bytes) {
+            var object = new JSONObject();
+            try {
+                object.put("type", "string");
+                object.put("value", StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(bytes)).toString());
+            } catch (CharacterCodingException e) {
+                object.put("type", "base64");
+                object.put("value", Base64.getEncoder().encodeToString(bytes));
+            }
+            return object;
+        }
+        throw new UnsupportedOperationException("Unsupported type: " + value.getClass());
+    }
+
+    /**
+     * Maps BiDi JSON tree to Java records.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> T fromJson(Object value, Class<T> type) {
+        try {
+            if (value == JSONObject.NULL) {
+                return null;
+            }
+            if (value == null || type.isPrimitive() || type.isAssignableFrom(value.getClass())) {
+                return (T) value;
+            }
+            if (type == Long.class && value instanceof Number number) {
+                return (T) (Long) number.longValue();
+            }
+            if (type == byte[].class && value instanceof JSONObject jsonObject) {
+                switch (jsonObject.getString("type")) {
+                    case "base64" -> {
+                        return (T) Base64.getDecoder().decode(jsonObject.getString("value"));
+                    }
+                    case "string" -> {
+                        return (T) jsonObject.getString("value").getBytes(StandardCharsets.UTF_8);
+                    }
+                }
+            }
+            if (Identifier.class.isAssignableFrom(type) && value instanceof String string) {
+                return type.getDeclaredConstructor(String.class).newInstance(string);
+            }
+            if (type.isAssignableFrom(List.class) && value instanceof JSONArray array) {
+                return (T) array.toList();
+            }
+            if (type.isEnum() && value instanceof String string) {
+                return (T) Enum.valueOf((Class<Enum>) type, string);
+            }
+            if (type.isRecord()) {
+                if (value instanceof JSONObject jsonObject) {
+                    RecordComponent[] components = type.getRecordComponents();
+                    Class<?>[] componentTypes = new Class<?>[components.length];
+                    Object[] values = new Object[components.length];
+                    for (int i = 0; i < components.length; i++) {
+                        componentTypes[i] = components[i].getType();
+                        var componentValue = jsonObject.opt(components[i].getName());
+                        if (componentValue != null && componentValue != JSONObject.NULL &&
+                                components[i].getGenericType() instanceof ParameterizedType parameterizedType) {
+                            if (parameterizedType.getRawType() == List.class && componentValue instanceof JSONArray array) {
+                                Class<?> listType = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+                                var list = new ArrayList<>();
+                                for (Object item : array) {
+                                    list.add(fromJson(item, listType));
+                                }
+                                values[i] = list;
+                            } else {
+                                throw new UnsupportedOperationException("Unsupported type: " + parameterizedType + " for " + components[i] + " in " + type + " (value '" + jsonObject + "')");
+                            }
+                        } else {
+                            values[i] = fromJson(componentValue, components[i].getType());
+                        }
+                    }
+                    return (T) type.getDeclaredConstructor(componentTypes).newInstance(values);
+                } else if (value instanceof String string) {
+                    return type.getConstructor(String.class).newInstance(string);
+                } else {
+                    throw new UnsupportedOperationException("Unsupported type: " + type);
+                }
+            }
+            if (type.isInterface() && type.isSealed() && value instanceof JSONObject jsonObject) {
+                String typeName = jsonObject.getString("type");
+                if (typeName == null) throw new UnsupportedOperationException("Missing 'type' field in " + jsonObject);
+                return (T) fromJson(jsonObject, getSubclassByTypeName(type, typeName));
+            }
+            throw new UnsupportedOperationException("Unsupported type: " + type + " (value '" + value + "')");
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                 InvocationTargetException | IllegalArgumentException e) {
+            throw new RuntimeException("Couldn't map to " + type + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static Class<?> getSubclassByTypeName(Class<?> type, String typeName) {
+        for (Class<?> subclass : type.getPermittedSubclasses()) {
+            TypeName annotation = subclass.getDeclaredAnnotation(TypeName.class);
+            if (annotation != null && annotation.value().equals(typeName)) return subclass;
+        }
+        throw new UnsupportedOperationException("Unsupported 'type' for " + type + ": " + typeName);
+    }
+
+    /**
+     * Marker for identifier records which are represented as a bare JSON String.
+     */
+    interface Identifier {
+        String id();
+    }
+
+    /**
+     * The value of the 'type' field for a BiDi object that can have multiple types.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface TypeName {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.RECORD_COMPONENT)
+    @interface PropertyName {
+        String value();
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/BiDiModule.java
+++ b/commons/src/main/java/org/archive/net/webdriver/BiDiModule.java
@@ -1,0 +1,24 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+// https://w3c.github.io/webdriver-bidi/#protocol-modules
+public interface BiDiModule {
+}

--- a/commons/src/main/java/org/archive/net/webdriver/Browser.java
+++ b/commons/src/main/java/org/archive/net/webdriver/Browser.java
@@ -1,0 +1,24 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+public interface Browser extends BiDiModule {
+    void close();
+}

--- a/commons/src/main/java/org/archive/net/webdriver/BrowsingContext.java
+++ b/commons/src/main/java/org/archive/net/webdriver/BrowsingContext.java
@@ -1,0 +1,49 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+// https://w3c.github.io/webdriver-bidi/#module-browsingContext
+public interface BrowsingContext extends BiDiModule {
+    CreateResult create(CreateType type);
+
+    NavigateResult navigate(Context context, String url, ReadinessState wait);
+
+    void close(Context context);
+
+    enum CreateType {tab, window}
+
+    enum ReadinessState {none, interactive, complete}
+
+    record CreateResult(Context context) {
+    }
+
+    record Load(Context context, Navigation navigation, long timestamp, String url) implements BiDiEvent {
+    }
+
+    record NavigateResult(Navigation navigation, String url) {
+    }
+
+    // This is browsingContext.BrowsingContext in the standard, but Java doesn't let us name it that.
+    record Context(String id) implements BiDiJson.Identifier {
+    }
+
+    record Navigation(String id) implements BiDiJson.Identifier {
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -1,0 +1,245 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.io.input.CharSequenceReader;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.json.JSONWriter;
+
+import java.io.*;
+import java.lang.reflect.*;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * Client for the BiDirectional WebDriver Protocol for remotely controlling browsers.
+ *
+ * @see <a href="https://www.w3.org/TR/webdriver-bidi/>WebDriver BiDi specification</a>
+ */
+public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
+    private final System.Logger logger = System.getLogger(getClass().getName());
+    private final Process process;
+    private final CompletableFuture<String> webSocketUrl = new CompletableFuture<>();
+    private final WebSocket webSocket;
+    private final AtomicLong requestId = new AtomicLong(0);
+    private final Map<Long, CompletableFuture<JSONObject>> commands = new ConcurrentHashMap<>();
+    private final Map<String, Consumer<JSONObject>> eventHandlers = new ConcurrentHashMap<>();
+    private final ExecutorService eventExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+            .setNameFormat("ClientBiDi-event-%d")
+            .setDaemon(true)
+            .build());
+    private final String sessionId;
+    private static final String[] BROWSERS = new String[]{
+            "firefox", "/Applications/Firefox.app/Contents/MacOS/firefox", "chromedriver"};
+
+    public LocalWebDriverBiDi(String executable, List<String> options, int proxyPort, Path profileDir)
+            throws ExecutionException, InterruptedException, IOException {
+        this.process = executable == null ? launchAnyBrowser(options, profileDir) : launchBrowser(executable, options, profileDir);
+        Runtime.getRuntime().addShutdownHook(new Thread(this.process::destroyForcibly));
+        new Thread(this::handleStderr).start();
+        webSocket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .buildAsync(URI.create(webSocketUrl.get() + "/session"), new Listener())
+                .get();
+        var alwaysMatch = Map.of("acceptInsecureCerts", true,
+                "proxy", new Session.ProxyConfiguration("manual",
+                        "127.0.0.1:" + proxyPort, "127.0.0.1:" + proxyPort));
+        sessionId = session().new_(new Session.CapabilitiesRequest(alwaysMatch, null)).sessionId();
+    }
+
+    private static Process launchAnyBrowser(List<String> options, Path profileDir) throws IOException {
+        IOException lastException = null;
+        for (String executable : BROWSERS) {
+            try {
+                return launchBrowser(executable, options, profileDir);
+            } catch (IOException e) {
+                lastException = e;
+            }
+        }
+        throw new IOException("Failed to launch any of: " + List.of(BROWSERS), lastException);
+    }
+
+    private static Process launchBrowser(String executable, List<String> options, Path profileDir) throws IOException {
+        var command = new ArrayList<String>();
+        command.add(executable);
+        command.add("--remote-debugging-port=0");
+        if (executable.contains("firefox")) {
+            command.add("--profile");
+            command.add(profileDir.toAbsolutePath().toString());
+        } else {
+            command.add("--user-data-dir=" + profileDir.toAbsolutePath());
+        }
+        command.addAll(options);
+        return new ProcessBuilder(command)
+                .redirectInput(ProcessBuilder.Redirect.INHERIT)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectErrorStream(true)
+                .start();
+    }
+
+    private void handleStderr() {
+        String firefoxListening = "WebDriver BiDi listening on ";
+        String chromeDriverListening = "ChromeDriver was started successfully on port ";
+        try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                if (line.startsWith(firefoxListening)) {
+                    webSocketUrl.complete(line.substring(firefoxListening.length()));
+                } else if (line.startsWith(chromeDriverListening)) {
+                    webSocketUrl.complete("ws://127.0.0.1:" + line.substring(chromeDriverListening.length(), line.length() - 1));
+                } else if (line.startsWith("DevTools listening on ")) {
+                    webSocketUrl.completeExceptionally(new WebDriverException("Chrome does not directly implement WebDriver BiDi. Please run ChromeDriver instead of running Chrome directly."));
+                } else if (line.contains("Missing response info, network.responseCompleted will be skipped for URL:")) {
+                    continue; // suppress noisy Firefox logs
+                }
+                logger.log(System.Logger.Level.INFO, "Browser: {0}", line);
+            }
+            webSocketUrl.completeExceptionally(new EOFException("EOF waiting for start message"));
+        } catch (Exception e) {
+            webSocketUrl.completeExceptionally(e);
+        }
+    }
+
+    public CompletableFuture<JSONObject> send(String method, Map<String, Object> params) {
+        long id = requestId.incrementAndGet();
+        var command = new JSONObject();
+        command.put("id", id);
+        command.put("method", method);
+        if (sessionId != null) command.put("sessionId", sessionId);
+        command.put("params", BiDiJson.toJson(params));
+        String message = JSONWriter.valueToString(command);
+        logger.log(System.Logger.Level.TRACE, "BiDi SEND {0}", message);
+        CompletableFuture<JSONObject> future = new CompletableFuture<>();
+        commands.put(id, future);
+        webSocket.sendText(message, true);
+        return future;
+    }
+
+    public <T extends BiDiEvent> void on(Class<T> eventClass, Consumer<T> handler) {
+        String eventName = StringUtils.uncapitalize(eventClass.getEnclosingClass().getSimpleName()) + "." +
+                StringUtils.uncapitalize(eventClass.getSimpleName());
+        eventHandlers.put(eventName, node -> {
+            handler.accept(BiDiJson.fromJson(node, eventClass));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends BiDiModule> T module(Class<T> moduleClass) {
+        String prefix = moduleClass.getSimpleName().substring(0, 1).toLowerCase(Locale.ROOT)
+                + moduleClass.getSimpleName().substring(1) + ".";
+        return (T) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{moduleClass},
+                (proxy, method, args) -> {
+                    if (method.isDefault()) return InvocationHandler.invokeDefault(proxy, method, args);
+                    return switch (method.getName()) {
+                        case "equals" -> proxy == args[0];
+                        case "hashCode" -> System.identityHashCode(proxy);
+                        case "toString" -> moduleClass.getName();
+                        default -> {
+                            var map = new LinkedHashMap<String, Object>();
+                            if (args != null) {
+                                for (int i = 0; i < args.length; i++) {
+                                    map.put(method.getParameters()[i].getName(), args[i]);
+                                }
+                            }
+                            String methodName = method.getName();
+                            if (methodName.endsWith("_")) methodName = methodName.substring(0, methodName.length() - 1);
+                            if (methodName.endsWith("Async"))
+                                methodName = methodName.substring(0, methodName.length() - 5);
+                            var future = send(prefix + methodName, map);
+                            if (method.getReturnType() == CompletableFuture.class &&
+                                    method.getGenericReturnType() instanceof ParameterizedType parameterizedType &&
+                                    parameterizedType.getActualTypeArguments()[0] instanceof Class<?> typeClass) {
+                                yield future.thenApply(result -> BiDiJson.fromJson(result, typeClass));
+                            } else {
+                                yield BiDiJson.fromJson(future.get(30, TimeUnit.SECONDS), method.getReturnType());
+                            }
+                        }
+                    };
+                });
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (process.isAlive() && !webSocket.isInputClosed()) {
+                browser().close();
+            }
+        } catch (Exception e) {
+            logger.log(System.Logger.Level.ERROR, "Error closing browser", e);
+        }
+        process.destroy();
+    }
+
+    private class Listener implements WebSocket.Listener {
+        StringBuffer buffer = new StringBuffer();
+
+        @Override
+        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            webSocket.request(1L);
+            buffer.append(data);
+            if (!last) {
+                return null;
+            }
+            data = buffer;
+            buffer = new StringBuffer();
+            logger.log(System.Logger.Level.TRACE, "BiDi RECV {0}", data);
+            try {
+                var message = new JSONObject(new JSONTokener(new CharSequenceReader(data)));
+                switch (message.getString("type")) {
+                    case "success" -> {
+                        var future = commands.remove(message.getLong("id"));
+                        if (future != null) future.complete(message.getJSONObject("result"));
+                    }
+                    case "error" -> {
+                        var future = commands.remove(message.getLong("id"));
+                        if (future != null)
+                            future.completeExceptionally(new WebDriverException(message.getString("message")));
+                    }
+                    case "event" -> {
+                        var handler = eventHandlers.get(message.getString("method"));
+                        if (handler != null) {
+                            JSONObject params = message.getJSONObject("params");
+                            eventExecutor.execute(() -> handler.accept(params));
+                        }
+                    }
+                    default ->
+                            throw new UnsupportedOperationException("Unsupported message type: " + message.getString("type"));
+                }
+            } catch (Exception e) {
+                logger.log(System.Logger.Level.ERROR, "Error handling message", e);
+                webSocket.abort();
+            }
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            logger.log(System.Logger.Level.ERROR, "WebSocket error", error);
+        }
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -58,7 +58,7 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
     private static final String[] BROWSERS = new String[]{
             "firefox", "/Applications/Firefox.app/Contents/MacOS/firefox", "chromedriver"};
 
-    public LocalWebDriverBiDi(String executable, List<String> options, int proxyPort, Path profileDir)
+    public LocalWebDriverBiDi(String executable, List<String> options, Session.CapabilitiesRequest capabilities, Path profileDir)
             throws ExecutionException, InterruptedException, IOException {
         this.process = executable == null ? launchAnyBrowser(options, profileDir) : launchBrowser(executable, options, profileDir);
         Runtime.getRuntime().addShutdownHook(new Thread(this.process::destroyForcibly));
@@ -66,10 +66,7 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
         webSocket = HttpClient.newHttpClient().newWebSocketBuilder()
                 .buildAsync(URI.create(webSocketUrl.get() + "/session"), new Listener())
                 .get();
-        var alwaysMatch = Map.of("acceptInsecureCerts", true,
-                "proxy", new Session.ProxyConfiguration("manual",
-                        "127.0.0.1:" + proxyPort, "127.0.0.1:" + proxyPort));
-        sessionId = session().new_(new Session.CapabilitiesRequest(alwaysMatch, null)).sessionId();
+        sessionId = session().new_(capabilities).sessionId();
     }
 
     private static Process launchAnyBrowser(List<String> options, Path profileDir) throws IOException {

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -173,7 +173,12 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
                                     parameterizedType.getActualTypeArguments()[0] instanceof Class<?> typeClass) {
                                 yield future.thenApply(result -> BiDiJson.fromJson(result, typeClass));
                             } else {
-                                yield BiDiJson.fromJson(future.get(30, TimeUnit.SECONDS), method.getReturnType());
+                                try {
+                                    yield BiDiJson.fromJson(future.get(30, TimeUnit.SECONDS), method.getReturnType());
+                                } catch (ExecutionException e) {
+                                    if (e.getCause() instanceof RuntimeException re) throw re;
+                                    throw e;
+                                }
                             }
                         }
                     };

--- a/commons/src/main/java/org/archive/net/webdriver/Network.java
+++ b/commons/src/main/java/org/archive/net/webdriver/Network.java
@@ -1,0 +1,100 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+// https://w3c.github.io/webdriver-bidi/#module-network
+public interface Network extends BiDiModule {
+    AddInterceptResult addIntercept(List<InterceptPhase> phases,
+                                    List<BrowsingContext.Context> contexts,
+                                    List<UrlPattern> urlPatterns);
+
+    CompletableFuture<Void> continueRequestAsync(Request request, List<Header> headers);
+
+    enum InterceptPhase {beforeRequestSent, responseStarted, authRequired}
+
+    record AddInterceptResult(Intercept intercept) {
+    }
+
+    record Intercept(String id) implements BiDiJson.Identifier {
+    }
+
+    record BeforeRequestSent(
+            BrowsingContext.Context context,
+            boolean isBlocked,
+            BrowsingContext.Navigation navigation,
+            long redirectCount,
+            RequestData request,
+            long timestamp,
+            List<Intercept> intercepts,
+            Initiator initiator) implements BiDiEvent {
+    }
+
+    record Cookie(
+            String name,
+            byte[] value,
+            String domain,
+            String path,
+            Long size,
+            Boolean httpOnly,
+            Boolean secure,
+            SameSite sameSite,
+            Long expiry) {
+    }
+
+    record Header(String name, byte[] value) {
+        public Header(String name, String value) {
+            this(name, value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    record Initiator(Long columnNumber, Long lineNumber, InitiatorType type) {
+    }
+
+    enum InitiatorType {parser, script, preflight, other}
+
+    record Request(String id) implements BiDiJson.Identifier {
+    }
+
+    record RequestData(
+            Request request,
+            String url,
+            String method,
+            List<Header> headers,
+            List<Cookie> cookies,
+            long headersSize,
+            long bodySize,
+            String destination,
+            String initiatorType
+    ) {
+    }
+
+    enum SameSite {strict, lax, none}
+
+    interface UrlPattern {
+        String type();
+    }
+
+    record UrlPatternPattern(String type, String protocol) implements UrlPattern {
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/Script.java
+++ b/commons/src/main/java/org/archive/net/webdriver/Script.java
@@ -1,0 +1,113 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+import org.springframework.cglib.core.Local;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// https://www.w3.org/TR/webdriver-bidi/#module-script
+public interface Script extends BiDiModule {
+    EvaluateResult evaluate(String expression, Target target, boolean awaitPromise);
+
+    default EvaluateResultSuccess evaluateOrThrow(String expression, Target target, boolean awaitPromise) {
+        var result = evaluate(expression, target, awaitPromise);
+        if (result instanceof EvaluateResultSuccess success) {
+            return success;
+        } else if (result instanceof EvaluateResultException exception) {
+            throw new RuntimeException(exception.exceptionDetails().text());
+        } else {
+            throw new RuntimeException("Unexpected EvaluateResult: " + result);
+        }
+    }
+
+    EvaluateResult callFunction(String functionDeclaration, Target target, boolean awaitPromise, List<LocalValue> arguments);
+
+    sealed interface EvaluateResult permits EvaluateResultSuccess, EvaluateResultException {
+    }
+
+    @BiDiJson.TypeName("success")
+    record EvaluateResultSuccess(RemoteValue result, Realm realm) implements EvaluateResult {
+    }
+
+    @BiDiJson.TypeName("exception")
+    record EvaluateResultException(ExceptionDetails exceptionDetails, Realm realm) implements EvaluateResult {
+    }
+
+    record ExceptionDetails(String text /* TODO */) {
+    }
+
+    sealed interface LocalValue {
+        static LocalValue from(Object object) {
+            if (object instanceof Number number) return new NumberValue(number);
+            throw new IllegalArgumentException("Unsupported local value type: " + object.getClass());
+        }
+    }
+
+    sealed interface RemoteValue {
+        Object javaValue();
+    }
+
+    @BiDiJson.TypeName("number")
+    record NumberValue(Number value) implements RemoteValue, LocalValue {
+        @Override
+        public Number javaValue() {
+            return value;
+        }
+    }
+
+    @BiDiJson.TypeName("string")
+    record StringValue(String value) implements RemoteValue, LocalValue {
+        @Override
+        public String javaValue() {
+            return value;
+        }
+    }
+
+    @BiDiJson.TypeName("array")
+    record ArrayRemoteValue(List<RemoteValue> value) implements RemoteValue, LocalValue {
+        @Override
+        public List<?> javaValue() {
+            return value.stream().map(RemoteValue::javaValue).collect(Collectors.toList());
+        }
+    }
+
+    @BiDiJson.TypeName("undefined")
+    record UndefinedValue() implements RemoteValue, LocalValue {
+        @Override
+        public String javaValue() {
+            return null;
+        }
+    }
+
+    sealed interface Target {
+    }
+
+    record ContextTarget(BrowsingContext.Context context, String sandbox) implements Target {
+    }
+
+    record RealmTarget(Realm realm) implements Target {
+    }
+
+    record Realm(String id) implements BiDiJson.Identifier {
+    }
+
+}

--- a/commons/src/main/java/org/archive/net/webdriver/Session.java
+++ b/commons/src/main/java/org/archive/net/webdriver/Session.java
@@ -1,0 +1,57 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+import org.json.JSONObject;
+import org.json.JSONPropertyName;
+
+import java.util.List;
+import java.util.Map;
+
+// https://w3c.github.io/webdriver-bidi/#module-session
+public interface Session extends BiDiModule {
+    NewResult new_(CapabilitiesRequest capabilities);
+
+    void subscribe(List<String> events, List<BrowsingContext.Context> contexts);
+
+    record NewResult(String sessionId, JSONObject capabilities) {
+    }
+
+    record CapabilitiesRequest(Map<String,Object> alwaysMatch,
+                               List<Map<String,Object>> firstMatch) {
+    }
+
+    record CapabilityRequest(
+            boolean acceptInsecureCerts,
+            ProxyConfiguration proxy,
+            @BiDiJson.PropertyName("moz:firefoxOptions") FirefoxOptions firefoxOptions
+    ) {
+    }
+
+    record ProxyConfiguration(
+            String proxyType,
+            String httpProxy,
+            String sslProxy
+    ) {
+    }
+
+    record FirefoxOptions(Map<String,Object> prefs) {
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/WebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/WebDriverBiDi.java
@@ -1,0 +1,44 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+public interface WebDriverBiDi {
+    <T extends BiDiModule> T module(Class<T> moduleClass);
+
+    default Browser browser() {
+        return module(Browser.class);
+    }
+
+    default BrowsingContext browsingContext() {
+        return module(BrowsingContext.class);
+    }
+
+    default Session session() {
+        return module(Session.class);
+    }
+
+    default Network network() {
+        return module(Network.class);
+    }
+
+    default Script script() {
+        return module(Script.class);
+    }
+}

--- a/commons/src/main/java/org/archive/net/webdriver/WebDriverException.java
+++ b/commons/src/main/java/org/archive/net/webdriver/WebDriverException.java
@@ -1,0 +1,26 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.net.webdriver;
+
+public class WebDriverException extends RuntimeException {
+    public WebDriverException(String message) {
+        super(message);
+    }
+}

--- a/commons/src/main/java/org/archive/util/IdleBarrier.java
+++ b/commons/src/main/java/org/archive/util/IdleBarrier.java
@@ -1,0 +1,98 @@
+package org.archive.util;
+
+import java.time.Duration;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A synchronization aid that tracks concurrent activities and lets callers
+ * wait until the system has been continuously <em>idle</em> for a specified
+ * duration.
+ *
+ * <p>Call {@link #begin()} when an activity starts and {@link #end()} when it
+ * finishes.  A thread may then invoke {@link #awaitIdleFor(Duration, Duration)}
+ * to block until:
+ * <ol>
+ *   <li>there are no in‑flight activities, and</li>
+ *   <li>that idle state has lasted for at least the requested idle period.</li>
+ * </ol>
+ */
+public class IdleBarrier {
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition becameIdle = lock.newCondition();
+    private long inflight = 0;
+    private long lastBecameIdleAt = System.nanoTime();
+
+    /**
+     * Registers the start of an activity.
+     *
+     * <p>Every call to {@code begin()} <strong>must</strong> be paired with a
+     * later call to {@link #end()}, typically using a {@code try/finally}
+     * block.
+     */
+    public void begin() {
+        lock.lock();
+        try {
+            inflight++;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Registers the completion of a previously started activity.
+     *
+     * @throws IllegalStateException if called more times than {@code begin()}
+     */
+    public void end() {
+        lock.lock();
+        try {
+            if (inflight <= 0) throw new IllegalStateException("end() called more times than begin()");
+            inflight--;
+            if (inflight == 0) {
+                lastBecameIdleAt = System.nanoTime();
+                becameIdle.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Blocks the calling thread until the system has been idle for at least
+     * {@code minIdle} or the overall {@code timeout} expires.
+     *
+     * @return {@code true} if the idle period condition was satisfied,
+     *         {@code false} if the {@code timeout} was reached
+     * @throws InterruptedException if the thread was interrupted while waiting
+     */
+    public boolean awaitIdleFor(Duration idlePeriod, Duration timeout) throws InterruptedException {
+        long idlePeriodNanos = idlePeriod.toNanos();
+        long deadline = System.nanoTime() + timeout.toNanos();
+        lock.lockInterruptibly();
+        try {
+            while (true) {
+                long now = System.nanoTime();
+                long untilTimeout = deadline - now;
+                if (untilTimeout <= 0) {
+                    return false;
+                }
+
+                if (inflight == 0) {
+                    long idleSoFar = now - lastBecameIdleAt;
+                    if (idleSoFar >= idlePeriodNanos) {
+                        return true;
+                    }
+
+                    // Reached idle, but need to wait
+                    long waitTime = Math.min(idlePeriodNanos - idleSoFar, untilTimeout);
+                    long ignore = becameIdle.awaitNanos(waitTime);
+                } else {
+                    long ignore = becameIdle.awaitNanos(untilTimeout);
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -52,6 +52,10 @@
 					<groupId>org.mortbay.jetty.quiche</groupId>
 					<artifactId>jetty-quiche-native</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-slf4j-impl</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -204,7 +208,7 @@
 					<excludes>
 						<exclude>**/TestAll.java</exclude>
 					</excludes>
-					<argLine>-server -Xmx512m</argLine>
+					<argLine>-server -Xmx512m -Djava.util.logging.config.file=${basedir}/src/test/resources/logging.properties</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/engine/src/main/java/org/archive/crawler/processor/Browser.java
+++ b/engine/src/main/java/org/archive/crawler/processor/Browser.java
@@ -1,0 +1,446 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.crawler.processor;
+
+import org.archive.crawler.event.CrawlURIDispositionEvent;
+import org.archive.crawler.framework.CrawlController;
+import org.archive.crawler.framework.Frontier;
+import org.archive.io.RecordingInputStream;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.Processor;
+import org.archive.modules.ProcessorChain;
+import org.archive.modules.behaviors.Behavior;
+import org.archive.modules.behaviors.ExtractLinks;
+import org.archive.modules.behaviors.Page;
+import org.archive.modules.behaviors.ScrollDown;
+import org.archive.modules.extractor.Extractor;
+import org.archive.modules.extractor.Hop;
+import org.archive.modules.extractor.LinkContext;
+import org.archive.modules.extractor.UriErrorLoggerModule;
+import org.archive.modules.fetcher.FetchHTTP2;
+import org.archive.modules.fetcher.FetchStatusCodes;
+import org.archive.net.MitmProxy;
+import org.archive.net.webdriver.*;
+import org.archive.spring.KeyedProperties;
+import org.archive.util.IdleBarrier;
+import org.archive.util.Recorder;
+import org.eclipse.jetty.client.Result;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Stream;
+
+import static java.lang.System.Logger.Level.ERROR;
+import static org.archive.crawler.event.CrawlURIDispositionEvent.Disposition.FAILED;
+import static org.archive.crawler.event.CrawlURIDispositionEvent.Disposition.SUCCEEDED;
+import static org.archive.modules.CoreAttributeConstants.A_HTTP_RESPONSE_HEADERS;
+
+/**
+ * Processor which opens a web page in a real web browser via WebDriver BiDi and runs {@link Behavior} scripts.
+ * Subresources loaded by the browser are recorded using a MITM proxy. Must be used in conjunction with
+ * {@link FetchHTTP2}.
+ */
+public class Browser extends Processor {
+    private static final System.Logger logger = System.getLogger(Browser.class.getName());
+    protected static final String PAGE_ID_HEADER = "Heritrix-Request-ID";
+    protected final CrawlController crawlController;
+    protected final MitmProxy proxy = new MitmProxy(this::handleProxyRequest);
+    protected final FetchHTTP2 fetcher;
+    protected LocalWebDriverBiDi webdriver;
+    protected final ApplicationEventPublisher eventPublisher;
+    protected final Map<String, BrowserPage> pages = new ConcurrentHashMap<>();
+    protected final Map<BrowsingContext.Context, String> pageIdsByContext = new ConcurrentHashMap<>();
+    protected final ProcessorChain extractorChain = new ProcessorChain();
+    protected List<Behavior> behaviors;
+    protected String executable;
+    protected List<String> options = List.of("--headless");
+    protected int concurrency = 20;
+    protected Semaphore semaphore;
+
+    public Browser(FetchHTTP2 fetcher, CrawlController crawlController, ApplicationEventPublisher eventPublisher,
+                   UriErrorLoggerModule uriErrorLoggerModule) {
+        this.crawlController = crawlController;
+        this.fetcher = fetcher;
+        this.eventPublisher = eventPublisher;
+        this.behaviors = List.of(new ScrollDown(), new ExtractLinks(uriErrorLoggerModule));
+    }
+
+    public void stop() {
+        if (!isRunning) return;
+        super.stop();
+        try {
+            proxy.stop();
+        } catch (Exception e) {
+            logger.log(ERROR, "Error stopping proxy server", e);
+        }
+        try {
+            webdriver.close();
+        } catch (Exception e) {
+            logger.log(ERROR, "Error closing WebDriverBiDi", e);
+        }
+    }
+
+    @Override
+    protected boolean shouldProcess(CrawlURI curi) {
+        if (curi.getFetchStatus() != 200) return false;
+        String scheme = curi.getUURI().getScheme();
+        if (!scheme.equals("https") && !scheme.equals("http")) return false;
+        String mime = curi.getContentType().toLowerCase();
+        if (!mime.startsWith("text/html")) return false;
+        return true;
+    }
+
+    @Override
+    public void innerProcess(CrawlURI curi) {
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        try {
+            visit(curi);
+        } finally {
+            semaphore.release();
+        }
+    }
+
+    private void visit(CrawlURI curi) {
+        String pageId = UUID.randomUUID().toString();
+        var tab = webdriver.browsingContext().create(BrowsingContext.CreateType.tab).context();
+        try {
+            BrowserPage page = new BrowserPage(curi, new IdleBarrier(), webdriver, tab);
+            pages.put(pageId, page);
+            pageIdsByContext.put(tab, pageId);
+            webdriver.network().addIntercept(List.of(Network.InterceptPhase.beforeRequestSent), List.of(tab),
+                    List.of(new Network.UrlPatternPattern("pattern", "http"),
+                            new Network.UrlPatternPattern("pattern", "https")));
+            var navigation = webdriver.browsingContext().navigate(tab, curi.getURI(), BrowsingContext.ReadinessState.complete);
+            logger.log(System.Logger.Level.DEBUG, "Navigated to {0}", navigation);
+
+            // Wait for network activity to stop
+            if (!page.networkActivity().awaitIdleFor(Duration.ofMillis(500), Duration.ofSeconds(30))) {
+                logger.log(System.Logger.Level.DEBUG, "Timed out waiting network activity to stop on {0}", curi);
+            }
+
+            for (Behavior behavior : behaviors) {
+                try {
+                    behavior.run(page);
+                } catch (Exception e) {
+                    logger.log(ERROR, "Error running " + behavior.getClass().getName() + " on " + curi, e);
+                }
+            }
+
+            curi.getAnnotations().add("browser");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            pageIdsByContext.remove(tab);
+            pages.remove(pageId);
+            webdriver.browsingContext().close(tab);
+        }
+    }
+
+    public void start() {
+        if (isRunning) return;
+        super.start();
+
+        semaphore = new Semaphore(concurrency);
+        extractorChain.setProcessors(crawlController.getFetchChain().getProcessors().stream()
+                .filter(processor -> processor instanceof Extractor).toList());
+
+        try {
+            proxy.start();
+        } catch (Exception e) {
+            logger.log(ERROR, "Error starting proxy server", e);
+            throw new RuntimeException(e);
+        }
+        try {
+            Path profileDir = crawlController.getScratchDir().getFile().toPath().resolve("profile");
+            Files.createDirectories(profileDir);
+
+            // Firefox: send localhost requests via the proxy too (for tests and local crawling)
+            Files.writeString(profileDir.resolve("user.js"), "user_pref('network.proxy.allow_hijacking_localhost', true);");
+
+            this.webdriver = new LocalWebDriverBiDi(executable, options, proxy.getPort(), profileDir);
+        } catch (Exception e) {
+            logger.log(ERROR, "Error starting browser", e);
+            throw new RuntimeException(e);
+        }
+        webdriver.session().subscribe(List.of("browsingContext.contextCreated",
+                "network.beforeRequestSent"), null);
+        webdriver.on(Network.BeforeRequestSent.class, this::handleBeforeRequestSent);
+    }
+
+    private void handleBeforeRequestSent(Network.BeforeRequestSent event) {
+        if (event.request().url().startsWith("data:") || !event.isBlocked()) return;
+        List<Network.Header> requestHeaders = event.request().headers();
+        String pageId = pageIdsByContext.get(event.context());
+        if (pageId != null) requestHeaders.add(new Network.Header(PAGE_ID_HEADER, pageId));
+        webdriver.network().continueRequestAsync(event.request().request(), requestHeaders);
+    }
+
+    private void handleProxyRequest(MitmProxy.Request proxyRequest) throws IOException {
+        logger.log(System.Logger.Level.DEBUG, "Handling proxy request {0}", proxyRequest);
+        if (proxyRequest.url().startsWith("https://firefox.settings.services.mozilla.com/")) {
+            proxyRequest.sendResponse(403, Map.of(), InputStream.nullInputStream());
+            return;
+        }
+        String pageId = proxyRequest.request().getHeaders().get(PAGE_ID_HEADER);
+        if (pageId == null) return;
+        BrowserPage page = pages.get(pageId);
+        if (page == null) return;
+        CrawlURI curi = page.curi();
+
+        // FIXME: more accurate to annotate with another header indicating this is the main request?
+        if (proxyRequest.request().getMethod().equals("GET") && curi.getURI().equals(proxyRequest.url())) {
+            // Replay page response
+            // FIXME: this probably doesn't handle duplicate headers (e.g. Set-Cookie) properly
+            var headers = (Map<String,String>)curi.getData().get(A_HTTP_RESPONSE_HEADERS);
+            proxyRequest.sendResponse(curi.getFetchStatus(), headers, curi.getRecorder().getContentReplayInputStream());
+        } else {
+            // Record exchange as a subresource
+            proxyRequest.setListener(new SubresourceRecorder(page, proxyRequest.url()));
+        }
+    }
+
+    /**
+     * Sets a list of {@link Behavior}s to run on each page.
+     */
+    public void setBehaviors(List<Behavior> behaviors) {
+        this.behaviors = behaviors;
+    }
+
+    public List<Behavior> getBehaviors() {
+        return behaviors;
+    }
+
+    /**
+     * Sets the webdriver executable to launch. If null, will try several common paths.
+     * <p>
+     * Firefox can be used directly as implements WebDriver BiDI natively. To use Chrome set this to a
+     * <a href="https://developer.chrome.com/docs/chromedriver">ChromeDriver</a> executable.
+     */
+    public void setExecutable(String executable) {
+        this.executable = executable;
+    }
+
+    public String getExecutable() {
+        return executable;
+    }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    public int getConcurrency() {
+        return concurrency;
+    }
+
+    /**
+     * Sets the maximum number of web pages that can be open in the browser at once.
+     */
+    public void setConcurrency(int concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    /**
+     * Records the request and response for a subresource the browser loads via the MITM proxy.
+     */
+    private class SubresourceRecorder implements MitmProxy.ExchangeListener {
+        private final CrawlURI curi;
+        private final WritableByteChannel requestRecorder;
+        private final WritableByteChannel responseRecorder;
+        private final BrowserPage page;
+        private String method;
+        private boolean recordingFailed;
+
+        public SubresourceRecorder(BrowserPage page, String url) throws IOException {
+            this.page = page;
+            this.curi = page.curi().createCrawlURI(url, LinkContext.EMBED_MISC, Hop.EMBED);
+            String requestId = UUID.randomUUID().toString();
+            Recorder recorder = new Recorder(crawlController.getScratchDir().getFile(),
+                    getClass().getSimpleName() + "-" + requestId,
+                    crawlController.getRecorderOutBufferBytes(),
+                    crawlController.getRecorderInBufferBytes());
+            this.curi.setRecorder(recorder);
+            this.curi.setFetchBeginTime(System.currentTimeMillis());
+            this.curi.getAnnotations().add("subresource");
+            this.requestRecorder = Channels.newChannel(recorder.outputWrap(null));
+            //noinspection resource
+            this.responseRecorder = Channels.newChannel(((RecordingInputStream)recorder.inputWrap(null)).asOutputStream());
+            this.page.networkActivity().begin();
+        }
+
+        @Override
+        public void onBegin(org.eclipse.jetty.client.Request request) {
+            request.headers(headers -> headers.remove(PAGE_ID_HEADER));
+        }
+
+        @Override
+        public void onHeaders(org.eclipse.jetty.client.Request request) {
+            try {
+                this.method = request.getMethod();
+                FetchHTTP2.recordRequest(request, curi.getRecorder());
+            } catch (Exception e) {
+                logger.log(ERROR, "Error recording request header of {0}", curi, e);
+                recordingFailed = true;
+            }
+        }
+
+        @Override
+        public void onContent(org.eclipse.jetty.client.Request request, ByteBuffer content) {
+            try {
+                requestRecorder.write(content.duplicate());
+            } catch (Exception e) {
+                logger.log(ERROR, "Error recording request body of {0}", curi, e);
+                recordingFailed = true;
+            }
+        }
+
+        @Override
+        public void onHeaders(org.eclipse.jetty.client.Response response) {
+            try {
+                String header = FetchHTTP2.formatResponseHeader(response);
+                responseRecorder.write(ByteBuffer.wrap(header.getBytes(StandardCharsets.US_ASCII)));
+            } catch (Exception e) {
+                logger.log(ERROR, "Error recording response header of " + curi, e);
+                recordingFailed = true;
+            }
+            fetcher.updateCrawlURIWithResponseHeader(curi, response);
+        }
+
+        @Override
+        public void onContent(org.eclipse.jetty.client.Response response, ByteBuffer content) {
+            try {
+                responseRecorder.write(content.duplicate());
+            } catch (Exception e) {
+                logger.log(ERROR, "Error recording response body of " + curi, e);
+                recordingFailed = true;
+            }
+        }
+
+        @Override
+        public void onComplete(Result result) {
+            try {
+                curi.getRecorder().close();
+                fetcher.updateCrawlURIOnCompletion(curi, curi.getRecorder());
+
+                if (recordingFailed) {
+                    curi.setFetchStatus(FetchStatusCodes.S_RUNTIME_EXCEPTION);
+                } else {
+                    curi.getOverlayNames(); // for sideeffect of creating the overlayNames list
+
+                    Frontier frontier = crawlController.getFrontier();
+                    if ("GET".equals(method) && frontier != null) {
+                        frontier.considerIncluded(curi);
+                    }
+
+                    KeyedProperties.loadOverridesFrom(curi);
+                    try {
+                        extractorChain.process(curi, null);
+
+                        if (frontier != null) frontier.beginDisposition(curi);
+                        try {
+                            crawlController.getDispositionChain().process(curi, null);
+                        } finally {
+                            if (frontier != null) frontier.endDisposition();
+                        }
+                    } finally {
+                        KeyedProperties.clearOverridesFrom(curi);
+                    }
+                }
+
+                if (curi.isSuccess()) {
+                    eventPublisher.publishEvent(new CrawlURIDispositionEvent(this, curi, SUCCEEDED));
+                } else {
+                    eventPublisher.publishEvent(new CrawlURIDispositionEvent(this, curi, FAILED));
+                }
+
+                if (crawlController.getLoggerModule() != null) {
+                    curi.aboutToLog();
+                    crawlController.getLoggerModule().getUriProcessing().log(java.util.logging.Level.INFO,
+                            curi.getUURI().toString(), curi);
+                }
+            } catch (Exception e) {
+                logger.log(ERROR, "Error completing " + curi, e);
+            } finally {
+                page.networkActivity().end();
+                curi.getRecorder().cleanup();
+            }
+        }
+    }
+
+    /**
+     * A CrawlURI that's currently loaded as a page in a browser.
+     */
+    record BrowserPage(CrawlURI curi,
+                       IdleBarrier networkActivity,
+                       WebDriverBiDi webdriver,
+                       BrowsingContext.Context context) implements Page {
+
+        /**
+         * Evaluates JavaScript and returns the result as simple Java objects (numbers, strings, maps, lists).
+         */
+        public <T> T eval(String script, Object... args) {
+            return callFunction(script, false, args);
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T> T callFunction(String script, boolean awaitPromise, Object... args) {
+            List<Script.LocalValue> argsLocal = null;
+            if (args != null && args.length > 0) {
+                argsLocal = Stream.of(args).map(Script.LocalValue::from).toList();
+            }
+            var result = webdriver().script().callFunction(script, scriptTarget(), awaitPromise, argsLocal);
+            if (result instanceof Script.EvaluateResultSuccess success) {
+                return (T) success.result().javaValue();
+            } else if (result instanceof Script.EvaluateResultException failure) {
+                throw new RuntimeException(failure.exceptionDetails().text());
+            } else {
+                throw new RuntimeException("Unexpected result from script evaluation: " + result);
+            }
+        }
+
+        private Script.ContextTarget scriptTarget() {
+            return new Script.ContextTarget(context(), "heritrix");
+        }
+
+        @Override
+        public <T> T evalPromise(String script, Object... args) {
+            return callFunction(script, true, args);
+        }
+    }
+}

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -313,7 +313,24 @@ http://example.example/example
  <bean id="extractorJs" class="org.archive.modules.extractor.ExtractorJS">
  </bean>
  <bean id="extractorSwf" class="org.archive.modules.extractor.ExtractorSWF">
- </bean>    
+ </bean>
+ <!--
+ <bean id="browser" class="org.archive.crawler.processor.Browser">
+  <property name="behaviors">
+   <list>
+    <bean class="org.archive.modules.behaviors.ScrollDown" />
+    <bean class="org.archive.modules.behaviors.ExtractLinks" />
+   </list>
+  </property>
+  <property name="concurrency" value="20" />
+  <property name="executable" value="firefox" />
+  <property name="options">
+   <list>
+    <value>-headless</value>
+   </list>
+  </property>
+ </bean>
+ -->
  <!-- now, processors are assembled into ordered FetchChain bean -->
  <bean id="fetchProcessors" class="org.archive.modules.FetchChain">
   <property name="processors">
@@ -341,6 +358,8 @@ http://example.example/example
     <ref bean="extractorJs"/>
     <!-- ...extract outlinks from Flash content... -->
     <ref bean="extractorSwf"/>
+    <!-- ...visit in a web browser... -->
+    <!-- <ref bean="browser"/> -->
    </list>
   </property>
  </bean>

--- a/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
+++ b/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
@@ -1,0 +1,119 @@
+package org.archive.crawler.processor;
+
+import com.sun.net.httpserver.HttpServer;
+import org.archive.crawler.framework.CrawlController;
+import org.archive.modules.*;
+import org.archive.modules.fetcher.DefaultServerCache;
+import org.archive.modules.fetcher.FetchHTTP2;
+import org.archive.net.UURIFactory;
+import org.archive.util.Recorder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BrowserTest {
+    private static final System.Logger logger = System.getLogger(BrowserTest.class.getName());
+
+    private static HttpServer httpServer;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @EnabledIfSystemProperty(named = "runBrowserTests", matches = "true")
+    public void test() throws IOException, InterruptedException {
+        String url = "http://" + httpServer.getAddress().getAddress().getHostAddress() + ":" +
+                httpServer.getAddress().getPort() + "/";
+        var fetcher = new FetchHTTP2(new DefaultServerCache(), null);
+        fetcher.setUserAgentProvider(new CrawlMetadata());
+        fetcher.start();
+        try {
+            var crawlController = new CrawlController();
+            FetchChain fetchChain = new FetchChain();
+            fetchChain.setProcessors(List.of());
+            crawlController.setFetchChain(fetchChain);
+
+            var subrequests = new ArrayList<CrawlURI>();
+
+            DispositionChain dispositionChain = new DispositionChain();
+            dispositionChain.setProcessors(List.of(new Processor() {
+                @Override
+                protected boolean shouldProcess(CrawlURI uri) {
+                    return true;
+                }
+
+                @Override
+                protected void innerProcess(CrawlURI uri) throws InterruptedException {
+                    subrequests.add(uri);
+                }
+            }));
+            crawlController.setDispositionChain(dispositionChain);
+            crawlController.getScratchDir().setPath(tempDir.toString());
+            var browserProcessor = new Browser(fetcher, crawlController, event -> {}, null);
+            try {
+                browserProcessor.start();
+
+                CrawlURI crawlURI = new CrawlURI(UURIFactory.getInstance(url));
+                crawlURI.setRecorder(new Recorder(tempDir.toFile(), "fetcher"));
+                fetcher.process(crawlURI);
+                assertEquals(200, crawlURI.getFetchStatus());
+                browserProcessor.innerProcess(crawlURI);
+
+                var outLinks = new ArrayList<>(crawlURI.getOutLinks());
+                assertEquals("/link", outLinks.get(0).getUURI().getPath());
+                assertTrue(crawlURI.getAnnotations().contains("browser"));
+
+                logger.log(DEBUG, "Subrequests: {0}", subrequests);
+            } finally {
+                browserProcessor.stop();
+            }
+        } finally {
+            fetcher.stop();
+        }
+    }
+
+    @BeforeAll
+    static void startHttpServer() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), -1);
+        httpServer.createContext("/", exchange -> {
+            logger.log(DEBUG, "Server received request: {0} {1}",  exchange.getRequestMethod(), exchange.getRequestURI());
+
+            String contentType = "text/html";
+            int status = 200;
+            String body = "";
+            switch (exchange.getRequestURI().getPath()) {
+                case "/" -> {
+                    body = "<link href=style.css rel=stylesheet><a href=\"/link\">link</a><img src=img.jpg>";
+                }
+                case "/style.css" -> {
+                    body = "body { color: red; background: url(bg.jpg); }";
+                    contentType = "text/css";
+                }
+                default -> status = 404;
+            }
+            exchange.getResponseHeaders().add("Content-Type", contentType);
+            exchange.sendResponseHeaders(status, 0);
+            exchange.getResponseBody().write(body.getBytes());
+            exchange.close();
+        });
+        httpServer.start();
+    }
+
+    @AfterAll
+    static void stopHttpServer() {
+        if (httpServer != null) httpServer.stop(0);
+    }
+
+}

--- a/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
+++ b/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
@@ -6,10 +6,9 @@ import org.archive.modules.*;
 import org.archive.modules.fetcher.DefaultServerCache;
 import org.archive.modules.fetcher.FetchHTTP2;
 import org.archive.net.UURIFactory;
+import org.archive.url.URIException;
 import org.archive.util.Recorder;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -18,73 +17,77 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static org.junit.jupiter.api.Assertions.*;
 
+@EnabledIfSystemProperty(named = "runBrowserTests", matches = "true")
 class BrowserTest {
     private static final System.Logger logger = System.getLogger(BrowserTest.class.getName());
 
     private static HttpServer httpServer;
-
+    private static FetchHTTP2 fetcher;
+    private static Browser browser;
+    private static String baseUrl;
+    private static ArrayList<CrawlURI> subrequests;
+    private static CrawlController crawlController;
+    private Set<Recorder> recorders = new HashSet<>();
     @TempDir
     Path tempDir;
 
     @Test
-    @EnabledIfSystemProperty(named = "runBrowserTests", matches = "true")
+    @Disabled
     public void test() throws IOException, InterruptedException {
-        String url = "http://" + httpServer.getAddress().getAddress().getHostAddress() + ":" +
-                httpServer.getAddress().getPort() + "/";
-        var fetcher = new FetchHTTP2(new DefaultServerCache(), null);
-        fetcher.setUserAgentProvider(new CrawlMetadata());
-        fetcher.start();
-        try {
-            var crawlController = new CrawlController();
-            FetchChain fetchChain = new FetchChain();
-            fetchChain.setProcessors(List.of());
-            crawlController.setFetchChain(fetchChain);
+        CrawlURI crawlURI = newCrawlURI(baseUrl);
+        fetcher.process(crawlURI);
+        assertEquals(200, crawlURI.getFetchStatus());
+        browser.innerProcess(crawlURI);
 
-            var subrequests = new ArrayList<CrawlURI>();
+        var outLinks = new ArrayList<>(crawlURI.getOutLinks());
+        assertEquals("/link", outLinks.get(0).getUURI().getPath());
+        assertTrue(crawlURI.getAnnotations().contains("browser"));
 
-            DispositionChain dispositionChain = new DispositionChain();
-            dispositionChain.setProcessors(List.of(new Processor() {
-                @Override
-                protected boolean shouldProcess(CrawlURI uri) {
-                    return true;
-                }
+        logger.log(DEBUG, "Subrequests: {0}", subrequests);
+    }
 
-                @Override
-                protected void innerProcess(CrawlURI uri) throws InterruptedException {
-                    subrequests.add(uri);
-                }
-            }));
-            crawlController.setDispositionChain(dispositionChain);
-            crawlController.getScratchDir().setPath(tempDir.toString());
-            var browserProcessor = new Browser(fetcher, crawlController, event -> {}, null);
-            try {
-                browserProcessor.start();
+    @Test
+    public void testDownload() throws IOException, InterruptedException {
+        CrawlURI crawlURI = newCrawlURI(baseUrl + "download.bin");
+        fetcher.process(crawlURI);
+        assertEquals(200, crawlURI.getFetchStatus());
+        browser.innerProcess(crawlURI);
+    }
 
-                CrawlURI crawlURI = new CrawlURI(UURIFactory.getInstance(url));
-                crawlURI.setRecorder(new Recorder(tempDir.toFile(), "fetcher"));
-                fetcher.process(crawlURI);
-                assertEquals(200, crawlURI.getFetchStatus());
-                browserProcessor.innerProcess(crawlURI);
+    private CrawlURI newCrawlURI(String uri) throws URIException {
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance(uri));
+        Recorder recorder = new Recorder(tempDir.toFile(), "fetcher");
+        recorders.add(recorder);
+        curi.setRecorder(recorder);
+        return curi;
+    }
 
-                var outLinks = new ArrayList<>(crawlURI.getOutLinks());
-                assertEquals("/link", outLinks.get(0).getUURI().getPath());
-                assertTrue(crawlURI.getAnnotations().contains("browser"));
+    @BeforeEach
+    void setUp() {
+        crawlController.getScratchDir().setPath(tempDir.toString());
+    }
 
-                logger.log(DEBUG, "Subrequests: {0}", subrequests);
-            } finally {
-                browserProcessor.stop();
-            }
-        } finally {
-            fetcher.stop();
+    @AfterEach
+    void tearDown() {
+        subrequests.clear();
+        for (Recorder recorder : recorders) {
+            recorder.cleanup();
         }
     }
 
     @BeforeAll
+    static void setUpAll() throws Exception {
+        startHttpServer();
+        startProcessors();
+    }
+
     static void startHttpServer() throws IOException {
         httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), -1);
         httpServer.createContext("/", exchange -> {
@@ -101,6 +104,10 @@ class BrowserTest {
                     body = "body { color: red; background: url(bg.jpg); }";
                     contentType = "text/css";
                 }
+                case "/download.bin" -> {
+                    body = "sample-download-file";
+                    contentType = "application/octet-stream";
+                }
                 default -> status = 404;
             }
             exchange.getResponseHeaders().add("Content-Type", contentType);
@@ -109,11 +116,43 @@ class BrowserTest {
             exchange.close();
         });
         httpServer.start();
+        baseUrl = "http://" + httpServer.getAddress().getAddress().getHostAddress() + ":" +
+                     httpServer.getAddress().getPort() + "/";
+    }
+
+    static void startProcessors() {
+        fetcher = new FetchHTTP2(new DefaultServerCache(), null);
+        fetcher.setUserAgentProvider(new CrawlMetadata());
+        fetcher.start();
+        crawlController = new CrawlController();
+        FetchChain fetchChain = new FetchChain();
+        fetchChain.setProcessors(List.of());
+        crawlController.setFetchChain(fetchChain);
+
+        subrequests = new ArrayList<CrawlURI>();
+
+        DispositionChain dispositionChain = new DispositionChain();
+        dispositionChain.setProcessors(List.of(new Processor() {
+            @Override
+            protected boolean shouldProcess(CrawlURI uri) {
+                return true;
+            }
+
+            @Override
+            protected void innerProcess(CrawlURI uri) throws InterruptedException {
+                subrequests.add(uri);
+            }
+        }));
+        crawlController.setDispositionChain(dispositionChain);
+        browser = new Browser(fetcher, crawlController, event -> {}, null);
+            browser.start();
     }
 
     @AfterAll
-    static void stopHttpServer() {
+    static void tearDownAll() {
         if (httpServer != null) httpServer.stop(0);
+        if (browser != null) browser.stop();
+        if (fetcher != null) fetcher.stop();
     }
 
 }

--- a/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
+++ b/engine/src/test/java/org/archive/crawler/processor/BrowserTest.java
@@ -58,7 +58,11 @@ class BrowserTest {
         CrawlURI crawlURI = newCrawlURI(baseUrl + "download.bin");
         fetcher.process(crawlURI);
         assertEquals(200, crawlURI.getFetchStatus());
+        assertFalse(browser.shouldProcess(crawlURI), "content-disposition header should skip processing");
+
+        // force processing anyway to test the behavior for other download reasons (e.g. non-HTML)
         browser.innerProcess(crawlURI);
+        assertFalse(crawlURI.getAnnotations().contains("browser"), "navigation should have aborted");
     }
 
     private CrawlURI newCrawlURI(String uri) throws URIException {
@@ -106,7 +110,7 @@ class BrowserTest {
                 }
                 case "/download.bin" -> {
                     body = "sample-download-file";
-                    contentType = "application/octet-stream";
+                    exchange.getResponseHeaders().add("Content-Disposition", "attachment; filename=heritrix-test.bin");
                 }
                 default -> status = 404;
             }

--- a/engine/src/test/resources/logging.properties
+++ b/engine/src/test/resources/logging.properties
@@ -1,0 +1,10 @@
+.level = INFO
+
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT [%4$s] %2$s - %5$s%6$s%n
+
+org.archive.crawler.processor.Browser.level = FINEST
+org.archive.crawler.processor.BrowserTest.level = FINEST
+#org.archive.net.webdriver.level = FINEST

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -86,22 +86,14 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-proxy</artifactId>
-			<version>${jetty.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 			<version>${slf4j.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.ftpserver</groupId>

--- a/modules/src/main/java/org/archive/modules/behaviors/Behavior.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/Behavior.java
@@ -1,0 +1,24 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.modules.behaviors;
+
+public interface Behavior {
+    void run(Page page);
+}

--- a/modules/src/main/java/org/archive/modules/behaviors/Behavior.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/Behavior.java
@@ -21,4 +21,8 @@ package org.archive.modules.behaviors;
 
 public interface Behavior {
     void run(Page page);
+
+    default String report() {
+        return "  Behavior: " + getClass().getName() + "\n";
+    }
 }

--- a/modules/src/main/java/org/archive/modules/behaviors/ExtractLinks.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/ExtractLinks.java
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.modules.behaviors;
+
+import org.archive.url.URIException;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.extractor.Hop;
+import org.archive.modules.extractor.LinkContext;
+import org.archive.modules.extractor.UriErrorLoggerModule;
+import org.archive.net.UURI;
+import org.archive.net.UURIFactory;
+
+import java.util.List;
+
+public class ExtractLinks implements Behavior {
+    private final UriErrorLoggerModule loggerModule;
+
+    public ExtractLinks(UriErrorLoggerModule loggerModule) {
+        this.loggerModule = loggerModule;
+    }
+
+    public void run(Page page) {
+        List<String> urls = page.eval(/* language=JavaScript */ """
+                () => {
+                    const links = new Set();
+                    for (const el of document.querySelectorAll('a[href]')) {
+                        let href = el.href;
+                        if (href instanceof SVGAnimatedString) {
+                            href = new URL(href.baseVal, el.ownerDocument.location.href).toString();
+                        }
+                        if (href.startsWith('http://') || href.startsWith('https://')) {
+                            links.add(href.replace(/#.*$/, ''));
+                        }
+                    }
+                    return Array.from(links);
+                }""");
+        for (var url : urls) {
+            try {
+                UURI dest = UURIFactory.getInstance(page.curi().getUURI(), url);
+                CrawlURI link = page.curi().createCrawlURI(dest, LinkContext.NAVLINK_MISC, Hop.NAVLINK);
+                page.curi().getOutLinks().add(link);
+            } catch (URIException e) {
+                loggerModule.logUriError(e, page.curi().getUURI(), url);
+            }
+        }
+    }
+}

--- a/modules/src/main/java/org/archive/modules/behaviors/ExtractLinks.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/ExtractLinks.java
@@ -28,8 +28,10 @@ import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ExtractLinks implements Behavior {
+    private final AtomicLong numberOfLinksExtracted = new AtomicLong(0);
     private final UriErrorLoggerModule loggerModule;
 
     public ExtractLinks(UriErrorLoggerModule loggerModule) {
@@ -56,9 +58,15 @@ public class ExtractLinks implements Behavior {
                 UURI dest = UURIFactory.getInstance(page.curi().getUURI(), url);
                 CrawlURI link = page.curi().createCrawlURI(dest, LinkContext.NAVLINK_MISC, Hop.NAVLINK);
                 page.curi().getOutLinks().add(link);
+                numberOfLinksExtracted.incrementAndGet();
             } catch (URIException e) {
                 loggerModule.logUriError(e, page.curi().getUURI(), url);
             }
         }
+    }
+
+    @Override
+    public String report() {
+        return Behavior.super.report() + "    Links extracted: " + numberOfLinksExtracted.get() + "\n";
     }
 }

--- a/modules/src/main/java/org/archive/modules/behaviors/Page.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/Page.java
@@ -1,0 +1,34 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.modules.behaviors;
+
+import org.archive.modules.CrawlURI;
+
+/**
+ * Represents a {@link CrawlURI} loaded as web page that a @{@link Behavior} can
+ * interact with.
+ */
+public interface Page {
+    CrawlURI curi();
+
+    <T> T eval(String script, Object... args);
+
+    <T> T evalPromise(String script, Object... args);
+}

--- a/modules/src/main/java/org/archive/modules/behaviors/ScrollDown.java
+++ b/modules/src/main/java/org/archive/modules/behaviors/ScrollDown.java
@@ -1,0 +1,66 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.modules.behaviors;
+
+/**
+ * Scrolls the page down until it reaches the bottom (or until a timeout is reached).
+ */
+public class ScrollDown implements Behavior {
+    private long timeout = 5000;
+    private int scrollInterval = 50;
+
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+
+    public void setScrollInterval(int scrollInterval) {
+        this.scrollInterval = scrollInterval;
+    }
+
+    @Override
+    public void run(Page page) {
+        page.evalPromise(/* language=JavaScript */ """
+                (timeout, scrollInterval) => {
+                return new Promise((doneCallback, reject) => {
+                    const startTime = Date.now();
+                
+                    function scroll() {
+                        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+                            // We've reached the bottom of the page
+                            doneCallback();
+                            return;
+                        }
+                
+                        if (Date.now() - startTime > timeout) {
+                            // We've exceeded the timeout
+                            doneCallback();
+                            return;
+                        }
+                
+                        const scrollStep = document.scrollingElement.clientHeight * 0.2;
+                
+                        window.scrollBy({top: scrollStep, behavior: "instant"});
+                        setTimeout(scroll, scrollInterval);
+                    }
+                
+                    scroll();
+                })}""", timeout, scrollInterval);
+    }
+}


### PR DESCRIPTION
The Browser processor can load a fetched page in a local web browser, record any requests the browser makes and run behaviors that interact with the page such as scrolling down and extracting links.

This needs some more testing and more error handling but is working for small crawls with Firefox and ChromeDriver.

This differs from my previous attempt (ExtractorChrome #403) in a number of ways:

- Uses the new WebDriver BiDi standard instead of the Chrome Devtools Protocol. The new protocol is mostly browser-agnostic, more consistent and hopefully more stable. It doesn't quite do everything CDP does, but most of the important stuff is there.

- Uses a MITM proxy instead of CDP request interception for recording sub-resources. That's partly because BiDi is still missing some key interception APIs (like request bodies). But in practice I anyway found the proxy method loads pages faster and more reliably. Perhaps because responses can be streamed incrementally, which helps a lot for large resources and server-sent events. It does unfortunately make the remote browser support a little more difficult (but should still be quite doable).

- This builds on the new FetchHTTP2 module (#649) which does connection pooling making subrequests a lot faster. The original FetchHTTP opens a new connection for every request which is quite slow for browsing.

- The Browser processor can be configured with a list of behavior beans making it extensible.

- The BiDi protocol is described with typed interfaces and records implemented by a Java Proxy. It's mostly synchronous for ease of use but when useful you can define an asynchronous method by returning CompletableFuture.

Some obvious areas for future development:

- More Behavior beans: take screenshots, save the rendered DOM, run Browsertrix-compatible behavior scripts

- Support for remote WebDrivers (e.g. Selenium Server or cloud browser services)

- UI integration for monitoring the browser

- I just did basic record mapping on top of the json.org library Heritrix is already using, but as Heritrix's JSON needs evolve it might make sense to switch to something like Jackson.