### PR TITLE
Add `--web-auth basic` command-line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/internetarchive/heritrix3/compare/3.9.0...HEAD)
 
+#### New features
+
+- **Basic web auth:** You can now switch the web interface from Digest authentication to Basic authentication
+  with the `--web-auth basic` command-line option. This is useful when running Heritrix behind a reverse proxy that
+  adds external authentication.
+
 #### Fixes
 
 - **Code editor:** The configuration editor and script console were upgraded to CodeMirror 6. This resolves some browser

--- a/docs/operating.rst
+++ b/docs/operating.rst
@@ -42,6 +42,8 @@ Command-line Options
             Specifies a keystore path, keystore password, and key password for HTTPS use.  Separate the values with
             commas and do not include whitespace. By default Heritrix will generate a self-signed certificate the
             first time it is run.
+--web-auth digest|basic
+            Authentication mode for the web interface. **Default:** ``digest``
 
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/RateLimitGuard.java
@@ -22,6 +22,7 @@ import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.Response;
 import org.restlet.ext.crypto.DigestAuthenticator;
+import org.restlet.security.LocalVerifier;
 
 import java.util.logging.Logger;
 
@@ -38,8 +39,9 @@ public class RateLimitGuard extends DigestAuthenticator {
 
     protected long lastFailureTime = 0;
     
-    public RateLimitGuard(Context context, String realm, String serverKey) throws IllegalArgumentException {
+    public RateLimitGuard(Context context, String realm, String serverKey, LocalVerifier verifier) throws IllegalArgumentException {
         super(context, realm, serverKey);
+        setWrappedVerifier(verifier);
     }
 
     @Override


### PR DESCRIPTION
This option enables HTTP Basic authentication for the web interface instead of the default Digest authentication. This is useful when running Heritrix behind a reverse proxy that adds external authentication as typically they don't support Digest auth for the upstream server.

#641