### PR TITLE
Updated Dockerfile and Docker- compose.yml to heritrix v3.9.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,8 @@ RUN \
 # Install dependencies
 RUN \
     apt-get update && \
-    apt-get install -y && \
-    wget && \
+    apt-get install -y \
+    wget \
     unzip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-ARG java=11-jre
+ARG java=21-jdk-slim
 
 FROM openjdk:${java}
 
-ARG version="3.4.0-20210923"
+ARG version="3.9.0"
 ARG user="heritrix"
 ARG userid=1000
 
@@ -14,10 +14,18 @@ RUN \
     groupadd -g $userid $user && \
     useradd -r -u $userid -g $user $user
 
+# Install dependencies
+RUN \
+    apt-get update && \
+    apt-get install -y && \
+    wget && \
+    unzip && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt
 
 # download latest version according to:
-#   https://github.com/internetarchive/heritrix3/releases/tag/3.4.0-20210923
+#   https://github.com/internetarchive/heritrix3/releases/tag/3.9.0
 RUN \
     wget -O heritrix-${version}-dist.zip https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/${version}/heritrix-${version}-dist.zip && \
     unzip heritrix-${version}-dist.zip && \

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -18,9 +18,9 @@ RUN \
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    youtube-dl && \
-    wget && \
-    unzip && \
+    youtube-dl \
+    wget \
+    tar && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -1,8 +1,8 @@
-ARG java=8-jre
+ARG java=21-jdk-slim
 
 FROM openjdk:${java}
 
-ARG version="3.4.0-20210923"
+ARG version="3.9.0"
 ARG user="heritrix"
 ARG userid=1000
 
@@ -14,11 +14,13 @@ RUN \
     groupadd -g $userid $user && \
     useradd -r -u $userid -g $user $user
 
-# install other requirements (for contrib)
+# install dependencies and other requirements (for contrib)
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     youtube-dl && \
+    wget && \
+    unzip && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.7"
 services:
 
   heritrix:
-    image: heritrix
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: heritrix
     # TEST: keeps the container running without doing anything (for inspections)
     # entrypoint: bash -c 'while :; do :; done & kill -STOP $$! && wait $$!'


### PR DESCRIPTION
Updated docker file to the newest version, it was using version 3.4.0-20210923 in the Dockerfile.
It was also using 8-jre image to build, i updated to the latest version of 21-jdk-slim. it also requested to add 2 dependencies to build the zip file and tar to the Dockerfile.contrib