### PR TITLE
fix: handle bdb shutdown interrupts

### DIFF
--- a/commons/src/main/java/org/archive/bdb/StoredQueue.java
+++ b/commons/src/main/java/org/archive/bdb/StoredQueue.java
@@ -93,6 +93,7 @@ public class StoredQueue<E extends Serializable> extends AbstractQueue<E>  {
     @Override
     public int size() {
         try {
+            Thread.interrupted();
             return Math.max(0, 
                     (int)(tailIndex.get() 
                           - queueMap.firstKey())); 

--- a/engine/src/main/java/org/archive/crawler/framework/CrawlController.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlController.java
@@ -423,7 +423,8 @@ implements Serializable,
     public synchronized void requestCrawlStop() {
         if(state == State.STOPPING) {
             // second stop request; nudge the threads with interrupts
-            getToePool().cleanup();
+            if (getToePool() != null)
+                getToePool().cleanup();
         }
         requestCrawlStop(CrawlStatus.ABORTED);
     }

--- a/modules/src/main/java/org/archive/modules/fetcher/BdbCookieStore.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/BdbCookieStore.java
@@ -134,7 +134,7 @@ public class BdbCookieStore extends AbstractCookieStore implements
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e); // impossible
         }
-
+        Thread.interrupted();
         if (!cookie.isExpired(new Date())) {
             cookies.put(key, cookie);
         } else {
@@ -144,7 +144,7 @@ public class BdbCookieStore extends AbstractCookieStore implements
     
     public boolean expireCookie(Cookie cookie, Date date) {
         byte[] key = sortableKey(cookie).getBytes(StandardCharsets.UTF_8);
-
+        Thread.interrupted();
         if (cookie.isExpired(date)) {
             cookies.remove(key);
             return true;
@@ -160,6 +160,7 @@ public class BdbCookieStore extends AbstractCookieStore implements
             char chAfterDelim = (char)(((int)';')+1); 
             byte[] endKey = (host + chAfterDelim).getBytes("UTF-8");
 
+            Thread.interrupted();
             SortedMap<byte[], Cookie> submap = cookies.subMap(startKey, endKey);
             return submap.values();
 
@@ -225,6 +226,7 @@ public class BdbCookieStore extends AbstractCookieStore implements
 
     @Override
     public void clear() {
+        Thread.interrupted();
         cookies.clear();
     }
 
@@ -234,6 +236,7 @@ public class BdbCookieStore extends AbstractCookieStore implements
     @Override
     public List<Cookie> getCookies() {
         if (cookies != null) {
+            Thread.interrupted();
             return new RestrictedCollectionWrappedList<Cookie>(cookies.values());
         } else {
             return null;


### PR DESCRIPTION
When `CrawlController.requestCrawlStop()` is triggered multiple times, `Thread.interrupt()` is called on each of the toe threads every time. If BDB is accessed while the interrupted status flag is set, the environment is invalidated and all subsequent interactions will fail.  This error only occurs during with specific timing, but you can trigger this by repeatedly hitting 'Terminate' in UI.

The BdbFrontier avoids this with a lock that is triggered during shutdown, leaving only a few interactions that occur during shutdown.  Preceding these calls with `Thread.interrupted()` clears the flag and allows the environment to survive the shutdown. A more robust solution may be to move all BDB interactions into a separate thread, but I'm unable to replicate the issue with these checks in place.