### PR TITLE
Seeds report: record redirect URI for statuses 303, 307 and 308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - HTTP/1.1 is now used on servers that don't support ALPN. Fixes `IOException: frame_size_error/invalid_frame_length`
   - Fixed NullPointerException when the server's IP address isn't available. 
 
+- **Seeds report:** Redirect URIs are now recorded from the `Location` header for HTTP status codes `303 See other`, 
+ `307 Temporary Redirect` and `308 Permanent Redirect`.
+  Previously this was only done for `301 Moved Permanently` and `302 Found`. 
+
 ## [3.10.0](https://github.com/internetarchive/heritrix3/releases/tag/3.10.0)  (2025-06-12)
 
 [Download distribution zip](https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/3.10.0/heritrix-3.10.0-dist.zip) (

--- a/engine/src/main/java/org/archive/crawler/reporting/SeedRecord.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/SeedRecord.java
@@ -109,7 +109,7 @@ public class SeedRecord implements CoreAttributeConstants, Serializable, Identit
         }
         this.statusCode = curi.getFetchStatus();
         this.disposition = disposition;
-        if (statusCode==301 || statusCode == 302) {
+        if (statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 307 || statusCode == 308) {
             for (CrawlURI cauri: curi.getOutLinks()) {
                 if("location:".equalsIgnoreCase(cauri.getViaContext().
                         toString())) {


### PR DESCRIPTION
These can also redirect, not just 301 and 302.

Fixes #564