### PR TITLE
fix: don't restore crawlEndTime when resuming from checkpoint.

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
@@ -354,7 +354,7 @@ public class StatisticsTracker
                 JSONObject json = recoveryCheckpoint.loadJson(beanName);
                 
                 crawlStartTime = json.getLong("crawlStartTime");
-                crawlEndTime = json.getLong("crawlEndTime");
+                // skip crawlEndTime - crawl is not ended if we're recovering
                 crawlTotalPausedTime = json.getLong("crawlTotalPausedTime");
                 crawlPauseStarted = json.getLong("crawlPauseStarted");
                 tallyCurrentPause();


### PR DESCRIPTION
`crawlEndTime` remains set to `-1` while a crawl is running, and `statisticsTracker.getCrawlElapsedTime()` relies on this to calculate how long the crawl has run. `crawlEndTime` is only set to a timestamp when the crawl has terminated, but it is possible to trigger a checkpoint after termination and before teardown. Doing so results in a checkpoint that has a positive value for `crawlEndTime`. Resuming from this checkpoint results in a state where the crawl is running, but `crawlEndTime` is set, which can make the elapsed time calculation return a negative value which then breaks the `CrawlLimitEnforcer` max time limit.