### PR TITLE
fix: sheet setting of extractorJs.strict doesn't work without kp keyname matching

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ConfigurableExtractorJS.java
@@ -47,10 +47,10 @@ public class ConfigurableExtractorJS extends ExtractorJS {
 	
     /** If true, then only extract non-relative paths */
     public boolean getStrict() {
-        return (Boolean) kp.get("strictMode");
+        return (Boolean) kp.get("strict");
     }
     public void setStrict(boolean strict) {
-        kp.put("strictMode", strict);
+        kp.put("strict", strict);
     }
     {
     	setStrict(false);


### PR DESCRIPTION
I didn't realize this was a requirement, but it seems that the naming of the KeyedProperties key is critical when creating a bean property that can be overridden via a sheet.

Experimentally, I've determined that when we have a property like:
``` 
public boolean getStrict() {
    return (Boolean) kp.get("strictMode");
}
```
Then the override will not apply. We cannot have a sheet referencing `extractorJs.strictMode` due to an `InvalidPropertyException`, and if we use `extractorJs.strict`, it is considered valid, but the value of `strict` never gets overridden.

However, if the property is like:
```
public boolean getStrict() {
    return (Boolean) kp.get("strict");
}
```
Then the override value for `extractorJs.strict` applies as expected.

Here are the beans I used in my testing, with a seed of `https://epidemics.web.ox.ac.uk/`:
```
<bean id="extractorJs" class="org.archive.modules.extractor.KnowledgableExtractorJS">
</bean>
  <bean id="extractorJsStrictMode" class="org.archive.spring.Sheet">
    <property name="map">
      <map>
        <entry key="extractorJs.strict" value="true"/>
      </map>
    </property>
  </bean>
    <bean id="enableStrictJsExtraction" class="org.archive.crawler.spring.SurtPrefixesSheetAssociation">
    <property name="surtPrefixes">
      <list>
        <value>http://(uk,ac,</value>
      </list>
    </property>
    <property name="targetSheetNames">
      <list>
        <value>extractorJsStrictMode</value>
      </list>
    </property>
  </bean>
```