### PR TITLE
feat: Add configurable regex rules to block extraction of script tags based on the attributes of the tag.

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -721,7 +721,6 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
         }
     }
 
-
     /**
      * Extract the (java)script source in the given CharSequence.
      *
@@ -732,6 +731,21 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
         if (getExtractorJS() != null && getExtractJavascript()) {
             numberOfLinksExtracted.addAndGet(
                 getExtractorJS().considerStrings(this, curi, cs));
+        }
+    }
+
+    /**
+     * Extract the (java)script source in the given CharSequence.
+     *
+     * @param curi  source CrawlURI
+     * @param cs    CharSequence of javascript code
+     * @param attributeContext  attributes of the tag from which the script
+     *                          was extracted (e.g. "onload", "onclick", "data-", etc.)
+     */
+    protected void processScriptCode(CrawlURI curi, CharSequence cs, String attributeContext) {
+        if (getExtractorJS() != null && getExtractJavascript()) {
+            numberOfLinksExtracted.addAndGet(
+                    getExtractorJS().considerStrings(this, curi, cs, attributeContext));
         }
     }
 
@@ -1041,6 +1055,11 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
 
         // then, apply best-effort string-analysis heuristics
         // against any code present (false positives are OK)
+        if(endOfOpenTag > 6) {
+            String attributes = sequence.subSequence(6, endOfOpenTag).toString().strip();
+            processScriptCode(
+                    curi, sequence.subSequence(endOfOpenTag, sequence.length()), attributes);
+        }
         processScriptCode(
             curi, sequence.subSequence(endOfOpenTag, sequence.length()));
     }

--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
@@ -137,6 +137,10 @@ public class ExtractorJS extends ContentExtractor {
             CrawlURI curi, CharSequence cs) {
         return considerStrings(ext, curi, cs, false);
     }
+    public long considerStrings(Extractor ext,
+            CrawlURI curi, CharSequence cs, String attributeContext) {
+        return considerStrings(ext, curi, cs, false);
+    }
     
     public long considerStrings(Extractor ext, 
             CrawlURI curi, CharSequence cs, boolean handlingJSFile) {


### PR DESCRIPTION
When handling <script> tags, we normally strip the attributes. This change passes them along as an additional parameter to ExtractorJS. The base class ignores them, but this hook allows ConfigurableExtractorJS to add a list of regex rules to match against the attributes and block extraction of the script tag.