### PR TITLE
docs: replace javalang with an annotation processor

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,14 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
+  apt_packages:
+    - default-jdk
+    - maven
+  jobs:
+    pre_build:
+      - mvn compile
 sphinx:
   configuration: docs/conf.py
 python:

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.archive</groupId>
+        <artifactId>heritrix</artifactId>
+        <version>3.11.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.archive.heritrix</groupId>
+    <artifactId>heritrix-docgen</artifactId>
+    <packaging>jar</packaging>
+    <name>Heritrix 3: 'docgen' subproject</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- prevent attempting to run docgen on itself -->
+                    <proc>none</proc>
+                    <annotationProcessorPaths combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/docgen/src/main/java/org/archive/crawler/BeanDocProcessor.java
+++ b/docgen/src/main/java/org/archive/crawler/BeanDocProcessor.java
@@ -1,0 +1,207 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.crawler;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.source.tree.*;
+import com.sun.source.util.Trees;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.tools.StandardLocation;
+import java.beans.Introspector;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedAnnotationTypes("*")
+public class BeanDocProcessor extends AbstractProcessor {
+    private Trees trees;
+    private Map<String, Bean> classes = new LinkedHashMap<>();
+    private final Pattern DOC_CLEANUP = Pattern.compile("^\\s*@(?:author|version|see).*", Pattern.MULTILINE);
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        this.trees = Trees.instance(processingEnv);
+    }
+
+    private String getDocComment(Element element) {
+        var path = trees.getPath(element);
+        if (path == null) return null; // no source available
+        String docComment = trees.getDocComment(path);
+        if (docComment == null) return null;
+        docComment = docComment.replace("\n ", "\n"); // remove indent
+        return DOC_CLEANUP.matcher(docComment).replaceAll("").trim();
+    }
+
+    private class FieldInfo {
+        private String docComment;
+        private Object initializer;
+
+        public FieldInfo(VariableElement field) {
+            VariableTree vt = (VariableTree) trees.getTree(field);
+            if (vt != null) {
+                ExpressionTree init = vt.getInitializer();
+                if (init instanceof LiteralTree lit) {
+                    initializer = lit.getValue();
+                }
+            }
+
+            docComment = getDocComment(field);
+        }
+    }
+
+    public class Bean {
+        public final String superclass;
+        public final String description;
+        public final HashMap<String, Property> properties;
+
+        Bean(TypeElement type) {
+            superclass = getSuperclass(type);
+            description = getDocComment(type);
+            properties = getProperties(type);
+        }
+    }
+
+    public class Property {
+        @JsonProperty("default")
+        public Object defaultValue;
+        public String description;
+        public String type;
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        for (var root : round.getRootElements()) {
+            if (root.getKind().isClass()) {
+                processClass((TypeElement) root);
+            }
+        }
+
+        if (round.processingOver()) {
+            writeJsonOutput();
+        }
+
+        return false;
+    }
+
+    private void writeJsonOutput() {
+        var objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+        try (Writer writer = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
+                "META-INF/heritrix-beans.json").openWriter()) {
+            objectMapper.writeValue(writer, classes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void processClass(TypeElement type) {
+        String className = processingEnv.getElementUtils().getBinaryName(type).toString();
+        classes.put(className, new Bean(type));
+    }
+
+    private HashMap<String, Property> getProperties(TypeElement type) {
+        // Visit fields
+        var fields = new HashMap<String, FieldInfo>();
+        for (VariableElement field : ElementFilter.fieldsIn(type.getEnclosedElements())) {
+            fields.put(field.getSimpleName().toString(), new FieldInfo(field));
+        }
+
+        // Visit initializers like `setMyProperty(5)`
+        var initializers = new HashMap<String, Object>();
+        ClassTree classTree = trees.getTree(type);
+        if (classTree != null) {
+            for (Tree member : classTree.getMembers()) {
+                if (member.getKind() == Tree.Kind.BLOCK) {
+                    BlockTree block = (BlockTree) member;
+                    if (block.isStatic()) continue; // skip static initializers
+                    for (StatementTree stmt : block.getStatements()) {
+                        if (stmt instanceof ExpressionStatementTree est
+                            && est.getExpression() instanceof MethodInvocationTree mit) {
+                            ExpressionTree select = mit.getMethodSelect();
+                            if (select instanceof IdentifierTree identifier) {
+                                String name = identifier.getName().toString();
+                                if (name.startsWith("set") && mit.getArguments().size() == 1) {
+                                    String prop = Introspector.decapitalize(name.substring(3));
+                                    ExpressionTree arg = mit.getArguments().get(0);
+                                    if (arg instanceof LiteralTree lit) {
+                                        initializers.put(prop, lit.getValue());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Visit setters
+        var properties = new HashMap<String, Property>();
+        for (ExecutableElement method : ElementFilter.methodsIn(type.getEnclosedElements())) {
+            String methodName = method.getSimpleName().toString();
+            if (methodName.startsWith("set")
+                && method.getModifiers().contains(javax.lang.model.element.Modifier.PUBLIC)
+                && method.getParameters().size() == 1) {
+                String propertyName = Introspector.decapitalize(methodName.substring(3));
+
+                var property = new Property();
+                property.description = getDocComment(method);
+                property.type = method.getParameters().get(0).asType().toString();
+
+                var field = fields.get(propertyName);
+                if (field != null) {
+                    if (property.description == null) property.description = field.docComment;
+                    if (field.initializer != null) property.defaultValue = field.initializer;
+                }
+
+                var initValue = initializers.get(propertyName);
+                if (initValue != null) property.defaultValue = initValue;
+
+                properties.put(propertyName, property);
+            }
+        }
+        return properties;
+    }
+
+    private static String getSuperclass(TypeElement type) {
+        TypeMirror superType = type.getSuperclass();
+        if (superType == null || superType.getKind() != TypeKind.DECLARED) return null;
+        TypeElement superElement = (TypeElement) ((DeclaredType) superType).asElement();
+        String superName = superElement.getQualifiedName().toString();
+        if (superName.equals("java.lang.Object")) return null;
+        return superName;
+    }
+}

--- a/docgen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/docgen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.archive.crawler.BeanDocProcessor

--- a/docs/bean-reference.rst
+++ b/docs/bean-reference.rst
@@ -11,92 +11,92 @@ Core Beans
 ActionDirectory
 ~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/framework/ActionDirectory.java
+.. bean-doc:: org.archive.crawler.framework.ActionDirectory
 
 BdbCookieStore
 ~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/BdbCookieStore.java
+.. bean-doc:: org.archive.modules.fetcher.BdbCookieStore
 
 BdbFrontier
 ~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/frontier/BdbFrontier.java
+.. bean-doc:: org.archive.crawler.frontier.BdbFrontier
 
 BdbModule
 ~~~~~~~~~
 
-.. bean-doc:: ../commons/src/main/java/org/archive/bdb/BdbModule.java
+.. bean-doc:: org.archive.bdb.BdbModule
 
 BdbServerCache
 ~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/net/BdbServerCache.java
+.. bean-doc:: org.archive.modules.net.BdbServerCache
 
 BdbUriUniqFilter
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/util/BdbUriUniqFilter.java
+.. bean-doc:: org.archive.crawler.util.BdbUriUniqFilter
 
 CheckpointService
 ~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/framework/CheckpointService.java
+.. bean-doc:: org.archive.crawler.framework.CheckpointService
 
 CrawlController
 ~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/framework/CrawlController.java
+.. bean-doc:: org.archive.crawler.framework.CrawlController
 
 CrawlerLoggerModule
 ~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/reporting/CrawlerLoggerModule.java
+.. bean-doc:: org.archive.crawler.reporting.CrawlerLoggerModule
 
 CrawlLimitEnforcer
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/framework/CrawlLimitEnforcer.java
+.. bean-doc:: org.archive.crawler.framework.CrawlLimitEnforcer
 
 CrawlMetadata
 ~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/CrawlMetadata.java
+.. bean-doc:: org.archive.modules.CrawlMetadata
 
 CredentialStore
 ~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/credential/CredentialStore.java
+.. bean-doc:: org.archive.modules.credential.CredentialStore
 
 DecideRuleSequence
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/DecideRuleSequence.java
+.. bean-doc:: org.archive.modules.deciderules.DecideRuleSequence
 
 DiskSpaceMonitor
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/monitor/DiskSpaceMonitor.java
+.. bean-doc:: org.archive.crawler.monitor.DiskSpaceMonitor
 
 RulesCanonicalizationPolicy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/canonicalize/RulesCanonicalizationPolicy.java
+.. bean-doc:: org.archive.modules.canonicalize.RulesCanonicalizationPolicy
 
 SheetOverlaysManager
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/spring/SheetOverlaysManager.java
+.. bean-doc:: org.archive.crawler.spring.SheetOverlaysManager
 
 StatisticsTracker
 ~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
+.. bean-doc:: org.archive.crawler.reporting.StatisticsTracker
 
 TextSeedModule
 ~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/seeds/TextSeedModule.java
+.. bean-doc:: org.archive.modules.seeds.TextSeedModule
 
 Decide Rules
 ------------
@@ -104,222 +104,222 @@ Decide Rules
 AcceptDecideRule
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/AcceptDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.AcceptDecideRule
 
 ClassKeyMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/deciderules/ClassKeyMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.crawler.deciderules.ClassKeyMatchesRegexDecideRule
 
 ContentLengthDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ContentLengthDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ContentLengthDecideRule
 
 ContentTypeMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ContentTypeMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ContentTypeMatchesRegexDecideRule
 
 ContentTypeNotMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ContentTypeNotMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ContentTypeNotMatchesRegexDecideRule
 
 ExpressionDecideRule (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/deciderules/ExpressionDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ExpressionDecideRule
 
 ExternalGeoLocationDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ExternalGeoLocationDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ExternalGeoLocationDecideRule
 
 FetchStatusDecideRule
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/FetchStatusDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.FetchStatusDecideRule
 
 FetchStatusMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/FetchStatusMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.FetchStatusMatchesRegexDecideRule
 
 FetchStatusNotMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/FetchStatusNotMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.FetchStatusNotMatchesRegexDecideRule
 
 HasViaDecideRule
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/HasViaDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.HasViaDecideRule
 
 HopCrossesAssignmentLevelDomainDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/HopCrossesAssignmentLevelDomainDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.HopCrossesAssignmentLevelDomainDecideRule
 
 HopsPathMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/HopsPathMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.HopsPathMatchesRegexDecideRule
 
 IdenticalDigestDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/recrawl/IdenticalDigestDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.recrawl.IdenticalDigestDecideRule
 
 IpAddressSetDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/IpAddressSetDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.IpAddressSetDecideRule
 
 MatchesFilePatternDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/MatchesFilePatternDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.MatchesFilePatternDecideRule
 
 MatchesListRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/MatchesListRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.MatchesListRegexDecideRule
 
 MatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/MatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.MatchesRegexDecideRule
 
 MatchesStatusCodeDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/MatchesStatusCodeDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.MatchesStatusCodeDecideRule
 
 NotMatchesFilePatternDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/NotMatchesFilePatternDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.NotMatchesFilePatternDecideRule
 
 NotMatchesListRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/NotMatchesListRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.NotMatchesListRegexDecideRule
 
 NotMatchesRegexDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/NotMatchesRegexDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.NotMatchesRegexDecideRule
 
 NotMatchesStatusCodeDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/NotMatchesStatusCodeDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.NotMatchesStatusCodeDecideRule
 
 NotOnDomainsDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/NotOnDomainsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.NotOnDomainsDecideRule
 
 NotOnHostsDecideRule
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/NotOnHostsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.NotOnHostsDecideRule
 
 NotSurtPrefixedDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/NotSurtPrefixedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.NotSurtPrefixedDecideRule
 
 OnDomainsDecideRule
 ~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/OnDomainsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.OnDomainsDecideRule
 
 OnHostsDecideRule
 ~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/OnHostsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.OnHostsDecideRule
 
 PathologicalPathDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/PathologicalPathDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.PathologicalPathDecideRule
 
 PredicatedDecideRule
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/PredicatedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.PredicatedDecideRule
 
 PrerequisiteAcceptDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/PrerequisiteAcceptDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.PrerequisiteAcceptDecideRule
 
 RejectDecideRule
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/RejectDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.RejectDecideRule
 
 ResourceLongerThanDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ResourceLongerThanDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ResourceLongerThanDecideRule
 
 ResourceNoLongerThanDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ResourceNoLongerThanDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ResourceNoLongerThanDecideRule
 
 ResponseContentLengthDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ResponseContentLengthDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ResponseContentLengthDecideRule
 
 SchemeNotInSetDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/SchemeNotInSetDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.SchemeNotInSetDecideRule
 
 ScriptedDecideRule
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ScriptedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ScriptedDecideRule
 
 SeedAcceptDecideRule
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/SeedAcceptDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.SeedAcceptDecideRule
 
 SourceSeedDecideRule
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/SourceSeedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.SourceSeedDecideRule
 
 SurtPrefixedDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/surt/SurtPrefixedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.surt.SurtPrefixedDecideRule
 
 TooManyHopsDecideRule
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/TooManyHopsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.TooManyHopsDecideRule
 
 TooManyPathSegmentsDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/TooManyPathSegmentsDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.TooManyPathSegmentsDecideRule
 
 TransclusionDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/TransclusionDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.TransclusionDecideRule
 
 ViaSurtPrefixedDecideRule
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/deciderules/ViaSurtPrefixedDecideRule.java
+.. bean-doc:: org.archive.modules.deciderules.ViaSurtPrefixedDecideRule
 
 Candidate Processors
 --------------------
@@ -327,12 +327,12 @@ Candidate Processors
 CandidateScoper
 ~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/prefetch/CandidateScoper.java
+.. bean-doc:: org.archive.crawler.prefetch.CandidateScoper
 
 FrontierPreparer
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/prefetch/FrontierPreparer.java
+.. bean-doc:: org.archive.crawler.prefetch.FrontierPreparer
 
 Pre-Fetch Processors
 --------------------
@@ -340,12 +340,12 @@ Pre-Fetch Processors
 PreconditionEnforcer
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/prefetch/PreconditionEnforcer.java
+.. bean-doc:: org.archive.crawler.prefetch.PreconditionEnforcer
 
 Preselector
 ~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/prefetch/Preselector.java
+.. bean-doc:: org.archive.crawler.prefetch.Preselector
 
 Fetch Processors
 ----------------
@@ -353,32 +353,32 @@ Fetch Processors
 FetchDNS
 ~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchDNS.java
+.. bean-doc:: org.archive.modules.fetcher.FetchDNS
 
 FetchFTP
 ~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
+.. bean-doc:: org.archive.modules.fetcher.FetchFTP
 
 FetchHTTP
 ~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+.. bean-doc:: org.archive.modules.fetcher.FetchHTTP
 
 FetchHTTP2
 ~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchHTTP2.java
+.. bean-doc:: org.archive.modules.fetcher.FetchHTTP2
 
 FetchSFTP
 ~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchSFTP.java
+.. bean-doc:: org.archive.modules.fetcher.FetchSFTP
 
 FetchWhois
 ~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/fetcher/FetchWhois.java
+.. bean-doc:: org.archive.modules.fetcher.FetchWhois
 
 Link Extractors
 ---------------
@@ -386,117 +386,117 @@ Link Extractors
 ExtractorCSS
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorCSS.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorCSS
 
 ExtractorDOC
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorDOC.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorDOC
 
 ExtractorHTML
 ~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorHTML
 
 AggressiveExtractorHTML
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/AggressiveExtractorHTML.java
+.. bean-doc:: org.archive.modules.extractor.AggressiveExtractorHTML
 
 JerichoExtractorHTML
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/JerichoExtractorHTML.java
+.. bean-doc:: org.archive.modules.extractor.JerichoExtractorHTML
 
 ExtractorHTMLForms
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/forms/ExtractorHTMLForms.java
+.. bean-doc:: org.archive.modules.forms.ExtractorHTMLForms
 
 ExtractorHTTP
 ~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorHTTP.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorHTTP
 
 ExtractorImpliedURI
 ~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorImpliedURI.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorImpliedURI
 
 ExtractorJS
 ~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorJS.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorJS
 
 KnowledgableExtractorJS (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/extractor/KnowledgableExtractorJS.java
+.. bean-doc:: org.archive.modules.extractor.KnowledgableExtractorJS
 
 ExtractorMultipleRegex
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorMultipleRegex.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorMultipleRegex
 
 ExtractorPDF
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorPDF.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorPDF
 
 ExtractorPDFContent (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/extractor/ExtractorPDFContent.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorPDFContent
 
 ExtractorRobotsTxt
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorRobotsTxt.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorRobotsTxt
 
 ExtractorSitemap
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorSitemap.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorSitemap
 
 ExtractorSWF
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorSWF.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorSWF
 
 ExtractorUniversal
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorUniversal.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorUniversal
 
 ExtractorURI
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorURI.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorURI
 
 ExtractorXML
 ~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/ExtractorXML.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorXML
 
 ExtractorYoutubeDL (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorYoutubeDL
 
 ExtractorYoutubeFormatStream (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeFormatStream.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorYoutubeFormatStream
 
 ExtractorYoutubeChannelFormatStream (contrib)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeChannelFormatStream.java
+.. bean-doc:: org.archive.modules.extractor.ExtractorYoutubeChannelFormatStream
 
 TrapSuppressExtractor
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/extractor/TrapSuppressExtractor.java
+.. bean-doc:: org.archive.modules.extractor.TrapSuppressExtractor
 
 Browser Processor
 -----------------
@@ -504,17 +504,17 @@ Browser Processor
 BrowserProcessor
 ~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+.. bean-doc:: org.archive.crawler.processor.BrowserProcessor
 
 ExtractLinksBehavior
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/behaviors/ExtractLinksBehavior.java
+.. bean-doc:: org.archive.modules.behaviors.ExtractLinksBehavior
 
 ScrollDownBehavior
 ~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/behaviors/ScrollDownBehavior.java
+.. bean-doc:: org.archive.modules.behaviors.ScrollDownBehavior
 
 Post-Processors
 ---------------
@@ -522,59 +522,59 @@ Post-Processors
 CandidatesProcessor
 ~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/postprocessor/CandidatesProcessor.java
+.. bean-doc:: org.archive.crawler.postprocessor.CandidatesProcessor
 
 DispositionProcessor
 ~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/postprocessor/DispositionProcessor.java
+.. bean-doc:: org.archive.crawler.postprocessor.DispositionProcessor
 
 ReschedulingProcessor
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../engine/src/main/java/org/archive/crawler/postprocessor/ReschedulingProcessor.java
+.. bean-doc:: org.archive.crawler.postprocessor.ReschedulingProcessor
 
 WARCWriterChainProcessor
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/writer/WARCWriterChainProcessor.java
+.. bean-doc:: org.archive.modules.writer.WARCWriterChainProcessor
 
 DnsResponseRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/DnsResponseRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.DnsResponseRecordBuilder
 
 FtpControlConversationRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/FtpControlConversationRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.FtpControlConversationRecordBuilder
 
 FtpResponseRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/FtpResponseRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.FtpResponseRecordBuilder
 
 HttpRequestRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/HttpRequestRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.HttpRequestRecordBuilder
 
 HttpResponseRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/HttpResponseRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.HttpResponseRecordBuilder
 
 MetadataRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/MetadataRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.MetadataRecordBuilder
 
 RevisitRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/RevisitRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.RevisitRecordBuilder
 
 WhoisResponseRecordBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. bean-doc:: ../modules/src/main/java/org/archive/modules/warc/WhoisResponseRecordBuilder.java
+.. bean-doc:: org.archive.modules.warc.WhoisResponseRecordBuilder

--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -558,7 +558,7 @@ in the following format: ```ftp://sftp.example.org/directory``.
 
 The FetchFTP bean needs to be defined:
 
-.. bean-example:: ../modules/src/main/java/org/archive/modules/fetcher/FetchFTP.java
+.. bean-example:: org.archive.modules.fetcher.FetchFTP
 
 and added to the FetchChain:
 
@@ -578,7 +578,7 @@ HTTP/2
 
 To use HTTP/2 the ``FetchHTTP`` bean should replaced with ``FetchHTTP2``:
 
-.. bean-example:: ../modules/src/main/java/org/archive/modules/fetcher/FetchHTTP2.java
+.. bean-example:: org.archive.modules.fetcher.FetchHTTP2
 
 ``FetchHTTP2`` will use HTTP/1.1 for non-https URLs and for servers that do not support HTTP/2. Requests that used HTTP/2
 will be annotated with ``h2`` in the crawl log and ``WARC-Protocol`` header.
@@ -621,7 +621,7 @@ be added in the following format:``sftp://sftp.example.org/directory``.
 
 The FetchSFTP bean needs to be defined:
 
-.. bean-example:: ../modules/src/main/java/org/archive/modules/fetcher/FetchSFTP.java
+.. bean-example:: org.archive.modules.fetcher.FetchSFTP
 
 and added to the FetchChain:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
 sphinxcontrib-httpdomain==1.7.0
-#javalang==0.13.0
-git+https://github.com/WorkOfArtiz/javalang17@1a8007a5601b20fce7fbb79c14940e6183ed96df
 beautifulsoup4==4.9.3
 sphinx==6.2.1
 sphinx-rtd-theme==1.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 	</dependencyManagement>
 
 	<modules>
+        <module>docgen</module>
 		<module>commons</module>
 		<module>modules</module>
 		<module>engine</module>
@@ -354,6 +355,14 @@ http://maven.apache.org/guides/mini/guide-m1-m2.html
 					<!-- Retain method parameter names. This is required for some autowiring like AbstractFrontier.setScope()
 					https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.1-Release-Notes#parameter-name-retention -->
 					<parameters>true</parameters>
+                    <!-- Generate heritrix-beans.json -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.archive.heritrix</groupId>
+                            <artifactId>heritrix-docgen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This means we can rely on the Java compiler to parse the source code instead of the old python library which no longer works as it only supported Java 8 source code. The new processor generates a META-INF/heritrix-beans.json file for each module at compile time which the sphinx beandoc plugin then reads.

My intent is to eventually use the heritrix-beans.json files to also implement autocomplete and context-sensitive help in the Heritrix config editor.

Fixes #666