### PR TITLE
Config editor: implement autocompletion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,3 @@ updates:
         versions: "[12.1,)"
       - dependency-name: "org.eclipse.jetty.ee10:jetty-ee10-bom"
         versions: "[12.1,)"
-      - dependency-name: "org.webjars.npm:codemirror"

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -103,11 +103,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
-			<artifactId>codemirror</artifactId>
-			<version>6.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars.npm</groupId>
 			<artifactId>codemirror__autocomplete</artifactId>
 			<version>6.18.6</version>
 		</dependency>

--- a/engine/src/main/java/org/archive/crawler/restlet/BeanDocResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/BeanDocResource.java
@@ -1,0 +1,68 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.crawler.restlet;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.restlet.data.MediaType;
+import org.restlet.data.Status;
+import org.restlet.data.Tag;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Get;
+import org.restlet.resource.ServerResource;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+
+public class BeanDocResource extends ServerResource {
+    private static Tag etag = null;
+
+    @Get("json")
+    public Representation getBeans() throws IOException {
+        if (etag != null && getRequest().getConditions().getNoneMatch().contains(etag)) {
+            getResponse().setStatus(Status.REDIRECTION_NOT_MODIFIED);
+            return null;
+        }
+        var resources = getClass().getClassLoader().getResources("META-INF/heritrix-beans.json");
+        var json = concatenateJsonObjects(resources);
+        var representation = new StringRepresentation(json, MediaType.APPLICATION_JSON);
+        if (etag == null) etag = new Tag(DigestUtils.md5Hex(json));
+        representation.setTag(etag);
+        return representation;
+    }
+
+    private static String concatenateJsonObjects(Enumeration<URL> resources) throws IOException {
+        var builder = new StringBuilder("{");
+        for (var url : Collections.list(resources)) {
+            try (var stream = url.openStream()) {
+                var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                if (json.isEmpty()) continue;
+                if (builder.length() > 1) builder.append(",");
+
+                // strip leading '{' and trailing '}' (we just assume no whitespace)
+                builder.append(json, 1, json.length() - 1);
+            }
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+}

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineApplication.java
@@ -74,6 +74,7 @@ public class EngineApplication extends Application {
             .setMatchingMode(Template.MODE_EQUALS);
         router.attach("/engine/",EngineResource.class)
             .setMatchingMode(Template.MODE_EQUALS);
+        router.attach("/engine/beandoc", BeanDocResource.class);
 
         Directory alljobsdir = new Directory(
                 getContext(),

--- a/engine/src/main/resources/org/archive/crawler/restlet/Edit.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Edit.ftl
@@ -28,7 +28,6 @@
     </style>
     <script type="importmap">
         ${webJars.importMap("
-            codemirror
             @codemirror/autocomplete
             @codemirror/commands
             @codemirror/language
@@ -47,10 +46,17 @@
             w3c-keyname index.js")}
     </script>
     <script type="module">
-        import {basicSetup} from "codemirror"
-        import {xml} from "@codemirror/lang-xml"
-        import {EditorView, keymap} from "@codemirror/view"
-        import {indentWithTab} from "@codemirror/commands"
+        import {keymap, highlightSpecialChars, drawSelection, highlightActiveLine, dropCursor,
+            rectangularSelection, crosshairCursor,
+            lineNumbers, highlightActiveLineGutter, EditorView} from "@codemirror/view"
+        import {EditorState} from "@codemirror/state"
+        import {defaultHighlightStyle, syntaxHighlighting, indentOnInput, bracketMatching,
+            foldGutter, foldKeymap, LanguageSupport, syntaxTree} from "@codemirror/language"
+        import {defaultKeymap, history, historyKeymap, indentWithTab} from "@codemirror/commands"
+        import {searchKeymap, highlightSelectionMatches} from "@codemirror/search"
+        import {autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap} from "@codemirror/autocomplete"
+        import {lintKeymap} from "@codemirror/lint"
+        import {autoCloseTags, xmlLanguage} from "@codemirror/lang-xml"
 
         const theme = EditorView.theme({
            "&": { flex: "1 1 auto", minHeight: "0" },
@@ -64,17 +70,278 @@
             document.getElementById('saveButton').disabled = false;
         }
 
+        /**
+         * Map of fully-qualified bean class names to their definitions.
+         * @typedef {Object<string, Bean>} BeanDoc
+         */
+
+        /**
+         * One bean entry describing the bean and its properties.
+         * @typedef {Object} Bean
+         * @property {string} description
+         * @property {Object<string, Property>} properties - Map of property name to metadata.
+         */
+
+        /**
+         * Metadata for a single property on a bean.
+         * @typedef {Object} Property
+         * @property {string} description
+         * @property {string} type - The Java type
+         * @property {*} [default] - Optional default value; may be number, boolean, string, etc.
+         */
+
+        function makeDiv(html) {
+            if (!html) return null;
+            const div = document.createElement('div');
+            div.innerHTML = html.replace(/\n\n/g, "<br><br>").replace(/\n/g, " ");
+            return div;
+        }
+
+        const TAG_COMPLETIONS = {
+            "beans": ["bean"],
+            "bean": ["constructor-arg", "property"],
+            "constructor-arg": ["bean", "list", "map", "ref", "value"],
+            "property": ["bean", "list", "map", "ref", "value"],
+            "map": ["entry"],
+            "list": ["bean", "list", "map", "ref", "value"],
+        };
+
+        const ATTRIBUTE_COMPLETIONS = {
+            "bean": ["class", "id"],
+            "constructor-arg": ["value"],
+            "property": ["name", "value"],
+            "ref": ["bean"],
+            "entry": ["key", "value"],
+        };
+
+        /**
+         * Calculate auto-completions for Heritrix XML.
+         *
+         * @param {BeanDoc} beandoc
+         * @param {CompletionContext} context
+         */
+        function completeHeritrixXml(beandoc, context) {
+            /**
+             * Get the given node's text content.
+             */
+            function slice(node) {
+                if (!node) return null;
+                return context.state.sliceDoc(node.from, node.to);
+            }
+
+            /**
+             * Get the value of the given attribute on the given element.
+             */
+            function getAttrValue(element, attr) {
+                console.assert(element.name === 'Element', "Expected element node");
+                let openTag = element.getChild('OpenTag');
+                for (let attribute of openTag.getChildren('Attribute')) {
+                    if (slice(attribute.getChild('AttributeName')) === attr) {
+                        let text = slice(attribute.getChild('AttributeValue'));
+                        if (text.startsWith("\"") || text.startsWith("\'")) {
+                            text = text.substring(1, text.length - 1);
+                        }
+                        return text;
+                    }
+                }
+                return null;
+            }
+
+            /**
+             * Get the names of all attributes on the given element.
+             */
+            function getAttrNames(element) {
+                console.assert(element.name === 'Element', "Expected element node");
+                let openTag = element.getChild('OpenTag');
+                let names = [];
+                for (let attribute of openTag.getChildren('Attribute')) {
+                    names.push(slice(attribute.getChild('AttributeName')));
+                }
+                return names;
+            }
+
+            /**
+             * Get the tag name of the given element.
+             */
+            function getElementName(element) {
+                if (!element) return null;
+                let openTag = element.getChild('OpenTag');
+                if (openTag) return slice(openTag.getChild('TagName'));
+                return null;
+            }
+
+            /**
+             * Find the closest ancestor element of the given node that has the given tag.
+             */
+            function closest(node, tag) {
+                while (node) {
+                    if (node.name === 'Element') {
+                        if (!tag || getElementName(node) === tag) return node;
+                    }
+                    node = node.parent;
+                }
+                return null;
+            }
+
+            /**
+             * @typedef {Object} DeclaredBean
+             * @property {string} id
+             * @property {string} class
+             */
+            /**
+             * Get all beans declared in the document that have an id.
+             * @returns {DeclaredBean[]}
+             */
+            function getDeclaredBeans() {
+                const beans = []
+                const cursor = syntaxTree(context.state).cursor();
+                while (cursor.next()) {
+                    if (cursor.name === "Element") {
+                        let openTag = cursor.node.getChild('OpenTag');
+                        if (openTag && slice(openTag.getChild('TagName')) === "bean") {
+                            let id = getAttrValue(cursor.node, "id");
+                            if (id) beans.push({id, class: getAttrValue(cursor.node, "class")});
+                        }
+                    }
+                }
+                beans.sort((a, b) => a.id.localeCompare(b.id));
+                return beans;
+            }
+
+            /**
+             * Strips the package from a fully qualified class name (including generic types).
+             * @param {string} className e.g. "java.util.List<java.lang.String>"
+             * @returns {string} e.g. "List<String>"
+             */
+            function stripPackage(className) {
+                return className.replace(/\b[^<>, ]+\./g, "");
+            }
+
+            let node = syntaxTree(context.state).resolveInner(context.pos, -1)
+            if (node.name === "TagName" || node.name === "StartTag") {
+                let parentElement = closest(node.parent.parent.parent);
+                let tag = getElementName(parentElement);
+                let completions = TAG_COMPLETIONS[tag];
+                if (!completions) return;
+                let text = node.name === "StartTag" ? "" : context.state.sliceDoc(node.from, context.pos);
+                return {
+                    from: context.pos - text.length,
+                    options: completions.filter(c => c.startsWith(text))
+                        .map(c => ({label: c, apply: c}))
+                }
+            } else if (node.name === "OpenTag" || node.name === "AttributeName") {
+                let element = node.name === "OpenTag" ? node.parent : node.parent.parent.parent;
+                const tag = getElementName(element);
+                const existingAttrs = getAttrNames(element);
+                let completions = ATTRIBUTE_COMPLETIONS[tag];
+                if (!completions) return;
+                let text = node.name === "OpenTag" ? "" : context.state.sliceDoc(node.from, context.pos);
+                return {
+                    from: context.pos - text.length,
+                    options: completions.filter(c => c.startsWith(text) && !existingAttrs.includes(c))
+                        .map(c => ({label: c, apply: c + '="', reactivate: true}))
+                }
+            } else if (node.name === "AttributeValue") {
+                let text = context.state.sliceDoc(node.from, context.pos);
+                let quote = "";
+                if (text.startsWith("\"") || text.startsWith("\'")) {
+                    quote = text.charAt(0);
+                    text = text.substring(1, text.length);
+                }
+
+                let matches = [];
+                const tag = slice(node.parent.parent.getChild('TagName'));
+                const attr = slice(node.parent.getChild('AttributeName'));
+                if (tag === "bean" && attr === "class") {
+                    matches = Object.entries(beandoc)
+                        .filter(([className]) => className.includes(text))
+                        .map(([className, bean]) => ({
+                            label: className,
+                            type: "class",
+                            info: () => makeDiv(bean.description),
+                            apply: className + quote
+                        }));
+                } else if (tag === "property" && attr === "name") {
+                    const beanElement = closest(node, "bean");
+                    if (!beanElement) return;
+                    const beanClass = getAttrValue(beanElement, "class");
+                    if (!beanClass) return;
+                    const bean = beandoc[beanClass];
+                    if (!bean) return;
+                    matches = Object.entries(bean.properties)
+                        .filter(([name]) => name.includes(text))
+                        .map(([name, prop]) => ({
+                            label: name,
+                            type: "property",
+                            detail: (!prop.type ? "" : stripPackage(prop.type)) +
+                                (prop.default ? " = " + prop.default : ""),
+                            info: () => makeDiv(prop.description),
+                        }));
+                } else if (tag === "ref" && attr === "bean") {
+                    matches = getDeclaredBeans()
+                        .filter(bean => bean.id.includes(text))
+                        .map(bean => ({
+                            label: bean.id,
+                            type: "variable",
+                            detail: bean.class ? stripPackage(bean.class) : null,
+                        }));
+                }
+                return {
+                    from: context.pos - text.length,
+                    options: matches
+                };
+            }
+        }
+
+        /**
+         * Language support for Heritrix XML configuration files with autocomplete functionality.
+         *
+         * @param {BeanDoc} beandoc The bean documentation object.
+         * @return {LanguageSupport}
+         */
+        function heritrixXml(beandoc) {
+            return new LanguageSupport(xmlLanguage, [xmlLanguage.data.of({
+                autocomplete: context => completeHeritrixXml(beandoc, context),
+            }), autoCloseTags]);
+        }
+
         async function initEditor() {
             try {
-                const response = await fetch(window.location.pathname);
-                const text = await response.text();
+                const [text, beandoc] = await Promise.all([
+                    fetch(window.location.pathname).then(r => r.text()),
+                    fetch("/engine/beandoc").then(r => r.json())]);
                 editorView = new EditorView({
                     doc: text,
                     extensions: [
-                        basicSetup,
+                        lineNumbers(),
+                        highlightActiveLineGutter(),
+                        highlightSpecialChars(),
+                        history(),
+                        foldGutter(),
+                        drawSelection(),
+                        dropCursor(),
+                        EditorState.allowMultipleSelections.of(true),
+                        indentOnInput(),
+                        syntaxHighlighting(defaultHighlightStyle, {fallback: true}),
+                        bracketMatching(),
+                        closeBrackets(),
+                        autocompletion({activateOnCompletion: completion => !!completion.reactivate}),
+                        rectangularSelection(),
+                        crosshairCursor(),
+                        highlightActiveLine(),
+                        highlightSelectionMatches(),
+                        keymap.of([
+                            ...closeBracketsKeymap,
+                            ...defaultKeymap,
+                            ...searchKeymap,
+                            ...historyKeymap,
+                            ...foldKeymap,
+                            ...completionKeymap,
+                            ...lintKeymap
+                        ]),
                         theme,
                         keymap.of(indentWithTab),
-                        xml(),
+                        heritrixXml(beandoc),
                         EditorView.updateListener.of(onUpdate)
                     ]
                 });


### PR DESCRIPTION
This adds context-sensitive autocompletion for bean names, bean ids, property names, Spring XML tags and attributes. The bean completions use a new `/engine/beandoc` endpoint that serves the combination of all the `/META-INF/heritrix-beans.json` files generated at compile-time by the heritrix-docgen annotation processor.

## Screenshots

### Bean class completions
<img width="1070" height="166" alt="image" src="https://github.com/user-attachments/assets/8cd5b45e-57f0-4f0e-9994-d56f6347be30" />

### Property name completions
<img width="860" height="204" alt="image" src="https://github.com/user-attachments/assets/458a11bd-bab7-4fc3-8639-80aa2b073ddf" />

### Bean id completions
<img width="477" height="196" alt="image" src="https://github.com/user-attachments/assets/feda4794-4a6a-4e1d-99a1-55f706e2aa17" />

