### PR TITLE
WebUI: Engine page: Limit height of "Exit Java" joblist, set auto-scroll behaviour on overflow

### DIFF
--- a/engine/src/main/resources/org/archive/crawler/restlet/Engine.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Engine.ftl
@@ -69,7 +69,7 @@
 	<div class="large-5 columns">
 		<div class="panel">
 			<h3>Exit Java</h3>
-			<form method='POST'>
+			<form method='POST' style="max-height:20em;overflow-y:auto">
 				<#list engine.jobs as crawlJob>
 				<#if crawlJob.hasApplicationContext>
 				<label for='ignore__${crawlJob.key}' style="color:#d9534f">


### PR DESCRIPTION
Having more than ~20 active jobs makes the Engine page a bit difficult to use as the right block to "Exit Java" lists all crawling jobs with active application context and requires scrolling to get to the actual jobs listing below. E.g., to create new jobs or see details. (_I'm currently working with an instance with ~1000 small jobs... which means a lot of scrolling._)

This adds a `max-height: 20em` which limits the box to about the page height on my device or ~18 jobs. `overflow-y: auto` adds scrollbars and avoids overflow due to the height limit. Local testing added overflow with scrollbars at 15 jobs.

The only issue I see is that the "exit java process" button will not be visible anymore if there are too many jobs. I'm not sure if it is an issue because users should notice the scrollbars (hopefully, _Firefox seems to hide the scrollbars if not hovering_), and users might kill Heritrix in other ways than the WebUI. Especially with lots of active jobs.

<details>
<summary>Screenshots</summary>

With only a few jobs:
<img width="1920" height="838" alt="grafik" src="https://github.com/user-attachments/assets/4d74126e-f18f-4ff4-b7d0-9b4eef5ff157" />

With about 15 jobs:
<img width="1920" height="838" alt="grafik" src="https://github.com/user-attachments/assets/d7c62d21-c76d-4d9f-9ac7-0f34d08c47a8" />

</details>