### PR TITLE
fixed Issue #181

### DIFF
--- a/modules/src/main/java/org/archive/modules/deciderules/TooManyHopsDecideRule.java
+++ b/modules/src/main/java/org/archive/modules/deciderules/TooManyHopsDecideRule.java
@@ -66,7 +66,14 @@ public class TooManyHopsDecideRule extends PredicatedDecideRule {
      */
     @Override
     protected boolean evaluate(CrawlURI uri) {
+        if (getMaxHops() < 0) {
+            return false;
+        }
+
+        if (uri.getHopCount() == 0) {
+            return false;
+        }
+
         return uri.getHopCount() > getMaxHops();
     }
-
 }


### PR DESCRIPTION
This change fixes an issue where setting preferenceDepthHops = 0 (intended to enable depth first crawling) caused Heritrix to reject seed URLs immediately with fetch status -50.

The problem was in TooManyHopsDecideRule, where a negative maxHops value (used internally for DFS) caused all URIs including seeds with hop count 0 to be evaluated as exceeding the hop limit. As a result, no crawling occurred.

The fix updates the hop limit evaluation logic to:
Treat negative maxHops values as “no hop limit”
Always allow seed URLs (hopCount == 0) to pass the rule
This restores the documented DFS behavior while preserving existing behavior for normal breadth first crawls.