### PR TITLE
Add job deletion to API and UI

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -611,6 +611,39 @@ Copy Job
 
        curl -v -d "copyTo=mycopy&asProfile=on" -k -u admin:admin --anyauth --location -H "Accept: application/json" https://localhost:8443/engine/job/myjob
 
+Delete Job
+~~~~~~~~~~
+
+.. http:post:: https://(heritrixhost):8443/engine/job/(jobname) [delete]
+
+   Deletes an existing job. It will remove everything related to the job
+   (configuration, statistics, logs and results) including the whole job
+   folder. Everything to keep has to be copied outside of the job folder.
+   
+   Deleting a job is only possible if no active application context for the job
+   exists which is the case for new or unbuilt jobs. If a job has been built,
+   it must first be torn down to allow deletion.
+
+   :form action: must be ``delete``
+
+   **HTML Example:**
+
+   .. code:: bash
+
+       curl -v -d "action=delete" -k -u admin:admin --anyauth --location https://localhost:8443/engine/job/myjob
+
+   **XML Example:**
+
+   .. code:: bash
+
+       curl -v -d "action=delete" -k -u admin:admin --anyauth --location -H "Accept: application/xml" https://localhost:8443/engine/job/myjob
+
+   **JSON Example:**
+
+   .. code:: bash
+
+       curl -v -d "action=delete" -k -u admin:admin --anyauth --location -H "Accept: application/json" https://localhost:8443/engine/job/myjob
+
 Checkpoint Job
 ~~~~~~~~~~~~~~
 

--- a/engine/src/main/resources/org/archive/crawler/restlet/Job.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Job.ftl
@@ -59,6 +59,14 @@
 					<li class="divider"></li>
 					<li>
 					<#if job.hasApplicationContext>
+					<a href="#" style="color:#444">Delete Job</a>
+					<#else>
+					<a href="#" data-reveal-id="deleteJobModal">Delete Job</a>
+					</#if>
+					</li>
+					<li class="divider"></li>
+					<li>
+					<#if job.hasApplicationContext>
 					<a href="script">Scripting Console</a>
 					<#else>
 					<a href="#" style="color:#444">Scripting Console</a>
@@ -344,6 +352,18 @@
 			</p>
 			<div>
 				<input class="small button" value="copy" type="submit">
+			</div>
+		</fieldset>
+	</form>
+	<a class="close-reveal-modal">&#215;</a>
+</div>
+<div id="deleteJobModal" class="reveal-modal">
+	<h2>Delete Job</h2>
+	<form method="POST">
+		<fieldset>
+			<p>Deleting the job will remove the complete job folder including configurations, logs, statistics and results! Only continue if you are sure.</p>
+			<div>
+				<input class="small button" name="action" value="delete" type="submit">
 			</div>
 		</fieldset>
 	</form>


### PR DESCRIPTION
This PR adds the feature for job deletion to the REST API and exposes it as menu item in the WebUI.

What is included:
- Add API handler for `JobResource` for `action=delete` to delete the job via `getEngine().deleteJob(cj)`.
  - Checks first for job application context and will abort if exists.
  - Otherwise, after deletion, job configs will be updated (rescan) to not list the deleted job anymore.
- Add "Delete Job" menu item to job web page
  - is only "enabled" when job has no application context (new/unbuild/torn-down jobs)
  - opens a dialog (similar to "Copy Job" menu item) to warn of results, with trigger button
- Add "Delete Job" section to REST API documentation (readthedocs)

Reasons to include this PR:
- Almost the full job lifecycle is possible via REST API / WebUI, from job creation, various job actions but the cleanup of jobs was missing.
- Job deletion is possible by using any other active job and running custom scripts that delete the target job folder. That is even possible for the active job itself (ie. a job with application context) but leaves Heritrix in a broken state...
- Having a well-defined API endpoint to handle cleanup (job deletion) avoid pitfalls such as using scripts or using direct filesystem access (on the server) without knowing the job status which could leave Heritrix in an invalid state.

Discussion points:
- I used `action=delete` with the `JobResource`.
  - The "delete" action is NOT explicitly listed in the job's list of actions, similar to the copyTo action. In my opinion, deletion should not be an action that is immediately visible like the normal lifecycle actions such as build, launch, ...
  - I was thinking about adding the "delete" action to the `EngineResource` like `add`/`create` with a new `deletepath` parameter but this seemed like a small detour. (And could not be easily done in the WebUI or wouldn't make much sense for users if it were so.)
- I did not add an automatic "teardown" before the "delete" action as this seemed a bit dangerous. Users have to explicitly set the job into an unbuilt/torn-down state to be able to delete the job. This should avoid some accidental deletions.

Questions:
- `getResponse().redirectSeeOther("/engine")` (at the end of `JobResource`) seemed to be the only way to get the redirection the the engine webpage? Or is there a better way? `EngineApplication` did hardcode those `/engine*` paths, so it might be ok but a way to dynamically get those URIs would be nice. Using the `EngineResource` somehow?