### PR TITLE
ExtractorYoutubeDL: skip YouTube super resolution videos

### DIFF
--- a/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
+++ b/contrib/src/main/java/org/archive/modules/extractor/ExtractorYoutubeDL.java
@@ -207,6 +207,19 @@ public class ExtractorYoutubeDL extends Extractor
         kp.put("processArguments", processArguments);
     }
 
+    {
+        setSkipSuperResolution(false);
+    }
+    public boolean getSkipSuperResolution() {
+        return (Boolean) kp.get("skipSuperResolution");
+    }
+    /**
+     * Whether or not to download Super Resolution upscaled videos.
+     */
+    public void setSkipSuperResolution(boolean skipSuperResolution) {
+        kp.put("skipSuperResolution",skipSuperResolution);
+    }
+
     @Override
     public void start() {
         if (!isRunning) {
@@ -463,12 +476,12 @@ public class ExtractorYoutubeDL extends Extractor
 
                     String value = jsonReader.nextString();
                     // Format IDs ending with -sr are YouTube "Super Resolution"
-                    // upscaled videos; avoid downloading these in favour of the
-                    // original files.
+                    // upscaled videos; if requested, avoid downloading these in
+                    // favour of the original files.
                     // https://alexwlchan.net/til/2025/ignore-ai-scaled-videos/
                     if ("$.format_id".equals(jsonReader.getPath())
                             || jsonReader.getPath().matches("^\\$\\.entries\\[\\d+\\]\\.format_id$")) {
-                        if (value.endsWith("-sr")) {
+                        if (value.endsWith("-sr") && getSkipSuperResolution()) {
                             skipObject = true;
                             break;
                         }


### PR DESCRIPTION
YouTube has started upscaling older videos that are below a certain resolution. yt-dlp identifies these via the `-sr` suffix in the format ID. It's probably a good idea to avoid downloading these, and just focus on the originals instead.

yt-dlp's `--dump-single-json` option ignores the `--format` argument, so we can't use that to filter out super resolution videos. Instead, we'll need to check every format we get while iterating and skip it if it ends with `-sr`.

See: https://alexwlchan.net/til/2025/ignore-ai-scaled-videos/?ref=mastodon

I haven't had a chance to test this yet.