### PR TITLE
Enable XXE protection when parsing crawl job XML

### DIFF
--- a/commons/src/main/java/org/archive/spring/PathSharingContext.java
+++ b/commons/src/main/java/org/archive/spring/PathSharingContext.java
@@ -31,12 +31,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.io.FileUtils;
 import org.archive.util.ArchiveUtils;
+import org.archive.util.XmlUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.groovy.GroovyBeanDefinitionReader;
+import org.springframework.beans.factory.xml.DefaultDocumentLoader;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigUtils;
@@ -230,6 +235,16 @@ public class PathSharingContext extends FileSystemXmlApplicationContext {
         // This is essentially <context:annotation-config/>
         // By doing it here we don't need to include it in every crawl config.
         AnnotationConfigUtils.registerAnnotationConfigProcessors(xmlReader.getRegistry());
+
+        // Configure XXE protection
+        xmlReader.setDocumentLoader(new DefaultDocumentLoader() {
+            @Override
+            protected DocumentBuilderFactory createDocumentBuilderFactory(int validationMode, boolean namespaceAware) throws ParserConfigurationException {
+                DocumentBuilderFactory factory = super.createDocumentBuilderFactory(validationMode, namespaceAware);
+                XmlUtils.enableXxeProtection(factory);
+                return factory;
+            }
+        });
 
         GroovyBeanDefinitionReader groovyReader = new GroovyBeanDefinitionReader(xmlReader.getRegistry()) {
             // By default, the Groovy reader loads XML from .xml and Groovy for everything else, but

--- a/commons/src/main/java/org/archive/util/XmlUtils.java
+++ b/commons/src/main/java/org/archive/util/XmlUtils.java
@@ -1,0 +1,29 @@
+package org.archive.util;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class XmlUtils {
+    /**
+     * Creates a DocumentBuilderFactory with features set to prevent XXE attacks.
+     */
+    public static DocumentBuilderFactory newXxeSafeDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        enableXxeProtection(factory);
+        return factory;
+    }
+
+    /**
+     * Configures a given DocumentBuilderFactory instance to enable protections
+     * against XML External Entity (XXE) attacks. See
+     * <a href="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j">OWASP XML External Entity Prevention Cheat Sheet</a>.
+     */
+    public static void enableXxeProtection(DocumentBuilderFactory factory) throws ParserConfigurationException {
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+    }
+}

--- a/commons/src/test/java/org/archive/spring/PathSharingContextTest.java
+++ b/commons/src/test/java/org/archive/spring/PathSharingContextTest.java
@@ -1,7 +1,14 @@
 package org.archive.spring;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,6 +34,39 @@ public class PathSharingContextTest {
             assertNotNull(bean2, "bean2 should not be null");
             assertEquals(name, bean1.name, "bean1.name should be set");
             assertEquals(bean1, bean2.bean1, "bean1 should be autowired into bean2");
+        }
+    }
+
+    /**
+     * Test that XXE attacks with parameter entity declarations are blocked
+     */
+    @Test
+    public void testXxeProtectionBlocksParameterEntity(@TempDir Path tempDir) throws IOException {
+        String maliciousXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE beans [
+                  <!ENTITY % xxe SYSTEM "file:///dev/null">
+                  %xxe;
+                ]>
+                <beans xmlns="http://www.springframework.org/schema/beans"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+                    <bean id="bean1" class="org.archive.spring.PathSharingContextTest$Bean1">
+                        <property name="name" value="test"/>
+                    </bean>
+                </beans>
+                """;
+
+        File maliciousFile = tempDir.resolve("malicious_param.cxml").toFile();
+        Files.writeString(maliciousFile.toPath(), maliciousXml);
+
+        try {
+            new PathSharingContext("file:" + maliciousFile.getAbsolutePath()).close();
+            fail("XXE parameter entity attack should be blocked");
+        } catch (BeanDefinitionStoreException e) {
+            if (!e.getCause().getMessage().contains("DOCTYPE is disallowed")) {
+                fail("XXE parameter entity attack should be blocked");
+            }
         }
     }
 

--- a/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
+++ b/engine/src/main/java/org/archive/crawler/framework/CrawlJob.java
@@ -69,6 +69,7 @@ import org.archive.spring.PathSharingContext;
 import org.archive.util.ArchiveUtils;
 import org.archive.util.ObjectIdentityCache;
 import org.archive.util.TextUtils;
+import org.archive.util.XmlUtils;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
@@ -278,7 +279,7 @@ public class CrawlJob implements Comparable<CrawlJob>, ApplicationListener<Appli
      */
     protected Document getDomDocument(File f) {
         try {
-            DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory docBuilderFactory = XmlUtils.newXxeSafeDocumentBuilderFactory();
             DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
             return docBuilder.parse(f);
         } catch (ParserConfigurationException e) {

--- a/engine/src/main/java/org/archive/crawler/migrate/MigrateH1to3Tool.java
+++ b/engine/src/main/java/org/archive/crawler/migrate/MigrateH1to3Tool.java
@@ -40,6 +40,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;
+import org.archive.util.XmlUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -65,7 +66,7 @@ public class MigrateH1to3Tool {
 
     static {
         try {
-            DOCUMENT_BUILDER = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DOCUMENT_BUILDER = XmlUtils.newXxeSafeDocumentBuilderFactory().newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Heritrix's Spring XML based job config format by design allows arbitrary code execution, so this doesn't realistically make things much safer, but I also don't see any reason we need external entity resolution enabled. I suppose there's a chance this could mitigate a generic automated attack that uses XXE but doesn't target Heritrix or Spring XML specifically.

Fixes #711