### PR TITLE
Add profile selector to job creation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * **Profile selector:** You can now select a profile from a dropdown list when creating a new job.
 
+### Bug fixes
+
+* **Groovy profiles:** Fixed discovery of job directories containing `profile-crawler-beans.groovy`
+
 ## [3.14.1](https://github.com/internetarchive/heritrix3/releases/tag/3.14.1)  (2026-04-06)
 
 [Download distribution zip](https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/3.14.1/heritrix-3.14.1-dist.zip) (or [tar.gz](https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/3.14.1/heritrix-3.14.1-dist.tar.gz))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/internetarchive/heritrix3/compare/3.14.1...HEAD)
 
+### New features
+
+* **Profile selector:** You can now select a profile from a dropdown list when creating a new job.
+
 ## [3.14.1](https://github.com/internetarchive/heritrix3/releases/tag/3.14.1)  (2026-04-06)
 
 [Download distribution zip](https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/3.14.1/heritrix-3.14.1-dist.zip) (or [tar.gz](https://repo1.maven.org/maven2/org/archive/heritrix/heritrix/3.14.1/heritrix-3.14.1-dist.tar.gz))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,11 @@ Get Engine Status
             <key>myjob</key>
           </value>
         </jobs>
+        <profiles>
+          <value>Defaults (XML)</value>
+          <value>Defaults (Groovy)</value>
+          <value>myprofile</value>
+        </profiles>
       </engine>
 
    **JSON Example:**
@@ -104,17 +109,28 @@ Create New Job
 
 .. http:post:: https://(heritrixhost):8443/engine [action=create]
 
-   Creates a new crawl job. It uses the default configuration provided
-   by the profile-defaults profile.
-
+   Creates a new crawl job from the selected profile. If no profile is
+   supplied, ``Defaults (XML)`` is used. Built-in profiles include
+   ``Defaults (XML)`` and ``Defaults (Groovy)``. Existing job profiles may
+   also be selected by passing the profile job's short name.
    :form action: must be ``create``
    :form createpath: the name of the new job
+   :form profile: optional profile name. Existing profiles use their job
+      short names.
 
    **HTML Example:**
 
    .. code:: bash
 
-      curl -v -d "createpath=myjob&action=create" -k -u admin:admin --anyauth --location \
+       curl -v -d "createpath=myjob&action=create" -k -u admin:admin --anyauth --location \
+        https://localhost:8443/engine
+
+   To create a job from the Groovy defaults:
+
+   .. code:: bash
+
+      curl -v --data-urlencode "createpath=mygroovyjob" --data-urlencode "action=create" \
+        --data-urlencode "profile=Defaults (Groovy)" -k -u admin:admin --anyauth --location \
         https://localhost:8443/engine
 
    **XML Example:**
@@ -583,9 +599,10 @@ Copy Job
 
 .. http:post:: https://(heritrixhost):8443/engine/job/(jobname) [copyTo]
 
-   Copies an existing job configuration to a new job configuration. If the "as
-   profile" checkbox is selected, than the job configuration is copied as a
-   non-runnable profile configuration.
+   Copies an existing job configuration to a new job configuration. If the
+   ``asProfile`` option is submitted with value ``on``, then the copy is a
+   non-runnable profile. Profiles are listed as options when creating new
+   jobs, and profiles with built-in names override the built-ins.
 
    :form copyTo: the name of the new job or profile configuration
 

--- a/docs/configuring-jobs.rst
+++ b/docs/configuring-jobs.rst
@@ -4,8 +4,21 @@ Configuring Crawl Jobs
 Basic Job Settings
 ------------------
 
-Crawl settings are configured by editing a job's crawler-beans.cxml file.  Each job has a ``crawler-beans.cxml`` file
-that contains the Spring configuration for the job.
+Crawl settings are configured by editing the job's primary configuration file, usually ``crawler-beans.cxml`` or
+``crawler-beans.groovy``.
+
+Profiles
+~~~~~~~~
+
+A profile is a non-launchable job template. To create one from the web interface, open an existing job, choose
+``Copy Job``, enter the new profile name, check ``as profile``, and submit the form. Heritrix treats jobs
+whose primary configuration filename starts with ``profile-`` as profiles. They can be built for validation, but not
+launched directly.
+
+Profiles appear in the create job profile selector by their job name. Choosing one creates a new launchable job
+by copying the profile and removing the ``profile-`` prefix from the primary configuration filename.
+
+The built-in defaults can be overridden by creating a profile with the same name as the built-in profile.
 
 Crawl Limits
 ~~~~~~~~~~~~

--- a/engine/src/main/java/org/archive/crawler/framework/Engine.java
+++ b/engine/src/main/java/org/archive/crawler/framework/Engine.java
@@ -23,14 +23,12 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.nio.file.Files;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.archive.util.ArchiveUtils;
 
@@ -57,9 +55,13 @@ public class Engine {
     /** map of job short names -&gt; CrawlJob instances */ 
     protected HashMap<String,CrawlJob> jobConfigs = new HashMap<String,CrawlJob>();
 
-    protected String profileCxmlPath = 
-        "/org/archive/crawler/restlet/profile-crawler-beans.cxml";
-    
+    /** map of built-in profiles names to resource paths */
+    protected final Map<String, String> builtinProfiles = new LinkedHashMap<>();
+    {
+        builtinProfiles.put("Defaults (XML)", "/org/archive/crawler/restlet/profile-crawler-beans.cxml");
+        builtinProfiles.put("Defaults (Groovy)", "/org/archive/crawler/restlet/profile-crawler-beans.groovy");
+    }
+
     public Engine(File jobsDir) {
         this.jobsDir = jobsDir;
         
@@ -338,29 +340,66 @@ public class Engine {
     }
 
     /**
-     * @return InputStream resource from defined profile CXML path
+     * Lists the available profile names, including both built-in and user-created profiles.
      */
-    protected InputStream getProfileCxmlResource() {
-        return getClass().getResourceAsStream(profileCxmlPath);
+    public List<String> getProfileNames() {
+        List<String> profiles = new ArrayList<>();
+        profiles.addAll(builtinProfiles.keySet());
+        jobConfigs.entrySet().stream()
+                .filter(entry -> entry.getValue().isProfile()
+                                 && !builtinProfiles.containsKey(entry.getKey()))
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> profiles.add(entry.getKey()));
+        return profiles;
     }
-    
+
     /**
      * create a new job dir and copy profile CXML into as non-profile CXML
      * @param newJobDir new job directory
      */
 	public boolean createNewJobWithDefaults(File newJobDir) {
+        return createNewJobWithDefaults(newJobDir, null);
+    }
+
+    /**
+     * create a new job dir from the selected profile
+     * @param newJobDir new job directory
+     * @param profile selected built-in profile id or job profile id
+     */
+    public boolean createNewJobWithDefaults(File newJobDir, String profile) {
+        if (profile == null || profile.isBlank()) {
+            profile = builtinProfiles.keySet().iterator().next();
+        }
+        // check for job profile first so the user can choose to override the built-in profiles
+        CrawlJob source = getJob(profile);
+        if (source != null) {
+            if (!source.isProfile()) {
+                throw new IllegalArgumentException("Not a profile: " + profile);
+            }
+            try {
+                copy(source, newJobDir, false);
+                return true;
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "failed to create new job: " + newJobDir.getAbsolutePath());
+                return false;
+            }
+        }
+
+        String resource = builtinProfiles.get(profile);
+        if (resource == null) {
+            throw new IllegalArgumentException("Unknown profile: " + profile);
+        }
+
         try {
-            // get crawler-beans template into string
-            InputStream inStream = getProfileCxmlResource();
-            String defaultCxmlStr;
-            defaultCxmlStr = IOUtils.toString(inStream);
-            inStream.close();
-
-            // write default crawler-beans string to new job dir
-            org.archive.util.FileUtils.ensureWriteableDirectory(newJobDir);
-            File newJobCxml = new File(newJobDir,"crawler-beans.cxml");
-            FileUtils.writeStringToFile(newJobCxml, defaultCxmlStr);
-
+            try (InputStream stream = getClass().getResourceAsStream(resource)) {
+                if (stream == null) {
+                    throw new IOException("profile resource not found: " + profile);
+                }
+                org.archive.util.FileUtils.ensureWriteableDirectory(newJobDir);
+                String filename = resource.endsWith(".groovy") ? "crawler-beans.groovy" : "crawler-beans.cxml";
+                File newJobCxml = new File(newJobDir, filename);
+                Files.copy(stream, newJobCxml.toPath());
+            }
             return true;
 
         } catch (IOException e) {

--- a/engine/src/main/java/org/archive/crawler/framework/Engine.java
+++ b/engine/src/main/java/org/archive/crawler/framework/Engine.java
@@ -140,7 +140,9 @@ public class Engine {
         }
         File[] candidateConfigs = dir.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String name) {
-                return name.endsWith(".cxml") || name.equals("crawler-beans.groovy");
+                return name.endsWith(".cxml") ||
+                       name.equals("crawler-beans.groovy") ||
+                       name.equals("profile-crawler-beans.groovy");
             }});
         if(candidateConfigs==null || candidateConfigs.length == 0) {
             // no CXML file found!

--- a/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/EngineResource.java
@@ -110,6 +110,7 @@ public class EngineResource extends BaseResource {
             }
         } else if ("create".equals(action)) {
         	String path = form.getFirstValue("createpath");
+            String profile = form.getFirstValue("profile");
         	if (path==null) {
                 // protect against null path
         		Flash.addFlash(getResponse(), "Cannot create <i>null</i> path.", 
@@ -130,14 +131,19 @@ public class EngineResource extends BaseResource {
                     Flash.addFlash(getResponse(), "Directory exists: "
                             + "<i>" + path + "</i>", Flash.Kind.NACK);
         	    } else {
-        	        if (getEngine().createNewJobWithDefaults(newJobDir)) {
-        	            Flash.addFlash(getResponse(), "Created new crawl job: "
-        	                    + "<i>" + path + "</i>", Flash.Kind.ACK);
-        	            getEngine().findJobConfigs();
-        	        } else {
-                        Flash.addFlash(getResponse(), "Failed to create new job: "
-                                + "<i>" + path + "</i>", Flash.Kind.NACK);
-        	        }
+                    try {
+                        if (getEngine().createNewJobWithDefaults(newJobDir, profile)) {
+                            Flash.addFlash(getResponse(), "Created new crawl job: "
+                                                          + "<i>" + path + "</i>", Flash.Kind.ACK);
+                            getEngine().findJobConfigs();
+                        } else {
+                            Flash.addFlash(getResponse(), "Failed to create new job: "
+                                                          + "<i>" + path + "</i>", Flash.Kind.NACK);
+                        }
+                    } catch (IllegalArgumentException e) {
+                        Flash.addFlash(getResponse(), "Cannot create job from profile: "
+                                                      + "<i>" + profile + "</i>", Flash.Kind.NACK);
+                    }
         	    }
         	}
         } else if ("exit java process".equals(action)) { 

--- a/engine/src/main/java/org/archive/crawler/restlet/models/EngineModel.java
+++ b/engine/src/main/java/org/archive/crawler/restlet/models/EngineModel.java
@@ -31,6 +31,7 @@ public class EngineModel extends LinkedHashMap<String, Object> {
         this.put("availableActions", actions);
         
         this.put("jobs", makeJobList(engine, urlBaseRef));
+        this.put("profiles", engine.getProfileNames());
     }
 
 	private List<Map<String, Object>> makeJobList(Engine engine,

--- a/engine/src/main/resources/org/archive/crawler/restlet/Engine.ftl
+++ b/engine/src/main/resources/org/archive/crawler/restlet/Engine.ftl
@@ -110,6 +110,11 @@
 				<form method='POST' style="margin:0">
 					<h5 style="margin-bottom:0">create new job</h5>
 					<input style="display:inline;margin:0;width:50%" name='createpath' type="text" placeholder="myJob"/>
+					<select name="profile" style="display:inline; margin:0; width:auto; vertical-align:middle">
+						<#list engine.profiles as profile>
+						<option value="${profile?html}">${profile?html}</option>
+						</#list>
+					</select>
 					<input class="small inline button" type='submit' name='action' value='create'>
 				</form>
 			</div>

--- a/engine/src/test/java/org/archive/crawler/framework/EngineTest.java
+++ b/engine/src/test/java/org/archive/crawler/framework/EngineTest.java
@@ -1,14 +1,16 @@
 package org.archive.crawler.framework;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EngineTest {
@@ -16,11 +18,60 @@ public class EngineTest {
     Path tempDir;
 
     @Test
-    public void testGetProfileCxmlResource() throws IOException {
-        File dummyJobsDir = new File(tempDir.toFile(),"dummyJobsDir");
-        assertTrue(dummyJobsDir.mkdirs());
-        assertNotNull(new Engine(dummyJobsDir).getProfileCxmlResource());
-        FileUtils.deleteDirectory(dummyJobsDir); 
+    public void testCreateNewJobWithDefaultXmlProfile() throws IOException {
+        Path jobsDir = tempDir.resolve("jobsDir");
+        Files.createDirectories(jobsDir);
+        Path newJobDir = jobsDir.resolve("xmlJob");
+
+        assertTrue(new Engine(jobsDir.toFile()).createNewJobWithDefaults(newJobDir.toFile()));
+
+        assertTrue(Files.exists(newJobDir.resolve("crawler-beans.cxml")));
+        assertFalse(Files.exists(newJobDir.resolve("crawler-beans.groovy")));
     }
 
+    @Test
+    public void testCreateNewJobWithGroovyProfile() throws IOException {
+        Path jobsDir = tempDir.resolve("jobsDir");
+        Files.createDirectories(jobsDir);
+        Path newJobDir = jobsDir.resolve("groovyJob");
+
+        assertTrue(new Engine(jobsDir.toFile()).createNewJobWithDefaults(newJobDir.toFile(),
+                "Defaults (Groovy)"));
+
+        assertTrue(Files.exists(newJobDir.resolve("crawler-beans.groovy")));
+        assertFalse(Files.exists(newJobDir.resolve("crawler-beans.cxml")));
+    }
+
+    @Test
+    public void testCreateNewJobRejectsUnknownProfile() throws IOException {
+        Path jobsDir = tempDir.resolve("jobsDir");
+        Files.createDirectories(jobsDir);
+        Path newJobDir = jobsDir.resolve("badJob");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new Engine(jobsDir.toFile()).createNewJobWithDefaults(newJobDir.toFile(), "bogus"));
+        assertFalse(Files.exists(newJobDir));
+    }
+
+    @Test
+    public void testCreateNewJobFromJobProfile() throws IOException {
+        Path jobsDir = tempDir.resolve("jobsDir");
+        Path profileDir = jobsDir.resolve("profile-example");
+        Files.createDirectories(profileDir);
+        String profileConfig = "<!-- profile-example --><beans/>\n";
+        Files.write(profileDir.resolve("profile-crawler-beans.cxml"), profileConfig.getBytes());
+        Engine engine = new Engine(jobsDir.toFile());
+
+        assertEquals(List.of("Defaults (XML)", "Defaults (Groovy)", "profile-example"),
+                engine.getProfileNames());
+
+        Path newJobDir = jobsDir.resolve("copiedJob");
+
+        assertTrue(engine.createNewJobWithDefaults(newJobDir.toFile(),
+                "profile-example"));
+
+        assertTrue(Files.exists(newJobDir.resolve("crawler-beans.cxml")));
+        assertFalse(Files.exists(newJobDir.resolve("profile-crawler-beans.cxml")));
+        assertEquals(profileConfig, Files.readString(newJobDir.resolve("crawler-beans.cxml")));
+    }
 }


### PR DESCRIPTION
This means:

- Job profiles can be used without having to hunt for them among the regular jobs.
- The Groovy default profile can be selected as an alternative to the Spring XML one.
- The default profiles can be customised by creating a job profile with the same name.

<img width="486" height="172" alt="image" src="https://github.com/user-attachments/assets/03ab4e96-072e-4da2-8618-3a02e788d622" />
