### PR TITLE
fix: cap dynamic attribute names to avoid pathological loop.

### DIFF
--- a/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
+++ b/modules/src/main/java/org/archive/modules/extractor/ExtractorHTML.java
@@ -197,7 +197,7 @@ public class ExtractorHTML extends ContentExtractor implements InitializingBean 
     // matched by the above. attributes known to be URIs of various
     // sorts are matched specially
     static final String EACH_ATTRIBUTE_EXTRACTOR =
-      "(?is)\\s?((href|(?:cite))|(action)|(on\\w*)" // 1, 2, 3, 4
+      "(?is)\\s?((href|(?:cite))|(action)|(on\\w{0,"+MAX_ATTR_NAME_REPLACE+"})" // 1, 2, 3, 4
      +"|((?:src)|(?:srcset)|(?:lowsrc)|(?:background)" // ...
      +"|(?:longdesc)|(?:usemap)|(?:profile)|(?:datasrc)" // ...
      +"|(?:data-src)|(?:data-srcset)|(?:data-original)|(?:data-original-set))" // 5


### PR DESCRIPTION
I ran into a page with an attribute value that is 250MB. We cap that in the regex, but it causes problems when searching for the next attribute and we encounter the \w* while still positioned inside the very large value.