### PR TITLE
BrowserProcessor/MitmProxy: Fix request recording

### DIFF
--- a/commons/src/main/java/org/archive/net/MitmProxy.java
+++ b/commons/src/main/java/org/archive/net/MitmProxy.java
@@ -209,6 +209,18 @@ public class MitmProxy {
         }
 
         @Override
+        protected org.eclipse.jetty.client.Request.Content newProxyToServerRequestContent(
+                org.eclipse.jetty.server.Request clientToProxyRequest,
+                Response proxyToClientResponse,
+                org.eclipse.jetty.client.Request proxyToServerRequest) {
+            var listener = (ExchangeListener)clientToProxyRequest.getAttribute(ExchangeListener.class.getName());
+            if (listener != null) {
+                return new RecordingProxyRequestContent(clientToProxyRequest, proxyToServerRequest, listener);
+            }
+            return super.newProxyToServerRequestContent(clientToProxyRequest, proxyToClientResponse, proxyToServerRequest);
+        }
+
+        @Override
         protected void addProxyHeaders(org.eclipse.jetty.server.Request clientToProxyRequest, org.eclipse.jetty.client.Request proxyToServerRequest) {
             proxyToServerRequest.headers(headers -> {
                 // Ensure we only get the encodings we support
@@ -228,7 +240,10 @@ public class MitmProxy {
             if (listener != null) {
                 proxyToServerRequest.onRequestBegin(listener);
                 proxyToServerRequest.onRequestHeaders(listener);
-                proxyToServerRequest.onRequestContent(listener);
+                // Note: We don't use proxyToServerRequest.onRequestContent(listener)
+                // because it's quirky and the buffer it passes doesn't have the limit
+                // set and includes browser-to-proxy bytes not proxy-to-server. So we
+                // use RecordingProxyRequestContent to tap the request body instead.
                 proxyToServerRequest.onResponseHeaders(listener);
                 proxyToServerRequest.onResponseContent(listener);
                 proxyToServerRequest.onComplete(listener);
@@ -240,6 +255,28 @@ public class MitmProxy {
                 if (existingProxy == proxy) return;
             }
             getHttpClient().getProxyConfiguration().addProxy(proxy);
+        }
+
+        private class RecordingProxyRequestContent extends ProxyRequestContent {
+            private final org.eclipse.jetty.client.Request proxyToServerRequest;
+            private final ExchangeListener listener;
+
+            public RecordingProxyRequestContent(org.eclipse.jetty.server.Request clientToProxyRequest,
+                                                org.eclipse.jetty.client.Request proxyToServerRequest,
+                                                ExchangeListener listener) {
+                super(clientToProxyRequest);
+                this.proxyToServerRequest = proxyToServerRequest;
+                this.listener = listener;
+            }
+
+            @Override
+            public Content.Chunk read() {
+                Content.Chunk chunk = super.read();
+                if (chunk != null && !Content.Chunk.isFailure(chunk) && chunk.hasRemaining()) {
+                    listener.onContent(proxyToServerRequest, chunk.getByteBuffer().asReadOnlyBuffer());
+                }
+                return chunk;
+            }
         }
     }
 

--- a/engine/src/test/java/org/archive/crawler/processor/BrowserProcessorTest.java
+++ b/engine/src/test/java/org/archive/crawler/processor/BrowserProcessorTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.zip.GZIPOutputStream;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @EnabledIfSystemProperty(named = "runBrowserTests", matches = "true")
 class BrowserProcessorTest {
     private static final System.Logger logger = System.getLogger(BrowserProcessorTest.class.getName());
+    private static final String JSON_POST_BODY = "{\"event\":\"browser-subresource\",\"count\":3}";
 
     private static HttpServer httpServer;
     private static FetchHTTP2 fetcher;
@@ -61,6 +63,13 @@ class BrowserProcessorTest {
         assertNotNull(gzip);
         assertEquals("gzip", gzip.getRecorder().getContentEncoding());
         assertEquals("/*hello world*/", gzip.getRecorder().getContentReplayPrefixString(100));
+
+        CrawlURI postJson = subrequestByPath.get("/post-json");
+        assertNotNull(postJson);
+        String postRequest = httpRequestString(postJson);
+        assertTrue(postRequest.startsWith("POST /post-json HTTP/1.1\r\n"), postRequest);
+        assertTrue(postRequest.toLowerCase(Locale.ROOT).contains("content-type: application/json\r\n"), postRequest);
+        assertTrue(postRequest.endsWith("\r\n\r\n" + JSON_POST_BODY), postRequest);
     }
 
     @Test
@@ -115,7 +124,11 @@ class BrowserProcessorTest {
             assertEquals("/link", outLinks.get(0).getUURI().getPath());
             assertTrue(crawlURI.getAnnotations().contains("browser"));
             assertEquals("true", crawlURI.getHttpResponseHeader("Used-Proxy"));
-            assertEquals("true", subrequests.get(0).getHttpResponseHeader("Used-Proxy"));
+            var subrequestByPath = new HashMap<String,CrawlURI>();
+            for (CrawlURI curi : subrequests) {
+                subrequestByPath.put(curi.getUURI().getPath(), curi);
+            }
+            assertEquals("true", subrequestByPath.get("/style.css").getHttpResponseHeader("Used-Proxy"));
 
             logger.log(DEBUG, "Subrequests: {0}", subrequests);
         } finally {
@@ -131,6 +144,11 @@ class BrowserProcessorTest {
         recorders.add(recorder);
         curi.setRecorder(recorder);
         return curi;
+    }
+
+    private static String httpRequestString(CrawlURI curi) throws IOException {
+        return new String(curi.getRecorder().getRecordedOutput().getReplayInputStream().readAllBytes(),
+                StandardCharsets.UTF_8);
     }
 
     @BeforeEach
@@ -160,10 +178,29 @@ class BrowserProcessorTest {
             int status = 200;
             String body = "";
             switch (exchange.getRequestURI().getPath()) {
-                case "/" -> body = "<link href=style.css rel=stylesheet><link href=gzip rel=stylesheet><a href=\"/link\">link</a><img src=img.jpg>";
+                case "/" -> body = """
+                        <link href=style.css rel=stylesheet>
+                        <link href=gzip rel=stylesheet>
+                        <a href="/link">link</a>
+                        <img src=img.jpg>
+                        <script>
+                            fetch('/post-json', {
+                                method: 'POST',
+                                headers: {'Content-Type': 'application/json'},
+                                body: '%s'
+                            });
+                        </script>
+                        """.formatted(JSON_POST_BODY);
                 case "/style.css" -> {
                     body = "body { color: red; background: url(bg.jpg); }";
                     contentType = "text/css";
+                }
+                case "/post-json" -> {
+                    assertEquals("POST", exchange.getRequestMethod());
+                    assertEquals(JSON_POST_BODY, new String(exchange.getRequestBody().readAllBytes(),
+                            StandardCharsets.UTF_8));
+                    body = "{\"ok\":true}";
+                    contentType = "application/json";
                 }
                 case "/paginated" -> body = """
                         <div id=items><a href="/item1">item</a></div>


### PR DESCRIPTION
This fixes a bug where POST requests would get recorded with a doubled header and a bunch of nulls at the end.

It seems that the onRequestContent() listener doesn't pass us the right buffer when proxying. The buffer seems to contain client-to-proxy data and the buffer's limit isn't set. So instead this records the request content by overriding newProxyToServerRequestContent.