### PR TITLE
BrowserProcessor: improve reliability

### DIFF
--- a/commons/src/main/java/org/archive/net/webdriver/BiDiJson.java
+++ b/commons/src/main/java/org/archive/net/webdriver/BiDiJson.java
@@ -111,7 +111,7 @@ class BiDiJson {
     @SuppressWarnings("unchecked")
     static <T> T fromJson(Object value, Class<T> type) {
         try {
-            if (value == JSONObject.NULL) {
+            if (value == JSONObject.NULL || type == Void.class) {
                 return null;
             }
             if (value == null || type.isPrimitive() || type.isAssignableFrom(value.getClass())) {

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -55,6 +55,8 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
             .setDaemon(true)
             .build());
     private final String sessionId;
+    private final Object sendLock = new Object();
+    private CompletableFuture<?> sendChain = CompletableFuture.completedFuture(null);
     private static final String[] BROWSERS = new String[]{
             "firefox", "/Applications/Firefox.app/Contents/MacOS/firefox", "chromedriver"};
 
@@ -132,7 +134,20 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
         logger.log(System.Logger.Level.TRACE, "BiDi SEND {0}", message);
         CompletableFuture<JSONObject> future = new CompletableFuture<>();
         commands.put(id, future);
-        webSocket.sendText(message, true);
+        // The JDK WebSocket only permits one outstanding send at a time, so queue sends one after
+        // another. If a send fails (e.g. connection lost) fail the command immediately rather than
+        // leaving it to time out.
+        synchronized (sendLock) {
+            sendChain = sendChain.handle((ignored, error) -> webSocket.sendText(message, true))
+                    .thenCompose(sendFuture -> sendFuture)
+                    .whenComplete((ignored, error) -> {
+                        if (error != null) {
+                            commands.remove(id);
+                            future.completeExceptionally(error instanceof WebDriverException ? error :
+                                    new WebDriverException("Failed to send " + method + " command", error));
+                        }
+                    });
+        }
         return future;
     }
 

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -174,6 +174,13 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
         return future;
     }
 
+    /**
+     * Returns true if the browser process is running and the WebDriver connection is still open.
+     */
+    public boolean isAlive() {
+        return process.isAlive() && !webSocket.isInputClosed() && !webSocket.isOutputClosed();
+    }
+
     private void failPendingCommands(Throwable failure) {
         for (Long id : commands.keySet()) {
             var future = commands.remove(id);
@@ -236,13 +243,28 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
     @Override
     public void close() throws IOException {
         try {
-            if (process.isAlive() && !webSocket.isInputClosed()) {
+            if (isAlive()) {
                 browser().close();
             }
         } catch (Exception e) {
             logger.log(System.Logger.Level.ERROR, "Error closing browser", e);
         }
         process.destroy();
+        try {
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+        }
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException ignored) {
+            // JVM is already shutting down
+        }
+        failPendingCommands(new WebDriverException("WebDriver connection closed"));
+        eventExecutor.shutdown();
     }
 
     private class Listener implements WebSocket.Listener {

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -151,6 +151,13 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
         return future;
     }
 
+    private void failPendingCommands(Throwable failure) {
+        for (Long id : commands.keySet()) {
+            var future = commands.remove(id);
+            if (future != null) future.completeExceptionally(failure);
+        }
+    }
+
     public <T extends BiDiEvent> void on(Class<T> eventClass, Consumer<T> handler) {
         String eventName = StringUtils.uncapitalize(eventClass.getEnclosingClass().getSimpleName()) + "." +
                 StringUtils.uncapitalize(eventClass.getSimpleName());
@@ -260,6 +267,13 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
         @Override
         public void onError(WebSocket webSocket, Throwable error) {
             logger.log(System.Logger.Level.ERROR, "WebSocket error", error);
+            failPendingCommands(new WebDriverException("WebDriver connection error: " + error));
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            failPendingCommands(new WebDriverException("WebDriver connection closed: " + statusCode + " " + reason));
+            return null;
         }
     }
 }

--- a/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
+++ b/commons/src/main/java/org/archive/net/webdriver/LocalWebDriverBiDi.java
@@ -55,20 +55,43 @@ public class LocalWebDriverBiDi implements WebDriverBiDi, Closeable {
             .setDaemon(true)
             .build());
     private final String sessionId;
+    private final Thread shutdownHook;
     private final Object sendLock = new Object();
     private CompletableFuture<?> sendChain = CompletableFuture.completedFuture(null);
+    private static final int LAUNCH_TIMEOUT_SECONDS = 60;
     private static final String[] BROWSERS = new String[]{
             "firefox", "/Applications/Firefox.app/Contents/MacOS/firefox", "chromedriver"};
 
     public LocalWebDriverBiDi(String executable, List<String> options, Session.CapabilitiesRequest capabilities, Path profileDir)
             throws ExecutionException, InterruptedException, IOException {
         this.process = executable == null ? launchAnyBrowser(options, profileDir) : launchBrowser(executable, options, profileDir);
-        Runtime.getRuntime().addShutdownHook(new Thread(this.process::destroyForcibly));
-        new Thread(this::handleStderr).start();
-        webSocket = HttpClient.newHttpClient().newWebSocketBuilder()
-                .buildAsync(URI.create(webSocketUrl.get() + "/session"), new Listener())
-                .get();
-        sessionId = session().new_(capabilities).sessionId();
+        shutdownHook = new Thread(this.process::destroyForcibly);
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        var stderrThread = new Thread(this::handleStderr, "LocalWebDriverBiDi-stderr");
+        stderrThread.setDaemon(true);
+        stderrThread.start();
+        try {
+            String url = webSocketUrl.get(LAUNCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            webSocket = HttpClient.newHttpClient().newWebSocketBuilder()
+                    .buildAsync(URI.create(url + "/session"), new Listener())
+                    .get(LAUNCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            sessionId = session().new_(capabilities).sessionId();
+        } catch (TimeoutException e) {
+            destroyProcess();
+            throw new IOException("Browser did not start within " + LAUNCH_TIMEOUT_SECONDS + " seconds", e);
+        } catch (Exception e) {
+            destroyProcess();
+            throw e;
+        }
+    }
+
+    private void destroyProcess() {
+        process.destroyForcibly();
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException ignored) {
+            // JVM is already shutting down
+        }
     }
 
     private static Process launchAnyBrowser(List<String> options, Path profileDir) throws IOException {

--- a/commons/src/main/java/org/archive/net/webdriver/WebDriverException.java
+++ b/commons/src/main/java/org/archive/net/webdriver/WebDriverException.java
@@ -23,4 +23,8 @@ public class WebDriverException extends RuntimeException {
     public WebDriverException(String message) {
         super(message);
     }
+
+    public WebDriverException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
@@ -189,7 +189,7 @@ public class BrowserProcessor extends Processor {
             try {
                 navigation = webdriver.browsingContext().navigate(tab, curi.getURI(), BrowsingContext.ReadinessState.complete);
             } catch (WebDriverException e) {
-                if (e.getMessage().equals("net::ERR_ABORTED")) return; // Chrome: probably download started
+                if ("net::ERR_ABORTED".equals(e.getMessage())) return; // Chrome: probably download started
                 throw e;
             }
             if (navigation.url().equals("about:blank")) return; // Firefox: probably download started

--- a/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
@@ -86,12 +86,13 @@ public class BrowserProcessor extends Processor {
     protected final CrawlController crawlController;
     protected MitmProxy proxy;
     protected final FetchHTTP2 fetcher;
-    protected LocalWebDriverBiDi webdriver;
+    protected volatile LocalWebDriverBiDi webdriver;
     protected final ApplicationEventPublisher eventPublisher;
     protected final Map<String, BrowserPage> pages = new ConcurrentHashMap<>();
     protected final Map<BrowsingContext.Context, String> pageIdsByContext = new ConcurrentHashMap<>();
     protected final ProcessorChain extractorChain = new ProcessorChain();
     protected final AtomicLong subresourcesRecorded = new AtomicLong();
+    protected final AtomicLong browserRestarts = new AtomicLong();
     protected List<Behavior> behaviors;
     protected String executable;
     protected List<String> options = List.of("--headless");
@@ -106,7 +107,7 @@ public class BrowserProcessor extends Processor {
         this.behaviors = List.of(new ScrollDownBehavior(), new ExtractLinksBehavior(uriErrorLoggerModule));
     }
 
-    public void stop() {
+    public synchronized void stop() {
         if (!isRunning) return;
         super.stop();
         if (proxy != null) {
@@ -170,6 +171,7 @@ public class BrowserProcessor extends Processor {
         builder.append(super.report());
         builder.append("  Pages visited: ").append(getURICount()).append("\n");
         builder.append("  Subresources recorded: ").append(subresourcesRecorded.get()).append("\n");
+        builder.append("  Browser restarts: ").append(browserRestarts.get()).append("\n");
         for (var behavior : behaviors) {
             builder.append(behavior.report());
         }
@@ -177,21 +179,66 @@ public class BrowserProcessor extends Processor {
     }
 
     private void visit(CrawlURI curi) {
+        for (int attempt = 0; ; attempt++) {
+            LocalWebDriverBiDi driver = webdriver;
+            try {
+                visit(curi, driver);
+                return;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (WebDriverException e) {
+                if (attempt == 0 && !driver.isAlive()) {
+                    logger.log(WARNING, "Browser died while visiting " + curi + ", restarting it", e);
+                    if (restartBrowser(driver)) continue; // retry once with the new browser
+                }
+                logger.log(WARNING, "WebDriver exception visiting " + curi, e);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Replaces a dead browser with a freshly launched one. Threads that lose the race to restart
+     * still return true so they retry against the browser the winner launched.
+     *
+     * @return true if a live browser is now available, false if the restart failed or the
+     *         processor is stopping
+     */
+    private synchronized boolean restartBrowser(LocalWebDriverBiDi deadDriver) {
+        if (!isRunning) return false;
+        if (webdriver != deadDriver) return true; // another thread already restarted it
+        try {
+            deadDriver.close();
+        } catch (Exception e) {
+            logger.log(WARNING, "Error closing dead browser", e);
+        }
+        try {
+            webdriver = createWebDriver();
+            browserRestarts.incrementAndGet();
+            return true;
+        } catch (Exception e) {
+            logger.log(ERROR, "Failed to restart browser", e);
+            return false;
+        }
+    }
+
+    private void visit(CrawlURI curi, LocalWebDriverBiDi driver) throws InterruptedException {
         String pageId = UUID.randomUUID().toString();
-        var tab = webdriver.browsingContext().create(BrowsingContext.CreateType.tab).context();
+        var tab = driver.browsingContext().create(BrowsingContext.CreateType.tab).context();
         try {
             String userAgent = curi.getUserAgent();
             if (userAgent == null) userAgent = fetcher.getUserAgentProvider().getUserAgent();
-            BrowserPage page = new BrowserPage(curi, new IdleBarrier(), webdriver, tab, fetcher.getProxy(), userAgent);
+            BrowserPage page = new BrowserPage(curi, new IdleBarrier(), driver, tab, fetcher.getProxy(), userAgent);
             pages.put(pageId, page);
             pageIdsByContext.put(tab, pageId);
-            webdriver.network().addIntercept(List.of(Network.InterceptPhase.beforeRequestSent), List.of(tab),
+            driver.network().addIntercept(List.of(Network.InterceptPhase.beforeRequestSent), List.of(tab),
                     List.of(new Network.UrlPatternPattern("pattern", "http"),
                             new Network.UrlPatternPattern("pattern", "https")));
             BrowsingContext.NavigateResult navigation;
 
             try {
-                navigation = webdriver.browsingContext().navigate(tab, curi.getURI(), BrowsingContext.ReadinessState.complete);
+                navigation = driver.browsingContext().navigate(tab, curi.getURI(), BrowsingContext.ReadinessState.complete);
             } catch (WebDriverException e) {
                 if ("net::ERR_ABORTED".equals(e.getMessage())) return; // Chrome: probably download started
                 throw e;
@@ -208,21 +255,20 @@ public class BrowserProcessor extends Processor {
             for (Behavior behavior : behaviors) {
                 try {
                     behavior.run(page);
+                } catch (WebDriverException e) {
+                    if (!driver.isAlive()) throw e; // browser died: restart it and revisit the page
+                    logger.log(ERROR, "Error running " + behavior.getClass().getName() + " on " + curi, e);
                 } catch (Exception e) {
                     logger.log(ERROR, "Error running " + behavior.getClass().getName() + " on " + curi, e);
                 }
             }
 
             curi.getAnnotations().add("browser");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (WebDriverException e) {
-            logger.log(WARNING, "WebDriver exception visiting " + curi, e);
         } finally {
             pageIdsByContext.remove(tab);
             pages.remove(pageId);
             try {
-                webdriver.browsingContext().close(tab);
+                driver.browsingContext().close(tab);
             } catch (WebDriverException e) {
                 logger.log(WARNING, "Error closing tab for " + curi, e);
             }
@@ -255,48 +301,58 @@ public class BrowserProcessor extends Processor {
             throw new RuntimeException(e);
         }
         try {
-            Path profileDir = scratchDir.resolve("profile");
-            Files.createDirectories(profileDir);
-
-            // Firefox doesn't seem to allow setting prefs via capabilities with bidi
-            // so drop them in user.js instead
-            Files.writeString(profileDir.resolve("user.js"), """
-            // send localhost requests via the proxy too (for tests and local crawling)
-            user_pref('network.proxy.allow_hijacking_localhost', true);
-            
-            // disable downloads by setting to something that can't be created as a directory
-            user_pref('browser.download.dir', '/dev/null');
-            user_pref('browser.download.folderList', 2);
-            """);
-
-            int proxyPort = proxy.getPort();
-            var alwaysMatch = Map.of("acceptInsecureCerts", true,
-                    "proxy", new Session.ProxyConfiguration("manual",
-                            "127.0.0.1:" + proxyPort, "127.0.0.1:" + proxyPort));
-
-            List<Map<String,Object>> firstMatch = List.of(
-                    Map.of("browserName", "chrome",
-                            "goog:chromeOptions", Map.of(
-                                    "args", List.of("headless=new", "user-data-dir=" + profileDir,
-                                            "proxy-bypass-list=<-loopback>"),
-                                    "prefs", Map.of("download_restrictions", 3))),
-                    // Fallback for other browsers
-                    Map.of()
-            );
-            var capabilities = new Session.CapabilitiesRequest(alwaysMatch, firstMatch);
-
-
-            this.webdriver = new LocalWebDriverBiDi(executable, options, capabilities, profileDir);
+            this.webdriver = createWebDriver();
         } catch (Exception e) {
             logger.log(ERROR, "Error starting browser", e);
             throw new RuntimeException(e);
         }
-        webdriver.session().subscribe(List.of("browsingContext.contextCreated",
-                "network.beforeRequestSent"), null);
-        webdriver.on(Network.BeforeRequestSent.class, this::handleBeforeRequestSent);
     }
 
-    private void handleBeforeRequestSent(Network.BeforeRequestSent event) {
+    private LocalWebDriverBiDi createWebDriver() throws Exception {
+        Path scratchDir = crawlController.getScratchDir().getFile().toPath();
+        Path profileDir = scratchDir.resolve("profile");
+        Files.createDirectories(profileDir);
+
+        // Firefox doesn't seem to allow setting prefs via capabilities with bidi
+        // so drop them in user.js instead
+        Files.writeString(profileDir.resolve("user.js"), """
+        // send localhost requests via the proxy too (for tests and local crawling)
+        user_pref('network.proxy.allow_hijacking_localhost', true);
+
+        // disable downloads by setting to something that can't be created as a directory
+        user_pref('browser.download.dir', '/dev/null');
+        user_pref('browser.download.folderList', 2);
+        """);
+
+        int proxyPort = proxy.getPort();
+        var alwaysMatch = Map.of("acceptInsecureCerts", true,
+                "proxy", new Session.ProxyConfiguration("manual",
+                        "127.0.0.1:" + proxyPort, "127.0.0.1:" + proxyPort));
+
+        List<Map<String,Object>> firstMatch = List.of(
+                Map.of("browserName", "chrome",
+                        "goog:chromeOptions", Map.of(
+                                "args", List.of("headless=new", "user-data-dir=" + profileDir,
+                                        "proxy-bypass-list=<-loopback>"),
+                                "prefs", Map.of("download_restrictions", 3))),
+                // Fallback for other browsers
+                Map.of()
+        );
+        var capabilities = new Session.CapabilitiesRequest(alwaysMatch, firstMatch);
+
+        var driver = new LocalWebDriverBiDi(executable, options, capabilities, profileDir);
+        try {
+            driver.session().subscribe(List.of("browsingContext.contextCreated",
+                    "network.beforeRequestSent"), null);
+            driver.on(Network.BeforeRequestSent.class, event -> handleBeforeRequestSent(driver, event));
+        } catch (Exception e) {
+            driver.close();
+            throw e;
+        }
+        return driver;
+    }
+
+    private void handleBeforeRequestSent(LocalWebDriverBiDi driver, Network.BeforeRequestSent event) {
         if (event.request().url().startsWith("data:") || !event.isBlocked()) return;
         List<Network.Header> requestHeaders = event.request().headers();
         String pageId = pageIdsByContext.get(event.context());
@@ -311,7 +367,7 @@ public class BrowserProcessor extends Processor {
                 }
             }
         }
-        webdriver.network().continueRequestAsync(event.request().request(), requestHeaders)
+        driver.network().continueRequestAsync(event.request().request(), requestHeaders)
                 .exceptionally(e -> {
                     logger.log(WARNING, "Error continuing request " + event.request().url() + ": " + e);
                     return null;

--- a/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
@@ -109,15 +109,19 @@ public class BrowserProcessor extends Processor {
     public void stop() {
         if (!isRunning) return;
         super.stop();
-        try {
-            proxy.stop();
-        } catch (Exception e) {
-            logger.log(ERROR, "Error stopping proxy server", e);
+        if (proxy != null) {
+            try {
+                proxy.stop();
+            } catch (Exception e) {
+                logger.log(ERROR, "Error stopping proxy server", e);
+            }
         }
-        try {
-            webdriver.close();
-        } catch (Exception e) {
-            logger.log(ERROR, "Error closing WebDriverBiDi", e);
+        if (webdriver != null) {
+            try {
+                webdriver.close();
+            } catch (Exception e) {
+                logger.log(ERROR, "Error closing WebDriverBiDi", e);
+            }
         }
     }
 

--- a/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
@@ -217,7 +217,11 @@ public class BrowserProcessor extends Processor {
         } finally {
             pageIdsByContext.remove(tab);
             pages.remove(pageId);
-            webdriver.browsingContext().close(tab);
+            try {
+                webdriver.browsingContext().close(tab);
+            } catch (WebDriverException e) {
+                logger.log(WARNING, "Error closing tab for " + curi, e);
+            }
         }
     }
 

--- a/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
+++ b/engine/src/main/java/org/archive/crawler/processor/BrowserProcessor.java
@@ -311,7 +311,11 @@ public class BrowserProcessor extends Processor {
                 }
             }
         }
-        webdriver.network().continueRequestAsync(event.request().request(), requestHeaders);
+        webdriver.network().continueRequestAsync(event.request().request(), requestHeaders)
+                .exceptionally(e -> {
+                    logger.log(WARNING, "Error continuing request " + event.request().url() + ": " + e);
+                    return null;
+                });
     }
 
     private void handleProxyRequest(MitmProxy.Request proxyRequest) throws IOException {

--- a/engine/src/test/java/org/archive/crawler/processor/BrowserProcessorTest.java
+++ b/engine/src/test/java/org/archive/crawler/processor/BrowserProcessorTest.java
@@ -101,6 +101,22 @@ class BrowserProcessorTest {
     }
 
     @Test
+    public void testBrowserRestart() throws IOException, InterruptedException {
+        long restartsBefore = browserProcessor.browserRestarts.get();
+        browserProcessor.webdriver.close(); // simulate the browser dying
+
+        CrawlURI crawlURI = newCrawlURI(baseUrl);
+        fetcher.process(crawlURI);
+        assertEquals(200, crawlURI.getFetchStatus());
+        browserProcessor.innerProcess(crawlURI);
+
+        assertEquals(restartsBefore + 1, browserProcessor.browserRestarts.get(),
+                "browser should have been restarted");
+        assertTrue(crawlURI.getAnnotations().contains("browser"),
+                "page should have been visited by the restarted browser");
+    }
+
+    @Test
     public void testDownload() throws IOException, InterruptedException {
         CrawlURI crawlURI = newCrawlURI(baseUrl + "download.bin");
         fetcher.process(crawlURI);


### PR DESCRIPTION
* Restart the browser if it crashes, failing any pending commands.
* Serialize WebSocket sends (it can throw if another thread is concurrently sending).
* Kill the browser if normal termination fails or the JVM is shutdown.
* Use a 60 second timeout when waiting for the browser to start.
* Improve error handling and logging.