### PR TITLE
Add Heritrix response codes in ResponseCode report

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/StatisticsTracker.java
@@ -787,14 +787,20 @@ public class StatisticsTracker
     
     public void crawledURINeedRetry(CrawlURI curi) {
         handleSeed(curi,"Failed to crawl seed, will retry");
+        // Save status codes
+        incrementMapCount(statusCodeDistribution, Integer.toString(curi.getFetchStatus()));
     }
 
     public void crawledURIDisregard(CrawlURI curi) {
         handleSeed(curi,"Seed was disregarded");
+        // Save status codes
+        incrementMapCount(statusCodeDistribution, Integer.toString(curi.getFetchStatus()));
     }
 
     public void crawledURIFailure(CrawlURI curi) {
         handleSeed(curi,"Failed to crawl seed");
+        // Save status codes
+        incrementMapCount(statusCodeDistribution, Integer.toString(curi.getFetchStatus()));
     }
     
     /**


### PR DESCRIPTION
Related to issue #747 

Instead of creating a new report for the Heritrix response codes, I added those codes in the ResponseCode report.
Now the file responsecode-report.txt displays the HTTP response codes and the Heritrix response codes.