### PR TITLE
Issue #753 verify if bdb is started before generating reports

### DIFF
--- a/engine/src/main/java/org/archive/crawler/reporting/HostsReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/HostsReport.java
@@ -76,6 +76,10 @@ public class HostsReport extends Report {
 	
 	@Override
     public void write(final PrintWriter writer, StatisticsTracker stats) {
+            if (!stats.bdb.isRunning()) {
+                writer.println("bdb not started");
+                return;
+            }
     	Collection<String> keys = null;
     	DisposableStoredSortedMap<Long, String> hd = null;
     	if (maxSortSize<0 || maxSortSize>stats.serverCache.hostKeys().size()) {

--- a/engine/src/main/java/org/archive/crawler/reporting/MimetypesReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/MimetypesReport.java
@@ -33,6 +33,10 @@ public class MimetypesReport extends Report {
 
     @Override
     public void write(PrintWriter writer, StatisticsTracker stats) {
+        if (!stats.bdb.isRunning()) {
+            writer.println("bdb not started");
+            return;
+        }
         // header
         writer.print("[#urls] [#bytes] [mime-types]\n");
         DisposableStoredSortedMap<Long,String> fd = stats.getReverseSortedCopy(stats.getFileDistribution());

--- a/engine/src/main/java/org/archive/crawler/reporting/ResponseCodeReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/ResponseCodeReport.java
@@ -32,6 +32,10 @@ public class ResponseCodeReport extends Report {
 
     @Override
     public void write(PrintWriter writer, StatisticsTracker stats) {
+        if (!stats.bdb.isRunning()) {
+            writer.println("bdb not started");
+            return;
+        }
         // header
         writer.print("[#urls] [rescode]\n");
         

--- a/engine/src/main/java/org/archive/crawler/reporting/SeedsReport.java
+++ b/engine/src/main/java/org/archive/crawler/reporting/SeedsReport.java
@@ -36,6 +36,11 @@ public class SeedsReport extends Report {
 
     @Override
     public void write(PrintWriter writer, StatisticsTracker stats) {
+        if (!stats.bdb.isRunning()) {
+            writer.println("bdb not started");
+            return;
+        }
+
         // Build header.
         writer.print("[code] [status] [seed] [redirect]\n");
 


### PR DESCRIPTION
Related to issue #753.

When you view the reports while the job is ready but hasn't been started yet, the BDB hasn't been started yet and throws an exception.
For the reports Seeds, Hosts, MimeTypes and ResponseCode, the message "bdb not started" appears instead of an error page with the exception's stack trace.
The message is modeled after the message "frontier unstarted" of the FrontierSummary.