### PR TITLE
Introduce queue-group scheduling mechanism

### DIFF
--- a/docs/QUEUE_GROUPS.md
+++ b/docs/QUEUE_GROUPS.md
@@ -1,0 +1,207 @@
+# Queue Groups
+
+Queue groups let you treat several otherwise-independent per-host work queues as
+if they were a **single web server** for the purposes of politeness and
+scheduling.
+
+The URLs are **not** merged into a single queue: each host keeps its own
+`WorkQueue` (its own `classKey`). A group only adds, on top of the existing flat
+frontier scheduler:
+
+- a **shared politeness gate**: at most `maxParallelInGroup` member queues may be
+  "in process" simultaneously, and a shared cool-down of at least
+  `groupMinDelayMs` milliseconds is enforced between fetches of the group;
+- a **round-robin rotation** among the group's member queues, so the crawler
+  alternates between hosts (`european-union.europa.eu`, then
+  `commission.europa.eu`, ...) instead of draining one host first. Members that
+  are not currently ready (snoozed, empty) are simply skipped.
+
+With `maxParallelInGroup=1` and a shared cool-down, the whole group behaves as a
+single scheduling unit toward the server: its member hosts share a single fetch
+slot.
+
+Queue groups are **optional**. When the `queueGroups` bean is absent (as by
+default), the frontier behaves exactly as before.
+
+## How members are matched: the `classKey`
+
+Group members are matched against the frontier's queue **`classKey`**, whose
+format depends on the configured `queueAssignmentPolicy`.
+
+The default policy, `SurtAuthorityQueueAssignmentPolicy`, produces **SURT-form
+authority** classKeys. For example:
+
+| URL                              | classKey                 |
+|----------------------------------|--------------------------|
+| `http://commission.europa.eu/`   | `eu,europa,commission,`  |
+| `http://data.europa.eu/`         | `eu,europa,data,`        |
+| `http://www.example.com:8080/`   | `com,example,www,#8080`  |
+
+
+> **Important:** choose your member declaration style to match the `classKey`
+> format produced by your `queueAssignmentPolicy`. With the default
+> `SurtAuthorityQueueAssignmentPolicy`, use `groupMembersBySurt`. The
+> `groupMembersByHost` and `groupMembersByRegex` forms match plain hostnames and
+> are only appropriate when a host-based policy (e.g.
+> `HostnameQueueAssignmentPolicy`) is used.
+
+## Declaring queue groups
+
+A queue group is declared through the `queueGroups` bean (a
+`QueueGroupManager`), which holds a list of `QueueGroup` beans.
+
+Each `QueueGroup` supports the following properties:
+
+| Property               | Type           | Default | Description                                                             |
+|------------------------|----------------|---------|-------------------------------------------------------------------------|
+| `name`                 | String         | —       | Human-readable, unique name of the group.                               |
+| `maxParallelInGroup`   | int            | `1`     | Max member queues fetched simultaneously (shared concurrency).          |
+| `groupMinDelayMs`      | long (ms)      | `0`     | Minimal shared delay between two fetches of the group.                  |
+| `groupMembersByHost`   | List<String>   | empty   | Exact host match (host-based policies only).                            |
+| `groupMembersByRegex`  | List<Pattern>  | empty   | Full regex match against the host part of the classKey.                 |
+| `groupMembersBySurt`   | List<String>   | empty   | classKey starts with the given SURT-authority prefix (default policy).  |
+
+A queue belongs to
+the group if it matches **any** member declaration.
+
+### Example 1 — By SURT prefix (default policy)
+
+Recommended with the default `SurtAuthorityQueueAssignmentPolicy`. A member
+matches when the `classKey` **starts with** the given SURT-authority prefix.
+
+The prefix `eu,europa,` groups all `*.europa.eu` queues
+(`commission.europa.eu` -> `eu,europa,commission,`,
+`data.europa.eu` -> `eu,europa,data,`, ...).
+
+```xml
+<bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
+ <property name="groups">
+  <list>
+   <bean class="org.archive.crawler.frontier.QueueGroup">
+    <property name="name" value="europa_eu" />
+    <property name="maxParallelInGroup" value="1" />
+    <property name="groupMinDelayMs" value="4000" />
+    <property name="groupMembersBySurt">
+     <list>
+      <value>eu,europa,</value>
+     </list>
+    </property>
+   </bean>
+  </list>
+ </property>
+</bean>
+```
+
+To group only two specific hosts (instead of a whole domain), use their full
+SURT authorities:
+
+```xml
+<property name="groupMembersBySurt">
+ <list>
+  <value>eu,europa,commission,</value>
+  <value>eu,europa,data,</value>
+ </list>
+</property>
+```
+
+### Example 2 — By exact host (host-based policy)
+
+Use `groupMembersByHost` only when a host-based `queueAssignmentPolicy` (e.g.
+`HostnameQueueAssignmentPolicy`) is configured, so that classKeys are plain
+hostnames. A member matches when the `classKey` equals the host, or begins with
+`host#` (port) or `host+` (subqueue).
+
+```xml
+<bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
+ <property name="groups">
+  <list>
+   <bean class="org.archive.crawler.frontier.QueueGroup">
+    <property name="name" value="europa_eu_hosts" />
+    <property name="maxParallelInGroup" value="1" />
+    <property name="groupMinDelayMs" value="4000" />
+    <property name="groupMembersByHost">
+     <list>
+      <value>european-union.europa.eu</value>
+      <value>commission.europa.eu</value>
+      <value>data.europa.eu</value>
+      <value>op.europa.eu</value>
+     </list>
+    </property>
+   </bean>
+  </list>
+ </property>
+</bean>
+```
+
+### Example 3 — By regex (host-based policy)
+
+Use `groupMembersByRegex` only with a host-based `queueAssignmentPolicy`. The
+pattern must **fully match** the host part of the classKey (the substring before
+any `#` or `+`).
+
+```xml
+<bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
+ <property name="groups">
+  <list>
+   <bean class="org.archive.crawler.frontier.QueueGroup">
+    <property name="name" value="europa_eu_regex" />
+    <property name="maxParallelInGroup" value="1" />
+    <property name="groupMinDelayMs" value="4000" />
+    <property name="groupMembersByRegex">
+     <list>
+      <value>.*\.europa\.eu</value>
+     </list>
+    </property>
+   </bean>
+  </list>
+ </property>
+</bean>
+```
+
+### Example 4 — Multiple groups and combined matchers
+
+You can declare several groups, and combine member lists within a group.
+
+```xml
+<bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
+ <property name="groups">
+  <list>
+   <!-- One shared visitor for all *.europa.eu (default SURT policy). -->
+   <bean class="org.archive.crawler.frontier.QueueGroup">
+    <property name="name" value="europa_eu" />
+    <property name="maxParallelInGroup" value="1" />
+    <property name="groupMinDelayMs" value="4000" />
+    <property name="groupMembersBySurt">
+     <list>
+      <value>eu,europa,</value>
+     </list>
+    </property>
+   </bean>
+
+   <!-- Allow up to 2 parallel fetches across a couple of example hosts. -->
+   <bean class="org.archive.crawler.frontier.QueueGroup">
+    <property name="name" value="example_sites" />
+    <property name="maxParallelInGroup" value="2" />
+    <property name="groupMinDelayMs" value="1000" />
+    <property name="groupMembersBySurt">
+     <list>
+      <value>com,example,</value>
+      <value>org,example,</value>
+     </list>
+    </property>
+   </bean>
+  </list>
+ </property>
+</bean>
+```
+
+## Choosing the matcher style
+
+| Matcher                | Matches against         | Use when the queueAssignmentPolicy is ...                |
+|------------------------|-------------------------|----------------------------------------------------------|
+| `groupMembersBySurt`   | whole `classKey` (prefix)| `SurtAuthorityQueueAssignmentPolicy` (default)          |
+| `groupMembersByHost`   | host part (exact)       | host-based (e.g. `HostnameQueueAssignmentPolicy`)         |
+| `groupMembersByRegex`  | host part (full match)  | host-based (e.g. `HostnameQueueAssignmentPolicy`)         |
+
+If a member declaration never matches, check that its style is consistent with
+the classKey format produced by your active `queueAssignmentPolicy`.

--- a/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
@@ -209,10 +209,7 @@ public class QueueGroup implements Serializable {
                 || classKey.startsWith(value + "+")) {
             return true;
         }
-        // SURT-prefix member (ends with a comma), e.g. "eu,europa,"
-        if (value.endsWith(",") && classKey.startsWith(value)) {
-            return true;
-        }
+        
         return false;
     }
 

--- a/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
@@ -1,0 +1,416 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.crawler.frontier;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A "queue group": a set of otherwise-independent per-host work queues
+ * that a crawler should treat as sharing a single web server for the
+ * purposes of politeness and scheduling (issue #754, "option 1").
+ *
+ * <p>The URLs are <b>not</b> merged into a single queue: each host keeps its
+ * own {@link WorkQueue} (its own {@code classKey}). The group only adds, on
+ * top of the existing flat scheduler:</p>
+ * <ul>
+ *   <li>a <b>shared politeness gate</b>: at most {@link #maxParallelInGroup}
+ *       member queues may be "in process" simultaneously, and a shared
+ *       cool-down of at least {@link #groupMinDelayMs} ms is enforced between
+ *       fetches of the group;</li>
+ *   <li>a <b>round-robin rotation</b> among the group's member queues, so the
+ *       crawler alternates between hosts (european-union.europa.eu, then
+ *       commission.europa.eu, ...) instead of draining one host first. Members
+ *       that are not currently ready (snoozed, empty) are simply skipped.</li>
+ * </ul>
+ *
+ * <p>With {@code maxParallelInGroup=1} and a shared cool-down, the whole group
+ * behaves as a single scheduling unit toward the server (the "17/50" balance
+ * described in the ticket): its member hosts share a single fetch slot.</p>
+ *
+ * <p>All rotation/gate state is transient and simply reset on
+ * restart/checkpoint.</p>
+ *
+ * <p>Members are matched against a queue's {@code classKey}. A member can be
+ * declared in three separate, dedicated lists:</p>
+ * <ul>
+ *   <li><b>{@link #groupMembersByHost}</b> (e.g. {@code european-union.europa.eu}):
+ *       exact host match;</li>
+ *   <li><b>{@link #groupMembersByRegex}</b> (e.g. {@code .*\.europa\.eu}): full
+ *       match on the host part of the classKey;</li>
+ *   <li><b>{@link #groupMembersBySurt}</b> (e.g. {@code http://(eu,europa,}):
+ *       classKey starts with the given SURT prefix.</li>
+ * </ul>
+ */
+public class QueueGroup implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger logger =
+            Logger.getLogger(QueueGroup.class.getName());
+
+    /** Human-readable, unique name of the group (e.g. "europa_eu"). */
+    protected String name;
+
+    /** Exact host member matchers (see class javadoc). */
+    protected List<String> groupMembersByHost = new ArrayList<String>();
+
+    /** Regex member matchers, matched against the host part of the classKey. */
+    protected List<String> groupMembersByRegex = new ArrayList<String>();
+
+    /** SURT-prefix member matchers, matched against the classKey. */
+    protected List<String> groupMembersBySurt = new ArrayList<String>();
+
+    /** Max member queues collected simultaneously (shared concurrency). */
+    protected int maxParallelInGroup = 1;
+
+    /** Minimal shared delay (ms) between two fetches of the group. */
+    protected long groupMinDelayMs = 0;
+
+    // ---- transient scheduling/politeness state ----
+
+    /** Number of member queues currently "in process". */
+    protected transient int activeCount = 0;
+
+    /** Shared cool-down: no fetch before this epoch-ms. */
+    protected transient long wakeTime = 0;
+
+    /** Rotation pointer for round-robin over members. */
+    protected transient int rotationIndex = 0;
+
+    /**
+     * Concrete member queue keys discovered at runtime, in first-seen order.
+     * The configured member lists are only <i>matchers</i>; the actual
+     * per-host classKeys that fall into this group are collected here to drive
+     * the round-robin rotation. Transient: rebuilt as queues are encountered.
+     */
+    protected transient java.util.LinkedHashSet<String> discoveredMembers =
+            new java.util.LinkedHashSet<String>();
+
+    /** Cache of compiled regex patterns, keyed by the raw member string. */
+    protected transient ConcurrentHashMap<String, Pattern> regexCache =
+            new ConcurrentHashMap<String, Pattern>();
+
+    public QueueGroup() {
+    }
+
+    public QueueGroup(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getGroupMembersByHost() {
+        return groupMembersByHost;
+    }
+
+    public void setGroupMembersByHost(List<String> groupMembersByHost) {
+        this.groupMembersByHost = (groupMembersByHost != null)
+                ? new ArrayList<String>(groupMembersByHost)
+                : new ArrayList<String>();
+    }
+
+    public List<String> getGroupMembersByRegex() {
+        return groupMembersByRegex;
+    }
+
+    public void setGroupMembersByRegex(List<String> groupMembersByRegex) {
+        this.groupMembersByRegex = (groupMembersByRegex != null)
+                ? new ArrayList<String>(groupMembersByRegex)
+                : new ArrayList<String>();
+    }
+
+    public List<String> getGroupMembersBySurt() {
+        return groupMembersBySurt;
+    }
+
+    public void setGroupMembersBySurt(List<String> groupMembersBySurt) {
+        this.groupMembersBySurt = (groupMembersBySurt != null)
+                ? new ArrayList<String>(groupMembersBySurt)
+                : new ArrayList<String>();
+    }
+
+    public int getMaxParallelInGroup() {
+        return maxParallelInGroup;
+    }
+
+    public void setMaxParallelInGroup(int maxParallelInGroup) {
+        this.maxParallelInGroup = maxParallelInGroup;
+    }
+
+    public long getGroupMinDelayMs() {
+        return groupMinDelayMs;
+    }
+
+    public void setGroupMinDelayMs(long groupMinDelayMs) {
+        this.groupMinDelayMs = groupMinDelayMs;
+    }
+
+    public long getWakeTime() {
+        return wakeTime;
+    }
+
+    public int getActiveCount() {
+        return activeCount;
+    }
+
+    // ---- membership matching ----
+
+    /**
+     * @return the host part of a classKey, i.e. the substring before any
+     *         {@code '#'} (host/port separator) or {@code '+'} (subqueue
+     *         separator).
+     */
+    protected static String hostPart(String classKey) {
+        if (classKey == null) {
+            return null;
+        }
+        int hash = classKey.indexOf('#');
+        int plus = classKey.indexOf('+');
+        int cut = -1;
+        if (hash >= 0 && plus >= 0) {
+            cut = Math.min(hash, plus);
+        } else if (hash >= 0) {
+            cut = hash;
+        } else if (plus >= 0) {
+            cut = plus;
+        }
+        return (cut >= 0) ? classKey.substring(0, cut) : classKey;
+    }
+
+    /**
+     * @return true if the given exact-host value matches the given classKey.
+     */
+    protected boolean matchesHost(String value, String classKey) {
+        if (value == null || value.isEmpty() || classKey == null) {
+            return false;
+        }
+        if (classKey.equals(value)) {
+            return true;
+        }
+        // hostname policy suffixes: host#port and host+subqueue
+        if (classKey.startsWith(value + "#")
+                || classKey.startsWith(value + "+")) {
+            return true;
+        }
+        // SURT-prefix member (ends with a comma), e.g. "eu,europa,"
+        if (value.endsWith(",") && classKey.startsWith(value)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return true if the given regex value matches the host part of classKey.
+     */
+    protected boolean matchesRegex(String value, String classKey) {
+        if (value == null || value.isEmpty() || classKey == null) {
+            return false;
+        }
+        Pattern p = regexPattern(value);
+        if (p == null) {
+            return false;
+        }
+        String host = hostPart(classKey);
+        return host != null && p.matcher(host).matches();
+    }
+
+    /**
+     * @return true if the given SURT prefix is a prefix of the classKey.
+     */
+    protected boolean matchesSurt(String value, String classKey) {
+        if (value == null || value.isEmpty() || classKey == null) {
+            return false;
+        }
+        return classKey.startsWith(value);
+    }
+
+    /**
+     * Compile (and cache) the regex for a regex member. Returns null if the
+     * pattern is invalid (a warning is logged once per member).
+     */
+    protected Pattern regexPattern(String value) {
+        if (regexCache == null) {
+            regexCache = new ConcurrentHashMap<String, Pattern>();
+        }
+        Pattern cached = regexCache.get(value);
+        if (cached != null) {
+            return cached;
+        }
+        try {
+            Pattern p = Pattern.compile(value);
+            regexCache.put(value, p);
+            return p;
+        } catch (PatternSyntaxException e) {
+            logger.log(Level.WARNING, "invalid regex member '" + value
+                    + "' in queue group '" + name + "': " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @return true if any member of this group matches the given classKey.
+     */
+    public boolean matches(String classKey) {
+        if (classKey == null) {
+            return false;
+        }
+        if (groupMembersByHost != null) {
+            for (String value : groupMembersByHost) {
+                if (matchesHost(value, classKey)) {
+                    return true;
+                }
+            }
+        }
+        if (groupMembersByRegex != null) {
+            for (String value : groupMembersByRegex) {
+                if (matchesRegex(value, classKey)) {
+                    return true;
+                }
+            }
+        }
+        if (groupMembersBySurt != null) {
+            for (String value : groupMembersBySurt) {
+                if (matchesSurt(value, classKey)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // ---- shared politeness gate ----
+
+    /**
+     * @return true if the group can currently emit a URI: neither at its
+     *         concurrency ceiling nor in a shared cool-down.
+     */
+    public synchronized boolean canProceed(long now) {
+        return activeCount < maxParallelInGroup && now >= wakeTime;
+    }
+
+    /**
+     * Reserve a shared fetch slot (call only when {@link #canProceed(long)} is
+     * true, under the same lock).
+     */
+    public synchronized void acquire() {
+        activeCount++;
+    }
+
+    /**
+     * Release a previously-acquired slot and arm the shared cool-down. The
+     * cool-down is the greater of the URI's own politeness delay and the
+     * group's configured minimum, so all members are spaced like a single
+     * visitor.
+     *
+     * @param now      current epoch-ms
+     * @param delay_ms the per-URI politeness delay just computed
+     */
+    public synchronized void release(long now, long delay_ms) {
+        if (activeCount > 0) {
+            activeCount--;
+        }
+        long candidate = now + Math.max(delay_ms, groupMinDelayMs);
+        if (candidate > wakeTime) {
+            wakeTime = candidate;
+        }
+    }
+
+    // ---- round-robin rotation over members ----
+
+    /**
+     * Register a concrete member queue key as belonging to this group, so it
+     * participates in the round-robin rotation. Idempotent.
+     */
+    public synchronized void noteMember(String classKey) {
+        if (classKey != null && discoveredMembers != null) {
+            discoveredMembers.add(classKey);
+        }
+    }
+
+    /**
+     * @return a stable snapshot of the concrete member keys seen so far.
+     */
+    public synchronized List<String> memberKeys() {
+        return new ArrayList<String>(discoveredMembers);
+    }
+
+    /**
+     * Round-robin turn test over the concrete member keys discovered so far.
+     * Starting from the rotation pointer, the first member reported ready by
+     * {@code readyChecker} wins the current turn; members that are not ready
+     * are skipped, so a silent/snoozed/empty host never blocks the group.
+     *
+     * @param readyChecker tells whether a member key is currently ready
+     * @param classKey     the candidate member key being considered
+     * @return true if {@code classKey} is the next ready member in rotation
+     */
+    public synchronized boolean isTurn(
+            java.util.function.Predicate<String> readyChecker, String classKey) {
+        if (discoveredMembers == null || discoveredMembers.isEmpty()) {
+            return true;
+        }
+        List<String> ordered = new ArrayList<String>(discoveredMembers);
+        int n = ordered.size();
+        if (rotationIndex >= n) {
+            rotationIndex = 0;
+        }
+        // scan from rotationIndex for the first ready member
+        for (int i = 0; i < n; i++) {
+            String candidate = ordered.get((rotationIndex + i) % n);
+            if (candidate.equals(classKey)) {
+                // reached the candidate before finding any other ready member
+                return true;
+            }
+            if (readyChecker.test(candidate)) {
+                // another member is ahead of classKey in rotation and ready
+                return false;
+            }
+        }
+        // classKey not among discovered members (shouldn't happen): allow it
+        return true;
+    }
+
+    /**
+     * Advance the rotation pointer past the member that was just served.
+     *
+     * @param servedKey the member key that has just been emitted
+     */
+    public synchronized void advanceRotation(String servedKey) {
+        if (discoveredMembers == null || discoveredMembers.isEmpty()) {
+            return;
+        }
+        List<String> ordered = new ArrayList<String>(discoveredMembers);
+        int idx = ordered.indexOf(servedKey);
+        if (idx >= 0) {
+            rotationIndex = (idx + 1) % ordered.size();
+        }
+    }
+}

--- a/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/QueueGroup.java
@@ -21,11 +21,7 @@ package org.archive.crawler.frontier;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 /**
  * A "queue group": a set of otherwise-independent per-host work queues
@@ -67,9 +63,6 @@ import java.util.regex.PatternSyntaxException;
 public class QueueGroup implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger =
-            Logger.getLogger(QueueGroup.class.getName());
-
     /** Human-readable, unique name of the group (e.g. "europa_eu"). */
     protected String name;
 
@@ -77,7 +70,7 @@ public class QueueGroup implements Serializable {
     protected List<String> groupMembersByHost = new ArrayList<String>();
 
     /** Regex member matchers, matched against the host part of the classKey. */
-    protected List<String> groupMembersByRegex = new ArrayList<String>();
+    protected List<Pattern> groupMembersByRegex = new ArrayList<Pattern>();
 
     /** SURT-prefix member matchers, matched against the classKey. */
     protected List<String> groupMembersBySurt = new ArrayList<String>();
@@ -108,10 +101,6 @@ public class QueueGroup implements Serializable {
     protected transient java.util.LinkedHashSet<String> discoveredMembers =
             new java.util.LinkedHashSet<String>();
 
-    /** Cache of compiled regex patterns, keyed by the raw member string. */
-    protected transient ConcurrentHashMap<String, Pattern> regexCache =
-            new ConcurrentHashMap<String, Pattern>();
-
     public QueueGroup() {
     }
 
@@ -137,14 +126,14 @@ public class QueueGroup implements Serializable {
                 : new ArrayList<String>();
     }
 
-    public List<String> getGroupMembersByRegex() {
+    public List<Pattern> getGroupMembersByRegex() {
         return groupMembersByRegex;
     }
 
-    public void setGroupMembersByRegex(List<String> groupMembersByRegex) {
+    public void setGroupMembersByRegex(List<Pattern> groupMembersByRegex) {
         this.groupMembersByRegex = (groupMembersByRegex != null)
-                ? new ArrayList<String>(groupMembersByRegex)
-                : new ArrayList<String>();
+                ? new ArrayList<Pattern>(groupMembersByRegex)
+                : new ArrayList<Pattern>();
     }
 
     public List<String> getGroupMembersBySurt() {
@@ -228,18 +217,14 @@ public class QueueGroup implements Serializable {
     }
 
     /**
-     * @return true if the given regex value matches the host part of classKey.
+     * @return true if the given regex pattern matches the host part of classKey.
      */
-    protected boolean matchesRegex(String value, String classKey) {
-        if (value == null || value.isEmpty() || classKey == null) {
-            return false;
-        }
-        Pattern p = regexPattern(value);
-        if (p == null) {
+    protected boolean matchesRegex(Pattern pattern, String classKey) {
+        if (pattern == null || classKey == null) {
             return false;
         }
         String host = hostPart(classKey);
-        return host != null && p.matcher(host).matches();
+        return host != null && pattern.matcher(host).matches();
     }
 
     /**
@@ -250,29 +235,6 @@ public class QueueGroup implements Serializable {
             return false;
         }
         return classKey.startsWith(value);
-    }
-
-    /**
-     * Compile (and cache) the regex for a regex member. Returns null if the
-     * pattern is invalid (a warning is logged once per member).
-     */
-    protected Pattern regexPattern(String value) {
-        if (regexCache == null) {
-            regexCache = new ConcurrentHashMap<String, Pattern>();
-        }
-        Pattern cached = regexCache.get(value);
-        if (cached != null) {
-            return cached;
-        }
-        try {
-            Pattern p = Pattern.compile(value);
-            regexCache.put(value, p);
-            return p;
-        } catch (PatternSyntaxException e) {
-            logger.log(Level.WARNING, "invalid regex member '" + value
-                    + "' in queue group '" + name + "': " + e.getMessage());
-            return null;
-        }
     }
 
     /**
@@ -290,8 +252,8 @@ public class QueueGroup implements Serializable {
             }
         }
         if (groupMembersByRegex != null) {
-            for (String value : groupMembersByRegex) {
-                if (matchesRegex(value, classKey)) {
+            for (Pattern pattern : groupMembersByRegex) {
+                if (matchesRegex(pattern, classKey)) {
                     return true;
                 }
             }

--- a/engine/src/main/java/org/archive/crawler/frontier/QueueGroupManager.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/QueueGroupManager.java
@@ -1,0 +1,163 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.crawler.frontier;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Optional bean holding the configured {@link QueueGroup}s and resolving a
+ * queue's {@code classKey} to the group (if any) it belongs to.
+ *
+ * <p>This bean is entirely opt-in: if it is not declared in the crawl beans,
+ * {@link WorkQueueFrontier} injects {@code null} and the frontier behaves
+ * exactly as before. If it is declared but has no groups, every lookup returns
+ * {@code null} as well.</p>
+ *
+ * <p>Lookups are cached per classKey. A small CRUD API is provided so groups
+ * can also be adjusted at runtime from the Heritrix scripting console; any
+ * mutation clears the cache.</p>
+ */
+public class QueueGroupManager implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** Sentinel cached for classKeys that belong to no group. */
+    private static final QueueGroup NONE = new QueueGroup("\u0000none");
+
+    protected List<QueueGroup> groups = new CopyOnWriteArrayList<QueueGroup>();
+
+    /** classKey -> group (or {@link #NONE}); rebuilt lazily, transient. */
+    protected transient ConcurrentHashMap<String, QueueGroup> cache =
+            new ConcurrentHashMap<String, QueueGroup>();
+
+    public QueueGroupManager() {
+    }
+
+    public List<QueueGroup> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<QueueGroup> groups) {
+        this.groups = new CopyOnWriteArrayList<QueueGroup>(
+                groups != null ? groups : new ArrayList<QueueGroup>());
+        clearCache();
+    }
+
+    protected ConcurrentHashMap<String, QueueGroup> cache() {
+        if (cache == null) {
+            cache = new ConcurrentHashMap<String, QueueGroup>();
+        }
+        return cache;
+    }
+
+    public void clearCache() {
+        cache().clear();
+    }
+
+    /**
+     * @return the group that the given classKey belongs to, or {@code null} if
+     *         none. The classKey is registered as a concrete member of its
+     *         group so it takes part in the round-robin rotation.
+     */
+    public QueueGroup groupFor(String classKey) {
+        if (classKey == null || groups == null || groups.isEmpty()) {
+            return null;
+        }
+        QueueGroup cached = cache().get(classKey);
+        if (cached != null) {
+            return cached == NONE ? null : cached;
+        }
+        QueueGroup found = null;
+        for (QueueGroup g : groups) {
+            if (g.matches(classKey)) {
+                found = g;
+                break;
+            }
+        }
+        cache().put(classKey, found == null ? NONE : found);
+        if (found != null) {
+            found.noteMember(classKey);
+        }
+        return found;
+    }
+
+    // ---- runtime CRUD (scripting console) ----
+
+    public synchronized QueueGroup addGroup(QueueGroup group) {
+        if (group != null) {
+            groups.add(group);
+            clearCache();
+        }
+        return group;
+    }
+
+    public synchronized boolean removeGroup(String name) {
+        boolean removed = false;
+        for (QueueGroup g : new ArrayList<QueueGroup>(groups)) {
+            if (g.getName() != null && g.getName().equals(name)) {
+                groups.remove(g);
+                removed = true;
+            }
+        }
+        if (removed) {
+            clearCache();
+        }
+        return removed;
+    }
+
+    public synchronized boolean addMember(String groupName, String member) {
+        return addHostMember(groupName, member);
+    }
+
+    public synchronized boolean addHostMember(String groupName, String member) {
+        for (QueueGroup g : groups) {
+            if (g.getName() != null && g.getName().equals(groupName)) {
+                g.getGroupMembersByHost().add(member);
+                clearCache();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public synchronized boolean addRegexMember(String groupName, String member) {
+        for (QueueGroup g : groups) {
+            if (g.getName() != null && g.getName().equals(groupName)) {
+                g.getGroupMembersByRegex().add(member);
+                clearCache();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public synchronized boolean addSurtMember(String groupName, String member) {
+        for (QueueGroup g : groups) {
+            if (g.getName() != null && g.getName().equals(groupName)) {
+                g.getGroupMembersBySurt().add(member);
+                clearCache();
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/engine/src/main/java/org/archive/crawler/frontier/QueueGroupManager.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/QueueGroupManager.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Pattern;
 
 /**
  * Optional bean holding the configured {@link QueueGroup}s and resolving a
@@ -142,7 +143,7 @@ public class QueueGroupManager implements Serializable {
     public synchronized boolean addRegexMember(String groupName, String member) {
         for (QueueGroup g : groups) {
             if (g.getName() != null && g.getName().equals(groupName)) {
-                g.getGroupMembersByRegex().add(member);
+                g.getGroupMembersByRegex().add(Pattern.compile(member));
                 clearCache();
                 return true;
             }

--- a/engine/src/main/java/org/archive/crawler/frontier/WorkQueue.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/WorkQueue.java
@@ -1,8 +1,8 @@
 /*
  *  This file is part of the Heritrix web crawler (crawler.archive.org).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual
- *  contributors.
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -18,7 +18,7 @@
  */
 
 package org.archive.crawler.frontier;
-
+ 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
@@ -45,7 +45,7 @@ import org.archive.util.Reporter;
 /**
  * A single queue of related URIs to visit, grouped by a classKey
  * (typically "hostname:port" or similar) 
- *
+ * 
  * @author gojomo
  * @author Christian Kohlschuetter 
  */
@@ -53,8 +53,8 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         Serializable, Reporter, Delayed, IdentityCacheable {
     private static final long serialVersionUID = -3199666138837266341L;
     private static final Logger logger =
-            Logger.getLogger(WorkQueue.class.getName());
-
+        Logger.getLogger(WorkQueue.class.getName());
+    
     /** The classKey */
     protected final String classKey;
 
@@ -66,7 +66,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** Total number of items ever enqueued */
     protected long enqueueCount = 0;
-
+    
     /** Whether queue is already in lifecycle stage */
     protected boolean isManaged = false;
 
@@ -75,7 +75,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** assigned precedence */
     protected PrecedenceProvider precedenceProvider = new SimplePrecedenceProvider(1);
-
+            
     /** Per-session 'budget' controlling activity duration */
     protected int sessionBudget = 0;
 
@@ -91,7 +91,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** Record of expenditures at last activation (session start) */
     protected long expenditureAtLastActivation = 0;
-
+    
     /** Total to spend on this queue over its lifetime */
     protected long totalBudget = 0;
 
@@ -104,12 +104,12 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /** Last URI peeked */
     protected String lastPeeked;
 
-    /** time of last dequeue (disposition of some URI) **/
+    /** time of last dequeue (disposition of some URI) **/ 
     protected long lastDequeueTime;
-
+    
     /** count of errors encountered */
     protected long errorCount = 0;
-
+    
     /** Substats for all CrawlURIs in this group */
     protected FetchStats substats = new FetchStats();
 
@@ -140,12 +140,12 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Add the given CrawlURI, noting its addition in running count. (It
      * should not already be present.)
-     *
+     * 
      * @param frontier Work queues manager.
      * @param curi CrawlURI to insert.
      */
     protected synchronized long enqueue(final WorkQueueFrontier frontier,
-                                        CrawlURI curi) {
+        CrawlURI curi) {
         try {
             insert(frontier, curi, false);
         } catch (IOException e) {
@@ -162,10 +162,10 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * Return the topmost queue item -- and remember it,
      * such that even later higher-priority inserts don't
      * change it. 
-     *
+     * 
      * TODO: evaluate if this is really necessary
      * @param frontier Work queues manager
-     *
+     * 
      * @return topmost queue item, or null
      */
     public synchronized CrawlURI peek(final WorkQueueFrontier frontier) {
@@ -187,7 +187,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Remove the peekItem from the queue and adjusts the count.
-     *
+     * 
      * @param frontier  Work queues manager.
      */
     protected synchronized void dequeue(final WorkQueueFrontier frontier, CrawlURI expected) {
@@ -209,7 +209,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * here by operator will not persist. Instead, change the 'balanceReplenishAmount' 
      * (or overlay its value with a URI/queue-specific value) to affect this
      * value.
-     *
+     * 
      * @param budget to use
      */
     protected void setSessionBudget(int budget) {
@@ -218,7 +218,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Return current session 'activity budget balance' 
-     *
+     * 
      * @return session balance
      */
     public int getSessionBudget() {
@@ -232,21 +232,21 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      */
     public synchronized void considerActive() {
         if(active) {
-            return;
+            return; 
         }
-        active=true;
+        active=true; 
         expenditureAtLastActivation = totalExpenditure;
     }
-
+    
     /**
      * Set the total expenditure level allowable before queue is 
      * considered inherently 'over-budget'. 
-     *
+     * 
      * Automatically reset continually as new CrawlURIs are enqueued; a direct change
      * here by operator will not persist. Instead, change the 'queueTotalBudget' 
      * (or overlay its value with a URI/queue-specific value) to affect this
      * value.
-     *
+     * 
      * @param budget
      */
     protected void setTotalBudget(long budget) {
@@ -255,7 +255,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Check whether queue has temporarily (session) exceeded its budget.
-     *
+     * 
      * @return true if queue is over either of its set budget(s)
      */
     public boolean isOverSessionBudget() {
@@ -266,7 +266,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Check whether queue has permanently (total) exceeded its budget.
-     *
+     * 
      * @return true if queue is over either of its set budget(s)
      */
     public boolean isOverTotalBudget() {
@@ -274,10 +274,10 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         // or totalExpenditure exceeds totalBudget
         return (this.totalBudget >= 0 && this.totalExpenditure >= this.totalBudget);
     }
-
+    
     /**
      * Return the tally of all expenditures on this queue
-     *
+     * 
      * @return total amount expended on this queue
      */
     public long getTotalExpenditure() {
@@ -287,7 +287,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Decrease the internal running budget by the given amount. (Use
      * negative value to effect 'refund'/undo.)
-     *
+     * 
      * @param amount tp decrement
      */
     public void expend(int amount) {
@@ -296,11 +296,11 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
             this.lastCost = amount;
             this.costCount++;
         } else {
-            this.costCount--;
+            this.costCount--; 
         }
     }
 
-
+    
     /**
      * Note an error and assess an extra penalty. 
      * @param penalty additional amount to deduct
@@ -309,7 +309,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         this.totalExpenditure = this.totalExpenditure + penalty;
         errorCount++;
     }
-
+    
     /**
      * @param l
      */
@@ -334,7 +334,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Forgive the peek, allowing a subsequent peek to 
      * return a different item. 
-     *
+     * 
      */
     public synchronized void unpeek(CrawlURI expected) {
         assert expected == peekItem : "unexpected peekItem";
@@ -369,7 +369,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Update the given CrawlURI, which should already be present. (This
      * is not checked.) Equivalent to an enqueue without affecting the count.
-     *
+     * 
      * @param frontier Work queues manager.
      * @param curi CrawlURI to update.
      */
@@ -384,7 +384,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Count of URIs in this queue. Only precise if called within frontier's
      * manager thread. 
-     *
+     * 
      * @return Returns the count.
      */
     public synchronized long getCount() {
@@ -398,8 +398,8 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * @throws IOException
      */
     private void insert(final WorkQueueFrontier frontier, CrawlURI curi,
-                        boolean overwriteIfPresent)
-            throws IOException {
+            boolean overwriteIfPresent)
+        throws IOException {
         insertItem(frontier, curi, overwriteIfPresent);
         lastQueued = curi.toString();
     }
@@ -407,13 +407,13 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Insert the given curi, whether it is already present or not.
      * Hook for subclasses. 
-     *
+     * 
      * @param frontier WorkQueueFrontier.
      * @param curi CrawlURI to insert.
      * @throws IOException  if there was a problem while inserting the item
      */
     protected abstract void insertItem(final WorkQueueFrontier frontier,
-                                       CrawlURI curi, boolean overwriteIfPresent) throws IOException;
+        CrawlURI curi, boolean overwriteIfPresent) throws IOException;
 
     /**
      * Delete URIs matching the given pattern from this queue. 
@@ -423,29 +423,29 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * @throws IOException  if there was a problem while deleting
      */
     protected abstract long deleteMatchingFromQueue(
-            final WorkQueueFrontier frontier, final String match)
-            throws IOException;
+        final WorkQueueFrontier frontier, final String match)
+        throws IOException;
 
     /**
      * Removes the given item from the queue.
-     *
+     * 
      * This is only used to remove the first item in the queue,
      * so it is not necessary to implement a random-access queue.
-     *
+     * 
      * @param frontier  Work queues manager.
      * @throws IOException  if there was a problem while deleting the item
      */
     protected abstract void deleteItem(final WorkQueueFrontier frontier,
-                                       final CrawlURI item) throws IOException;
+        final CrawlURI item) throws IOException;
 
     /**
      * Returns first item from queue (does not delete)
-     *
+     * 
      * @return The peeked item, or null
      * @throws IOException  if there was a problem while peeking
      */
     protected abstract CrawlURI peekItem(final WorkQueueFrontier frontier)
-            throws IOException;
+        throws IOException;
 
     // 
     // Reporter
@@ -504,7 +504,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(lastCost);
         writer.print("(");
         writer.print(ArchiveUtils.doubleToString(
-                ((double) totalExpenditure / costCount), 1));
+                    ((double) totalExpenditure / costCount), 1));
         writer.print(")");
         writer.print(" ");
         // last dequeue time, if any, or '-'
@@ -539,11 +539,11 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
                 "lastCost (averageCost) lastDequeueTime wakeTime " +
                 "totalSpend/totalBudget errorCount lastPeekUri lastQueuedUri";
     }
-
+    
     public String shortReportLine() {
         return ReportUtils.shortReportLine(this);
     }
-
+    
     @Override
     public synchronized void reportTo(PrintWriter writer) {
         reportTo(null, writer);
@@ -583,7 +583,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(lastCost);
         writer.print("(");
         writer.print(ArchiveUtils.doubleToString(
-                ((double) totalExpenditure / costCount), 1));
+                    ((double) totalExpenditure / costCount), 1));
         writer.print(")\n   ");
         writer.print(getSubstats().shortReportLegend());
         writer.print("\n   ");
@@ -594,20 +594,20 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(getPrecedenceProvider().shortReportLine());
         writer.print("\n\n");
     }
-
+    
     public FetchStats getSubstats() {
         return substats;
     }
 
     /**
      * Set the retired status of this queue.
-     *
+     * 
      * @param b new value for retired status
      */
     protected void setRetired(boolean b) {
         this.retired = b;
     }
-
+    
     public boolean isRetired() {
         return retired;
     }
@@ -625,7 +625,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     public void setPrecedenceProvider(PrecedenceProvider precedenceProvider) {
         this.precedenceProvider = precedenceProvider;
     }
-
+    
     /**
      * @return the precedence
      */
@@ -647,17 +647,17 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      */
     public synchronized void noteDeactivated() {
         active = false;
-        isManaged = true;
+        isManaged = true; 
         makeDirty();
     }
-
+    
     /**
      * Update queue state to recognize it has been completely exhausted,
      * and is no longer on any of the ready/inactive queues-of-queues
      */
     public synchronized void noteExhausted() {
         active = false;
-        isManaged = false;
+        isManaged = false; 
         makeDirty();
     }
 
@@ -665,13 +665,13 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * Whether the queue is already in a lifecycle stage --
      * such as ready, in-progress, snoozed -- and thus should
      * not be redundantly inserted to readyClassQueues
-     *
+     * 
      * @return isManaged
      */
     public boolean isManaged() {
         return isManaged;
     }
-
+    
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */
@@ -679,7 +679,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         return super.toString()+"("+getClassKey()+")";
     }
 
-
+    
     //
     // IdentityCacheable support
     //
@@ -696,6 +696,6 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     @Override
     public void setIdentityCache(ObjectIdentityCache<?> cache) {
-        this.cache = cache;
-    }
+        this.cache = cache; 
+    } 
 }

--- a/engine/src/main/java/org/archive/crawler/frontier/WorkQueue.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/WorkQueue.java
@@ -1,8 +1,8 @@
 /*
  *  This file is part of the Heritrix web crawler (crawler.archive.org).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual 
- *  contributors. 
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -18,7 +18,7 @@
  */
 
 package org.archive.crawler.frontier;
- 
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
@@ -45,7 +45,7 @@ import org.archive.util.Reporter;
 /**
  * A single queue of related URIs to visit, grouped by a classKey
  * (typically "hostname:port" or similar) 
- * 
+ *
  * @author gojomo
  * @author Christian Kohlschuetter 
  */
@@ -53,8 +53,8 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         Serializable, Reporter, Delayed, IdentityCacheable {
     private static final long serialVersionUID = -3199666138837266341L;
     private static final Logger logger =
-        Logger.getLogger(WorkQueue.class.getName());
-    
+            Logger.getLogger(WorkQueue.class.getName());
+
     /** The classKey */
     protected final String classKey;
 
@@ -66,7 +66,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** Total number of items ever enqueued */
     protected long enqueueCount = 0;
-    
+
     /** Whether queue is already in lifecycle stage */
     protected boolean isManaged = false;
 
@@ -75,7 +75,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** assigned precedence */
     protected PrecedenceProvider precedenceProvider = new SimplePrecedenceProvider(1);
-            
+
     /** Per-session 'budget' controlling activity duration */
     protected int sessionBudget = 0;
 
@@ -91,7 +91,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /** Record of expenditures at last activation (session start) */
     protected long expenditureAtLastActivation = 0;
-    
+
     /** Total to spend on this queue over its lifetime */
     protected long totalBudget = 0;
 
@@ -104,12 +104,12 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /** Last URI peeked */
     protected String lastPeeked;
 
-    /** time of last dequeue (disposition of some URI) **/ 
+    /** time of last dequeue (disposition of some URI) **/
     protected long lastDequeueTime;
-    
+
     /** count of errors encountered */
     protected long errorCount = 0;
-    
+
     /** Substats for all CrawlURIs in this group */
     protected FetchStats substats = new FetchStats();
 
@@ -140,12 +140,12 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Add the given CrawlURI, noting its addition in running count. (It
      * should not already be present.)
-     * 
+     *
      * @param frontier Work queues manager.
      * @param curi CrawlURI to insert.
      */
     protected synchronized long enqueue(final WorkQueueFrontier frontier,
-        CrawlURI curi) {
+                                        CrawlURI curi) {
         try {
             insert(frontier, curi, false);
         } catch (IOException e) {
@@ -162,10 +162,10 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * Return the topmost queue item -- and remember it,
      * such that even later higher-priority inserts don't
      * change it. 
-     * 
+     *
      * TODO: evaluate if this is really necessary
      * @param frontier Work queues manager
-     * 
+     *
      * @return topmost queue item, or null
      */
     public synchronized CrawlURI peek(final WorkQueueFrontier frontier) {
@@ -187,7 +187,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Remove the peekItem from the queue and adjusts the count.
-     * 
+     *
      * @param frontier  Work queues manager.
      */
     protected synchronized void dequeue(final WorkQueueFrontier frontier, CrawlURI expected) {
@@ -209,7 +209,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * here by operator will not persist. Instead, change the 'balanceReplenishAmount' 
      * (or overlay its value with a URI/queue-specific value) to affect this
      * value.
-     * 
+     *
      * @param budget to use
      */
     protected void setSessionBudget(int budget) {
@@ -218,7 +218,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Return current session 'activity budget balance' 
-     * 
+     *
      * @return session balance
      */
     public int getSessionBudget() {
@@ -232,21 +232,21 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      */
     public synchronized void considerActive() {
         if(active) {
-            return; 
+            return;
         }
-        active=true; 
+        active=true;
         expenditureAtLastActivation = totalExpenditure;
     }
-    
+
     /**
      * Set the total expenditure level allowable before queue is 
      * considered inherently 'over-budget'. 
-     * 
+     *
      * Automatically reset continually as new CrawlURIs are enqueued; a direct change
      * here by operator will not persist. Instead, change the 'queueTotalBudget' 
      * (or overlay its value with a URI/queue-specific value) to affect this
      * value.
-     * 
+     *
      * @param budget
      */
     protected void setTotalBudget(long budget) {
@@ -255,7 +255,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Check whether queue has temporarily (session) exceeded its budget.
-     * 
+     *
      * @return true if queue is over either of its set budget(s)
      */
     public boolean isOverSessionBudget() {
@@ -266,7 +266,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     /**
      * Check whether queue has permanently (total) exceeded its budget.
-     * 
+     *
      * @return true if queue is over either of its set budget(s)
      */
     public boolean isOverTotalBudget() {
@@ -274,10 +274,10 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         // or totalExpenditure exceeds totalBudget
         return (this.totalBudget >= 0 && this.totalExpenditure >= this.totalBudget);
     }
-    
+
     /**
      * Return the tally of all expenditures on this queue
-     * 
+     *
      * @return total amount expended on this queue
      */
     public long getTotalExpenditure() {
@@ -287,7 +287,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Decrease the internal running budget by the given amount. (Use
      * negative value to effect 'refund'/undo.)
-     * 
+     *
      * @param amount tp decrement
      */
     public void expend(int amount) {
@@ -296,11 +296,11 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
             this.lastCost = amount;
             this.costCount++;
         } else {
-            this.costCount--; 
+            this.costCount--;
         }
     }
 
-    
+
     /**
      * Note an error and assess an extra penalty. 
      * @param penalty additional amount to deduct
@@ -309,7 +309,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         this.totalExpenditure = this.totalExpenditure + penalty;
         errorCount++;
     }
-    
+
     /**
      * @param l
      */
@@ -334,7 +334,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Forgive the peek, allowing a subsequent peek to 
      * return a different item. 
-     * 
+     *
      */
     public synchronized void unpeek(CrawlURI expected) {
         assert expected == peekItem : "unexpected peekItem";
@@ -369,7 +369,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Update the given CrawlURI, which should already be present. (This
      * is not checked.) Equivalent to an enqueue without affecting the count.
-     * 
+     *
      * @param frontier Work queues manager.
      * @param curi CrawlURI to update.
      */
@@ -384,7 +384,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Count of URIs in this queue. Only precise if called within frontier's
      * manager thread. 
-     * 
+     *
      * @return Returns the count.
      */
     public synchronized long getCount() {
@@ -398,8 +398,8 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * @throws IOException
      */
     private void insert(final WorkQueueFrontier frontier, CrawlURI curi,
-            boolean overwriteIfPresent)
-        throws IOException {
+                        boolean overwriteIfPresent)
+            throws IOException {
         insertItem(frontier, curi, overwriteIfPresent);
         lastQueued = curi.toString();
     }
@@ -407,13 +407,13 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     /**
      * Insert the given curi, whether it is already present or not.
      * Hook for subclasses. 
-     * 
+     *
      * @param frontier WorkQueueFrontier.
      * @param curi CrawlURI to insert.
      * @throws IOException  if there was a problem while inserting the item
      */
     protected abstract void insertItem(final WorkQueueFrontier frontier,
-        CrawlURI curi, boolean overwriteIfPresent) throws IOException;
+                                       CrawlURI curi, boolean overwriteIfPresent) throws IOException;
 
     /**
      * Delete URIs matching the given pattern from this queue. 
@@ -423,29 +423,29 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * @throws IOException  if there was a problem while deleting
      */
     protected abstract long deleteMatchingFromQueue(
-        final WorkQueueFrontier frontier, final String match)
-        throws IOException;
+            final WorkQueueFrontier frontier, final String match)
+            throws IOException;
 
     /**
      * Removes the given item from the queue.
-     * 
+     *
      * This is only used to remove the first item in the queue,
      * so it is not necessary to implement a random-access queue.
-     * 
+     *
      * @param frontier  Work queues manager.
      * @throws IOException  if there was a problem while deleting the item
      */
     protected abstract void deleteItem(final WorkQueueFrontier frontier,
-        final CrawlURI item) throws IOException;
+                                       final CrawlURI item) throws IOException;
 
     /**
      * Returns first item from queue (does not delete)
-     * 
+     *
      * @return The peeked item, or null
      * @throws IOException  if there was a problem while peeking
      */
     protected abstract CrawlURI peekItem(final WorkQueueFrontier frontier)
-        throws IOException;
+            throws IOException;
 
     // 
     // Reporter
@@ -504,7 +504,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(lastCost);
         writer.print("(");
         writer.print(ArchiveUtils.doubleToString(
-                    ((double) totalExpenditure / costCount), 1));
+                ((double) totalExpenditure / costCount), 1));
         writer.print(")");
         writer.print(" ");
         // last dequeue time, if any, or '-'
@@ -539,22 +539,28 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
                 "lastCost (averageCost) lastDequeueTime wakeTime " +
                 "totalSpend/totalBudget errorCount lastPeekUri lastQueuedUri";
     }
-    
+
     public String shortReportLine() {
         return ReportUtils.shortReportLine(this);
     }
-    
-    /**
-     * @param writer
-     */
+
     @Override
     public synchronized void reportTo(PrintWriter writer) {
+        reportTo(null, writer);
+    }
+
+    public synchronized void reportTo(String groupName, PrintWriter writer) {
         // name is ignored: only one kind of report for now
         writer.print("Queue ");
         writer.print(classKey);
         writer.print(" (p");
         writer.print(getPrecedence());
-        writer.print(")\n");
+        writer.print(")");
+        if (groupName != null) {
+            writer.print(" in queueGroup ");
+            writer.print(groupName);
+        }
+        writer.print("\n");
         writer.print("  ");
         writer.print(Long.toString(count));
         writer.print(" items");
@@ -577,7 +583,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(lastCost);
         writer.print("(");
         writer.print(ArchiveUtils.doubleToString(
-                    ((double) totalExpenditure / costCount), 1));
+                ((double) totalExpenditure / costCount), 1));
         writer.print(")\n   ");
         writer.print(getSubstats().shortReportLegend());
         writer.print("\n   ");
@@ -588,20 +594,20 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         writer.print(getPrecedenceProvider().shortReportLine());
         writer.print("\n\n");
     }
-    
+
     public FetchStats getSubstats() {
         return substats;
     }
 
     /**
      * Set the retired status of this queue.
-     * 
+     *
      * @param b new value for retired status
      */
     protected void setRetired(boolean b) {
         this.retired = b;
     }
-    
+
     public boolean isRetired() {
         return retired;
     }
@@ -619,7 +625,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
     public void setPrecedenceProvider(PrecedenceProvider precedenceProvider) {
         this.precedenceProvider = precedenceProvider;
     }
-    
+
     /**
      * @return the precedence
      */
@@ -641,17 +647,17 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      */
     public synchronized void noteDeactivated() {
         active = false;
-        isManaged = true; 
+        isManaged = true;
         makeDirty();
     }
-    
+
     /**
      * Update queue state to recognize it has been completely exhausted,
      * and is no longer on any of the ready/inactive queues-of-queues
      */
     public synchronized void noteExhausted() {
         active = false;
-        isManaged = false; 
+        isManaged = false;
         makeDirty();
     }
 
@@ -659,13 +665,13 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
      * Whether the queue is already in a lifecycle stage --
      * such as ready, in-progress, snoozed -- and thus should
      * not be redundantly inserted to readyClassQueues
-     * 
+     *
      * @return isManaged
      */
     public boolean isManaged() {
         return isManaged;
     }
-    
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */
@@ -673,7 +679,7 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
         return super.toString()+"("+getClassKey()+")";
     }
 
-    
+
     //
     // IdentityCacheable support
     //
@@ -690,6 +696,6 @@ public abstract class WorkQueue implements Frontier.FrontierGroup,
 
     @Override
     public void setIdentityCache(ObjectIdentityCache<?> cache) {
-        this.cache = cache; 
-    } 
+        this.cache = cache;
+    }
 }

--- a/engine/src/main/java/org/archive/crawler/frontier/WorkQueueFrontier.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/WorkQueueFrontier.java
@@ -1,8 +1,8 @@
 /*
  *  This file is part of the Heritrix web crawler (crawler.archive.org).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual
- *  contributors.
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -73,8 +73,8 @@ import com.sleepycat.collections.StoredSortedMap;
 import com.sleepycat.je.DatabaseException;
 
 /**
- * A common Frontier base using several queues to hold pending URIs.
- *
+ * A common Frontier base using several queues to hold pending URIs. 
+ * 
  * Uses in-memory map of all known 'queues' inside a single database.
  * Round-robins between all queues.
  *
@@ -82,8 +82,8 @@ import com.sleepycat.je.DatabaseException;
  * @author Christian Kohlschuetter
  */
 public abstract class WorkQueueFrontier extends AbstractFrontier
-        implements Closeable,
-        ApplicationContextAware {
+implements Closeable, 
+           ApplicationContextAware {
     @SuppressWarnings("unused")
     private static final long serialVersionUID = 570384305871965843L;
 
@@ -92,25 +92,25 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      * we can avoid using a disk-based BigMap.
      * This only works efficiently if the WorkQueue does not hold its
      * entries in memory as well.
-     */
+     */ 
     private static final int MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY = 3000;
 
     /**
      * When a snooze target for a queue is longer than this amount, the queue
      * will be "long snoozed" instead of "short snoozed".  A "long snoozed"
-     * queue may be swapped to disk because it's not needed soon.
+     * queue may be swapped to disk because it's not needed soon.  
      */
-    protected long snoozeLongMs = 5L*60L*1000L;
+    protected long snoozeLongMs = 5L*60L*1000L; 
     public long getSnoozeLongMs() {
         return snoozeLongMs;
     }
     public void setSnoozeLongMs(long snooze) {
         this.snoozeLongMs = snooze;
     }
-
+    
     private static final Logger logger =
-            Logger.getLogger(WorkQueueFrontier.class.getName());
-
+        Logger.getLogger(WorkQueueFrontier.class.getName());
+    
     // ApplicationContextAware implementation, for eventing
     protected AbstractApplicationContext appCtx;
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -201,7 +201,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     public void setQueueTotalBudget(long budget) {
         kp.put("queueTotalBudget",budget);
     }
-
+    
     {
         setQueuePrecedencePolicy(new BaseQueuePrecedencePolicy());
     }
@@ -214,7 +214,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     }
 
     /** precedence rank at or below which queues are not crawled */
-    protected int precedenceFloor = 255;
+    protected int precedenceFloor = 255; 
     public int getPrecedenceFloor() {
         return this.precedenceFloor;
     }
@@ -223,7 +223,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     }
 
     /** truncate reporting of queues at this large but not unbounded number */
-    protected int maxQueuesPerReportCategory = 2000;
+    protected int maxQueuesPerReportCategory = 2000; 
     public int getMaxQueuesPerReportCategory() {
         return this.maxQueuesPerReportCategory;
     }
@@ -233,7 +233,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
     /** All known queues.
      */
-    protected ObjectIdentityCache<WorkQueue> allQueues = null;
+    protected ObjectIdentityCache<WorkQueue> allQueues = null; 
     // of classKey -> ClassKeyQueue
 
     /**
@@ -241,26 +241,26 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      * Linked-list of keys for the queues.
      */
     protected BlockingQueue<String> readyClassQueues;
-
+    
     /** all per-class queues from whom a URI is outstanding */
-    protected Set<WorkQueue> inProcessQueues =
-            Collections.newSetFromMap(new ConcurrentHashMap<WorkQueue, Boolean>()); // of ClassKeyQueue
-
+    protected Set<WorkQueue> inProcessQueues = 
+        Collections.newSetFromMap(new ConcurrentHashMap<WorkQueue, Boolean>()); // of ClassKeyQueue
+    
     /**
      * All per-class queues held in snoozed state, sorted by wake time.
      */
     transient protected DelayQueue<DelayedWorkQueue> snoozedClassQueues;
-    protected StoredSortedMap<Long,DelayedWorkQueue> snoozedOverflow;
-    protected AtomicInteger snoozedOverflowCount = new AtomicInteger(0);
-    protected static int MAX_SNOOZED_IN_MEMORY = 10000;
-
+    protected StoredSortedMap<Long,DelayedWorkQueue> snoozedOverflow; 
+    protected AtomicInteger snoozedOverflowCount = new AtomicInteger(0); 
+    protected static int MAX_SNOOZED_IN_MEMORY = 10000; 
+    
     /** URIs scheduled to be re-enqueued at future date */
-    protected StoredSortedMap<Long, CrawlURI> futureUris;
-
+    protected StoredSortedMap<Long, CrawlURI> futureUris; 
+    
     /** remember keys of small number of largest queues for reporting */
     transient protected TopNSet largestQueues = new TopNSet(20);
     /** remember this many largest queues for reporting's sake; actual tracking
-     *  can be somewhat approximate when some queues shrink before others'
+     *  can be somewhat approximate when some queues shrink before others' 
      *  sizes are again noted, or if the size is adjusted mid-crawl. */
     public int getLargestQueuesCount() {
         return largestQueues.getMaxSize();
@@ -268,11 +268,11 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     public void setLargestQueuesCount(int count) {
         largestQueues.setMaxSize(count);
     }
-
+    
     protected int highestPrecedenceWaiting = Integer.MAX_VALUE;
 
-    /** The UriUniqFilter to use, tracking those UURIs which are
-     * already in-process (or processed), and thus should not be
+    /** The UriUniqFilter to use, tracking those UURIs which are 
+     * already in-process (or processed), and thus should not be 
      * rescheduled. Also known as the 'alreadyIncluded' or
      * 'alreadySeen' structure */
     protected UriUniqFilter uriUniqFilter;
@@ -290,10 +290,10 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     public WorkQueueFrontier() {
         super();
     }
-
+    
     public void start() {
         if(isRunning()) {
-            return;
+            return; 
         }
         uriUniqFilter.setDestination(this);
         super.start();
@@ -309,34 +309,34 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      * Initializes internal queues.  May decide to keep all queues in memory based on
      * {@link QueueAssignmentPolicy#maximumNumberOfKeys}.  Otherwise invokes
      * {@link #initAllQueues()} to actually set up the queues.
-     *
-     * Subclasses should invoke this method with recycle set to "true" in
+     * 
+     * Subclasses should invoke this method with recycle set to "true" in 
      * a private readObject method, to restore queues after a checkpoint.
-     *
+     * 
      * @throws IOException
      * @throws DatabaseException
      */
-    protected void initInternalQueues()
-            throws IOException, DatabaseException {
+    protected void initInternalQueues() 
+    throws IOException, DatabaseException {
         this.initOtherQueues();
         if (workQueueDataOnDisk()
                 && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() >= 0
-                && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() <=
-                MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY) {
-            this.allQueues =
-                    new ObjectIdentityMemCache<WorkQueue>(701, .9f, 100);
+                && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() <= 
+                    MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY) {
+            this.allQueues = 
+                new ObjectIdentityMemCache<WorkQueue>(701, .9f, 100);
         } else {
             this.initAllQueues();
         }
     }
-
+    
     /**
      * Initialize the allQueues field in an implementation-appropriate
      * way.
      * @throws DatabaseException
      */
     protected abstract void initAllQueues() throws DatabaseException;
-
+    
     /**
      * Initialize all other internal queues in an implementation-appropriate
      * way.
@@ -344,8 +344,8 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      */
     protected abstract void initOtherQueues() throws DatabaseException;
 
-
-
+    
+    
     /* (non-Javadoc)
      * @see org.archive.crawler.frontier.AbstractFrontier#stop()
      */
@@ -353,45 +353,45 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     public void stop() {
         super.stop();
     }
-
+    
     public void destroy() {
         // release resources and trigger end-of-frontier actions
         close();
     }
-
+    
     /**
      * Release resources only needed when running
      */
     public void close() {
-        ArchiveUtils.closeQuietly(uriUniqFilter);
+        ArchiveUtils.closeQuietly(uriUniqFilter);     
         ArchiveUtils.closeQuietly(allQueues);
     }
-
+    
     /**
      * Accept the given CrawlURI for scheduling, as it has
-     * passed the alreadyIncluded filter.
-     *
+     * passed the alreadyIncluded filter. 
+     * 
      * Choose a per-classKey queue and enqueue it. If this
-     * item has made an unready queue ready, place that
-     * queue on the readyClassQueues queue.
+     * item has made an unready queue ready, place that 
+     * queue on the readyClassQueues queue. 
      * @param curi CrawlURI.
      */
     protected void processScheduleAlways(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        assert KeyedProperties.overridesActiveFrom(curi);
-
+        assert KeyedProperties.overridesActiveFrom(curi); 
+        
         prepForFrontier(curi);
         sendToQueue(curi);
     }
-
-
+    
+    
     /**
      * Arrange for the given CrawlURI to be visited, if it is not
-     * already enqueued/completed.
-     *
-     * Differs from superclass in that it operates in calling thread, rather
+     * already enqueued/completed. 
+     * 
+     * Differs from superclass in that it operates in calling thread, rather 
      * than deferring operations via in-queue to managerThread. TODO: settle
-     * on either defer or in-thread approach after testing.
+     * on either defer or in-thread approach after testing. 
      *
      * @see org.archive.crawler.framework.Frontier#schedule(org.archive.modules.CrawlURI)
      */
@@ -406,7 +406,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             }
             processScheduleIfUnique(curi);
         } finally {
-            KeyedProperties.clearOverridesFrom(curi);
+            KeyedProperties.clearOverridesFrom(curi); 
         }
     }
 
@@ -418,8 +418,8 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      */
     protected void processScheduleIfUnique(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        assert KeyedProperties.overridesActiveFrom(curi);
-
+        assert KeyedProperties.overridesActiveFrom(curi); 
+        
         // Canonicalization may set forceFetch flag.  See
         // #canonicalization(CrawlURI) javadoc for circumstance.
         String canon = curi.getCanonicalString();
@@ -432,12 +432,12 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
     /**
      * Send a CrawlURI to the appropriate subqueue.
-     *
+     * 
      * @param curi
      */
     protected void sendToQueue(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-
+        
         WorkQueue wq = getQueueFor(curi.getClassKey());
         synchronized(wq) {
             int originalPrecedence = wq.getPrecedence();
@@ -446,7 +446,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             // (whose overlay settings should be active here)
             wq.setSessionBudget(getBalanceReplenishAmount());
             wq.setTotalBudget(getQueueTotalBudget());
-
+            
             if(!wq.isRetired()) {
                 incrementQueuedUriCount();
                 int currentPrecedence = wq.getPrecedence();
@@ -479,7 +479,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         } catch (InterruptedException e) {
             e.printStackTrace();
             System.err.println("unable to ready queue "+wq);
-            // propagate interrupt up
+            // propagate interrupt up 
             throw new RuntimeException(e);
         }
     }
@@ -507,21 +507,21 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
             if(logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE,
-                        "queue deactivated to p" + precedence
-                                + ": " + wq.getClassKey());
+                        "queue deactivated to p" + precedence 
+                        + ": " + wq.getClassKey());
             }
         }
     }
-
+    
     /**
-     * Get the queue of inactive uri-queue names at the given precedence.
-     *
+     * Get the queue of inactive uri-queue names at the given precedence. 
+     * 
      * @param precedence
      * @return queue of inacti
      */
     protected Queue<String> getInactiveQueuesForPrecedence(int precedence) {
-        Map<Integer,Queue<String>> inactiveQueuesByPrecedence =
-                getInactiveQueuesByPrecedence();
+        Map<Integer,Queue<String>> inactiveQueuesByPrecedence = 
+            getInactiveQueuesByPrecedence();
         Queue<String> candidate = inactiveQueuesByPrecedence.get(precedence);
         if(candidate==null) {
             candidate = createInactiveQueueForPrecedence(precedence);
@@ -559,19 +559,19 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                     "queue retired: " + wq.getClassKey());
         }
     }
-
+    
     /**
      * Return queue of all retired queue names.
-     *
+     * 
      * @return Queue&lt;String&gt; of retired queue names
      */
     protected abstract Queue<String> getRetiredQueues();
 
-    /**
+    /** 
      * Accommodate any changes in retirement-determining settings (like
-     * total-budget or force-retire changes/overlays.
-     *
-     * (Essentially, exists to be called from tools like the UI
+     * total-budget or force-retire changes/overlays. 
+     * 
+     * (Essentially, exists to be called from tools like the UI 
      * Scripting Console when the operator knows it's necessary.)
      */
     public void reconsiderRetiredQueues() {
@@ -581,9 +581,9 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         // as retired/overbudget next time they come up, they'll
         // be re-retired; if not, they'll get a chance to become
         // active under the new rules.
-
+        
         // TODO: Do this automatically, only when necessary.
-
+        
         String key = getRetiredQueues().poll();
         while (key != null) {
             WorkQueue q = (WorkQueue)this.allQueues.get(key);
@@ -597,69 +597,69 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         }
     }
     /**
-     * Restore a retired queue to the 'inactive' state.
-     *
+     * Restore a retired queue to the 'inactive' state. 
+     * 
      * @param q
      */
     private void unretireQueue(WorkQueue q) {
 //        assert Thread.currentThread() == managerThread;
 
         deactivateQueue(q);
-        q.setRetired(false);
+        q.setRetired(false); 
         incrementQueuedUriCount(q.getCount());
     }
 
     /**
      * Return the work queue for the given classKey, or null
      * if no such queue exists.
-     *
+     * 
      * @param classKey key to look for
      * @return the found WorkQueue
      */
     protected abstract WorkQueue getQueueFor(String classKey);
-
-
+    
+ 
     /**
      * Return the next CrawlURI eligible to be processed (and presumably
      * visited/fetched) by a a worker thread.
      *
      * Relies on the readyClassQueues having been loaded with
-     * any work queues that are eligible to provide a URI.
+     * any work queues that are eligible to provide a URI. 
      *
      * @return next CrawlURI eligible to be processed, or null if none available
      *
      * @see org.archive.crawler.framework.Frontier#next()
      */
     protected CrawlURI findEligibleURI() {
-        // wake any snoozed queues
-        wakeQueues();
-        // consider rescheduled URIS
-        checkFutures();
-
-        // find a non-empty ready queue, if any
-        // TODO: refactor to untangle these loops, early-exits, etc!
-        WorkQueue readyQ = null;
-        findauri: while(true) {
-            findaqueue: do {
-                String key = readyClassQueues.poll();
-                if(key==null) {
-                    // no ready queues; try to activate one
-                    if(!getInactiveQueuesByPrecedence().isEmpty()
+            // wake any snoozed queues
+            wakeQueues();
+            // consider rescheduled URIS
+            checkFutures();
+                   
+            // find a non-empty ready queue, if any 
+            // TODO: refactor to untangle these loops, early-exits, etc!
+            WorkQueue readyQ = null;
+            findauri: while(true) {
+                findaqueue: do {
+                    String key = readyClassQueues.poll();
+                    if(key==null) {
+                        // no ready queues; try to activate one
+                        if(!getInactiveQueuesByPrecedence().isEmpty() 
                             && highestPrecedenceWaiting < getPrecedenceFloor()) {
-                        activateInactiveQueue();
-                        continue findaqueue;
-                    } else {
-                        // nothing ready or readyable
+                            activateInactiveQueue();
+                            continue findaqueue;
+                        } else {
+                            // nothing ready or readyable
+                            break findaqueue;
+                        }
+                    }
+                    readyQ = getQueueFor(key);
+                    if (readyQ == null) {
+                        // readyQ key wasn't in all queues: unexpected
+                        logger.severe("Key " + key
+                                + " in readyClassQueues but not allQueues");
                         break findaqueue;
                     }
-                }
-                readyQ = getQueueFor(key);
-                if (readyQ == null) {
-                    // readyQ key wasn't in all queues: unexpected
-                    logger.severe("Key " + key
-                            + " in readyClassQueues but not allQueues");
-                    break findaqueue;
-                }
                 synchronized (readyQ) {
                     if (readyQ.getCount() == 0) {
                         // readyQ is empty and ready: it's exhausted
@@ -704,123 +704,123 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                         readyQ.makeDirty();
                         readyQ = null;
                         continue;
-                    }
-                }
-            } while (readyQ == null);
-
-            if (readyQ == null) {
-                // no queues left in ready or readiable
-                break findauri;
-            }
-
-            returnauri: while(true) { // loop left by explicit return or break on empty
-                CrawlURI curi = null;
-                curi = readyQ.peek(this);
-                if(curi == null) {
-                    // should not reach
-                    logger.severe("No CrawlURI from ready non-empty queue "
-                            + readyQ.classKey + "\n"
-                            + readyQ.shortReportLegend() + "\n"
-                            + readyQ.shortReportLine() + "\n");
-                    break returnauri;
-                }
-
-                // from queues, override names persist but not map source
-                curi.setOverlayMapsSource(sheetOverlaysManager);
-                // TODO: consider optimizations avoiding this recalc of
-                // overrides when not necessary
-                sheetOverlaysManager.applyOverlaysTo(curi);
-                // check if curi belongs in different queue
-                String currentQueueKey;
-                try {
-                    KeyedProperties.loadOverridesFrom(curi);
-                    currentQueueKey = getClassKey(curi);
-                } finally {
-                    KeyedProperties.clearOverridesFrom(curi);
-                }
-                if (currentQueueKey.equals(curi.getClassKey())) {
-                    // curi was in right queue; apply queue-group gating and
-                    // round-robin (issue #754) if it belongs to a group,
-                    // otherwise emit exactly as before.
-                    QueueGroup group = groupFor(readyQ);
-                    if (group != null) {
-                        String memberKey = readyQ.getClassKey();
-                        long now = System.currentTimeMillis();
-                        synchronized (group) {
-                            // (a) shared gate closed: at concurrency ceiling
-                            // or in cool-down. Park the queue (snooze until
-                            // the group re-opens) and serve another queue.
-                            if (!group.canProceed(now)) {
-                                inProcessQueues.remove(readyQ);
-                                long until = Math.max(group.getWakeTime(), now + 1);
-                                snoozeQueue(readyQ, now, until - now);
-                                readyQ.makeDirty();
-                                readyQ = null;
-                                continue findauri;
-                            }
-                            // (b) not this member's turn: another member is
-                            // ahead in the rotation and ready. Requeue and
-                            // retry so the expected member gets served next.
-                            if (!group.isTurn(this::isMemberReady, memberKey)) {
-                                inProcessQueues.remove(readyQ);
-                                readyQueue(readyQ);
-                                readyQ.makeDirty();
-                                readyQ = null;
-                                continue findauri;
-                            }
-                            // (c) its turn and gate open: reserve a shared
-                            // slot, advance the rotation, and emit.
-                            group.acquire();
-                            group.advanceRotation(memberKey);
                         }
                     }
-                    noteAboutToEmit(curi, readyQ);
-                    return curi;
+                } while (readyQ == null);
+                
+                if (readyQ == null) {
+                    // no queues left in ready or readiable
+                    break findauri; 
                 }
-                // URI's assigned queue has changed since it
-                // was queued (eg because its IP has become
-                // known). Requeue to new queue.
-                // TODO: consider synchronization on readyQ
-                readyQ.dequeue(this,curi);
-                doJournalRelocated(curi);
-                curi.setClassKey(currentQueueKey);
-                decrementQueuedCount(1);
-                curi.setHolderKey(null);
-                sendToQueue(curi);
-                if(readyQ.getCount()==0) {
-                    // readyQ is empty and ready: it's exhausted
-                    // release held status, allowing any subsequent
-                    // enqueues to again put queue in ready
-                    // FIXME: tiny window here where queue could
-                    // receive new URI, be readied, fail not-in-process?
-                    inProcessQueues.remove(readyQ);
-                    readyQ.noteExhausted();
-                    readyQ.makeDirty();
-                    readyQ = null;
-                    continue findauri;
+           
+                returnauri: while(true) { // loop left by explicit return or break on empty
+                    CrawlURI curi = null;
+                    curi = readyQ.peek(this);   
+                    if(curi == null) {
+                        // should not reach
+                        logger.severe("No CrawlURI from ready non-empty queue "
+                                + readyQ.classKey + "\n" 
+                                + readyQ.shortReportLegend() + "\n"
+                                + readyQ.shortReportLine() + "\n");
+                        break returnauri;
+                    }
+                    
+                    // from queues, override names persist but not map source
+                    curi.setOverlayMapsSource(sheetOverlaysManager);
+                    // TODO: consider optimizations avoiding this recalc of
+                    // overrides when not necessary
+                    sheetOverlaysManager.applyOverlaysTo(curi);
+                    // check if curi belongs in different queue
+                    String currentQueueKey;
+                    try {
+                        KeyedProperties.loadOverridesFrom(curi);
+                        currentQueueKey = getClassKey(curi);
+                    } finally {
+                        KeyedProperties.clearOverridesFrom(curi); 
+                    }
+                    if (currentQueueKey.equals(curi.getClassKey())) {
+                        // curi was in right queue; apply queue-group gating and
+                        // round-robin (issue #754) if it belongs to a group,
+                        // otherwise emit exactly as before.
+                        QueueGroup group = groupFor(readyQ);
+                        if (group != null) {
+                            String memberKey = readyQ.getClassKey();
+                            long now = System.currentTimeMillis();
+                            synchronized (group) {
+                                // (a) shared gate closed: at concurrency ceiling
+                                // or in cool-down. Park the queue (snooze until
+                                // the group re-opens) and serve another queue.
+                                if (!group.canProceed(now)) {
+                                    inProcessQueues.remove(readyQ);
+                                    long until = Math.max(group.getWakeTime(), now + 1);
+                                    snoozeQueue(readyQ, now, until - now);
+                                    readyQ.makeDirty();
+                                    readyQ = null;
+                                    continue findauri;
+                                }
+                                // (b) not this member's turn: another member is
+                                // ahead in the rotation and ready. Requeue and
+                                // retry so the expected member gets served next.
+                                if (!group.isTurn(this::isMemberReady, memberKey)) {
+                                    inProcessQueues.remove(readyQ);
+                                    readyQueue(readyQ);
+                                    readyQ.makeDirty();
+                                    readyQ = null;
+                                    continue findauri;
+                                }
+                                // (c) its turn and gate open: reserve a shared
+                                // slot, advance the rotation, and emit.
+                                group.acquire();
+                                group.advanceRotation(memberKey);
+                            }
+                        }
+                        noteAboutToEmit(curi, readyQ);
+                        return curi;
+                    }
+                    // URI's assigned queue has changed since it
+                    // was queued (eg because its IP has become
+                    // known). Requeue to new queue.
+                    // TODO: consider synchronization on readyQ
+                    readyQ.dequeue(this,curi);
+                    doJournalRelocated(curi);
+                    curi.setClassKey(currentQueueKey);
+                    decrementQueuedCount(1);
+                    curi.setHolderKey(null);
+                    sendToQueue(curi);
+                    if(readyQ.getCount()==0) {
+                        // readyQ is empty and ready: it's exhausted
+                        // release held status, allowing any subsequent 
+                        // enqueues to again put queue in ready
+                        // FIXME: tiny window here where queue could 
+                        // receive new URI, be readied, fail not-in-process?
+                        inProcessQueues.remove(readyQ);
+                        readyQ.noteExhausted();
+                        readyQ.makeDirty();
+                        readyQ = null;
+                        continue findauri;
+                    }
                 }
             }
-        }
-
-        if(inProcessQueues.size()==0) {
-            // Nothing was ready or in progress or imminent to wake; ensure
-            // any piled-up pending-scheduled URIs are considered
-            uriUniqFilter.requestFlush();
-        }
-
-        // if truly nothing ready, wait a moment before returning null
-        // so that loop in surrounding next() has a chance of getting something
-        // next time
-        if(getTotalEligibleInactiveQueues()==0) {
-            try {
-                Thread.sleep(250);
-            } catch (InterruptedException e) {
-                //
+                
+            if(inProcessQueues.size()==0) {
+                // Nothing was ready or in progress or imminent to wake; ensure 
+                // any piled-up pending-scheduled URIs are considered
+                uriUniqFilter.requestFlush();
             }
-        }
-
-        // nothing eligible
-        return null;
+            
+            // if truly nothing ready, wait a moment before returning null
+            // so that loop in surrounding next() has a chance of getting something
+            // next time
+            if(getTotalEligibleInactiveQueues()==0) {
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException e) {
+                    // 
+                } 
+            }
+            
+            // nothing eligible
+            return null; 
     }
 
     /**
@@ -831,9 +831,9 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         // TODO: consider only checking this every set interval
         if(!futureUris.isEmpty()) {
             synchronized(futureUris) {
-                Iterator<CrawlURI> iter =
-                        futureUris.headMap(System.currentTimeMillis())
-                                .values().iterator();
+                Iterator<CrawlURI> iter = 
+                    futureUris.headMap(System.currentTimeMillis())
+                        .values().iterator();
                 while(iter.hasNext()) {
                     CrawlURI curi = iter.next();
                     curi.setRescheduleTime(-1); // unless again set elsewhere
@@ -844,9 +844,9 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             }
         }
     }
-
+    
     /**
-     * Activate an inactive queue, if any are available.
+     * Activate an inactive queue, if any are available. 
      */
     protected boolean activateInactiveQueue() {
         for (Entry<Integer, Queue<String>> entry: getInactiveQueuesByPrecedence().entrySet()) {
@@ -888,8 +888,8 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
     /**
      * Recalculate the value of thehighest-precedence queue waiting
-     * among inactive queues.
-     *
+     * among inactive queues. 
+     * 
      * @param startFrom start looking at this precedence value
      */
     protected void updateHighestWaiting(int startFrom) {
@@ -907,23 +907,23 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     /**
      * Enqueue the given queue to either readyClassQueues or inactiveQueues,
      * as appropriate.
-     *
+     * 
      * @param wq
      */
-    protected void reenqueueQueue(WorkQueue wq) {
+    protected void reenqueueQueue(WorkQueue wq) { 
         if (logger.isLoggable(Level.FINE)) {
             logger.fine("queue reenqueued: " +
-                    wq.getClassKey());
+                wq.getClassKey());
         }
-        if(highestPrecedenceWaiting < wq.getPrecedence()
-                || wq.getPrecedence() >= getPrecedenceFloor()) {
+        if(highestPrecedenceWaiting < wq.getPrecedence() 
+            || wq.getPrecedence() >= getPrecedenceFloor()) {
             // if still over budget, deactivate
             deactivateQueue(wq);
         } else {
             readyQueue(wq);
         }
     }
-
+    
     /* (non-Javadoc)
      * @see org.archive.crawler.frontier.AbstractFrontier#getMaxInWait()
      */
@@ -936,7 +936,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     /**
      * Utility method for advanced users/experimentation: force wake all snoozed
      * queues -- for example to kick a crawl where connectivity problems have
-     * put all queues in slow-retry-snoozes back to busy-ness.
+     * put all queues in slow-retry-snoozes back to busy-ness. 
      */
     public void forceWakeQueues() {
         Iterator<DelayedWorkQueue> iterSnoozed = snoozedClassQueues.iterator();
@@ -947,7 +947,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                 reenqueueQueue(queue);
                 queue.makeDirty();
             }
-            iterSnoozed.remove();
+            iterSnoozed.remove(); 
         }
         Iterator<DelayedWorkQueue> iterOverflow = snoozedOverflow.values().iterator();
         while(iterOverflow.hasNext()) {
@@ -957,16 +957,16 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                 reenqueueQueue(queue);
                 queue.makeDirty();
             }
-            iterOverflow.remove();
+            iterOverflow.remove(); 
             snoozedOverflowCount.decrementAndGet();
         }
     }
-
+    
     /**
      * Wake any queues sitting in the snoozed queue whose time has come.
      */
     protected void wakeQueues() {
-        DelayedWorkQueue waked;
+        DelayedWorkQueue waked; 
         while((waked = snoozedClassQueues.poll())!=null) {
             WorkQueue queue = waked.getWorkQueue(this);
             synchronized(queue) {
@@ -978,8 +978,8 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         // also consider overflow (usually empty)
         if(!snoozedOverflow.isEmpty()) {
             synchronized(snoozedOverflow) {
-                Iterator<DelayedWorkQueue> iter =
-                        snoozedOverflow.headMap(System.currentTimeMillis()).values().iterator();
+                Iterator<DelayedWorkQueue> iter = 
+                    snoozedOverflow.headMap(System.currentTimeMillis()).values().iterator();
                 while(iter.hasNext()) {
                     DelayedWorkQueue dq = iter.next();
                     iter.remove();
@@ -994,7 +994,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             }
         }
     }
-
+    
     /**
      * Note that the previously emitted CrawlURI has completed
      * its processing (for now).
@@ -1004,20 +1004,20 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      * via the next next() call, as a result of finished().
      *
      * TODO: make as many decisions about what happens to the CrawlURI
-     * (success, failure, retry) and queue (retire, snooze, ready) as
+     * (success, failure, retry) and queue (retire, snooze, ready) as 
      * possible elsewhere, such as in DispositionProcessor. Then, break
-     * this into simple branches or focused methods for each case.
-     *
+     * this into simple branches or focused methods for each case. 
+     *  
      * @see org.archive.crawler.framework.Frontier#finished(org.archive.modules.CrawlURI)
      */
     protected void processFinish(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-
+        
         long now = System.currentTimeMillis();
 
         curi.incrementFetchAttempts();
         logNonfatalErrors(curi);
-
+        
         WorkQueue wq = (WorkQueue) curi.getHolder();
         synchronized (wq) {
 
@@ -1038,7 +1038,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                 }
                 long delay_ms = retryDelayFor(curi) * 1000;
                 curi.processingCleanup(); // lose state that shouldn't burden
-                // retry
+                                          // retry
                 wq.unpeek(curi);
                 wq.update(this, curi); // rewrite any changes
                 releaseGroup(wq, now, delay_ms);
@@ -1103,23 +1103,23 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             handleQueue(wq,curi.includesRetireDirective(),now,delay_ms);
             wq.makeDirty();
         }
-
+        
         if(curi.getRescheduleTime()>0) {
             // marked up for forced-revisit at a set time
             curi.processingCleanup();
-            curi.resetForRescheduling();
+            curi.resetForRescheduling(); 
             futureUris.put(curi.getRescheduleTime(),curi);
-            futureUriCount.incrementAndGet();
+            futureUriCount.incrementAndGet(); 
         } else {
             curi.stripToMinimal();
             curi.processingCleanup();
         }
     }
-
+    
     /**
-     * Send an active queue to its next state, based on the supplied
+     * Send an active queue to its next state, based on the supplied 
      * parameters.
-     *
+     * 
      * @param wq
      * @param forceRetire
      * @param now
@@ -1139,10 +1139,10 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
     /**
      * Place the given queue into 'snoozed' state, ineligible to
-     * supply any URIs for crawling, for the given amount of time.
-     *
-     * @param wq queue to snooze
-     * @param now time now in ms
+     * supply any URIs for crawling, for the given amount of time. 
+     * 
+     * @param wq queue to snooze 
+     * @param now time now in ms 
      * @param delay_ms time to snooze in ms
      */
     protected void snoozeQueue(WorkQueue wq, long now, long delay_ms) {
@@ -1208,14 +1208,14 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     //
     // Reporter implementation
     //
-
-
+    
+    
     @Override
     public Map<String, Object> shortReportMap() {
         if (this.allQueues == null) {
             return null;
         }
-
+        
         int allCount = allQueues.size();
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1248,7 +1248,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     @Override
     public void shortReportLineTo(PrintWriter w) {
         if (!isRunning()) return; //???
-
+        
         if (this.allQueues == null) {
             return;
         }
@@ -1260,8 +1260,8 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         int inactiveCount = getTotalEligibleInactiveQueues();
         int ineligibleCount = getTotalIneligibleInactiveQueues();
         int retiredCount = getRetiredQueues().size();
-        int exhaustedCount =
-                allCount - activeCount - inactiveCount - retiredCount;
+        int exhaustedCount = 
+            allCount - activeCount - inactiveCount - retiredCount;
         State last = lastReachedState;
         w.print(last);
         w.print(" - ");
@@ -1282,30 +1282,30 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         w.print(retiredCount);
         w.print(" retired; ");
         w.print(exhaustedCount);
-        w.print(" exhausted");
+        w.print(" exhausted");        
         w.flush();
     }
 
     /**
      * Total of all URIs in inactive queues at all precedences
-     * @return int total
+     * @return int total 
      */
     protected int getTotalInactiveQueues() {
         return tallyInactiveTotals(getInactiveQueuesByPrecedence());
     }
-
+    
     /**
      * Total of all URIs in inactive queues at precedences above the floor
-     * @return int total
+     * @return int total 
      */
     protected int getTotalEligibleInactiveQueues() {
         return tallyInactiveTotals(
                 getInactiveQueuesByPrecedence().headMap(getPrecedenceFloor()));
     }
-
+    
     /**
      * Total of all URIs in inactive queues at precedences at or below the floor
-     * @return int total
+     * @return int total 
      */
     protected int getTotalIneligibleInactiveQueues() {
         return tallyInactiveTotals(
@@ -1313,13 +1313,13 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     }
 
     private int tallyInactiveTotals(SortedMap<Integer,Queue<String>> iqueues) {
-        int inactiveCount = 0;
+        int inactiveCount = 0; 
         for(Queue<String> q : iqueues.values()) {
             inactiveCount += q.size();
         }
         return inactiveCount;
     }
-
+    
     /* (non-Javadoc)
      * @see org.archive.util.Reporter#singleLineLegend()
      */
@@ -1342,9 +1342,9 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         int activeCount = inProcessCount + readyCount + snoozedCount;
         int inactiveCount = getTotalInactiveQueues();
         int retiredCount = getRetiredQueues().size();
-        int exhaustedCount =
-                allCount - activeCount - inactiveCount - retiredCount;
-
+        int exhaustedCount = 
+            allCount - activeCount - inactiveCount - retiredCount;
+        
         writer.print("Frontier report - ");
         writer.print(ArchiveUtils.get12DigitDate());
         writer.print("\n");
@@ -1396,7 +1396,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         writer.print(inactiveCount);
         writer.print(" (");
         Map<Integer,Queue<String>> inactives = getInactiveQueuesByPrecedence();
-        boolean betwixt = false;
+        boolean betwixt = false; 
         for(Integer k : inactives.keySet()) {
             if(betwixt) {
                 writer.print("; ");
@@ -1405,7 +1405,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             writer.print(k);
             writer.print(": ");
             writer.print(inactives.get(k).size());
-            betwixt = true;
+            betwixt = true; 
         }
         writer.print(")\n");
         writer.print("            Retired queues: ");
@@ -1414,31 +1414,31 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         writer.print("          Exhausted queues: ");
         writer.print(exhaustedCount);
         writer.print("\n");
-
+        
         State last = lastReachedState;
-        writer.print("\n             Last state: "+last);
-
+        writer.print("\n             Last state: "+last);        
+        
         writer.print("\n -----===== MANAGER THREAD =====-----\n");
         ToeThread.reportThread(managerThread, writer);
-
+        
         writer.print("\n -----===== "+largestQueues.size()+" LONGEST QUEUES =====-----\n");
         appendQueueReports(writer, "LONGEST", largestQueues.getEntriesDescending().iterator(), largestQueues.size(), largestQueues.size());
-
+        
         writer.print("\n -----===== IN-PROCESS QUEUES =====-----\n");
         Collection<WorkQueue> inProcess = inProcessQueues;
         ArrayList<WorkQueue> copy = extractSome(inProcess, maxQueuesPerReportCategory);
         appendQueueReports(writer, "IN-PROCESS", copy.iterator(), copy.size(), maxQueuesPerReportCategory);
-
+        
         writer.print("\n -----===== READY QUEUES =====-----\n");
         appendQueueReports(writer, "READY", this.readyClassQueues.iterator(),
-                this.readyClassQueues.size(), maxQueuesPerReportCategory);
-
+            this.readyClassQueues.size(), maxQueuesPerReportCategory);
+        
         writer.print("\n -----===== SNOOZED QUEUES =====-----\n");
         Object[] objs = snoozedClassQueues.toArray();
         DelayedWorkQueue[] qs = Arrays.copyOf(objs,objs.length,DelayedWorkQueue[].class);
         Arrays.sort(qs);
         appendQueueReports(writer, "SNOOZED", new ObjectArrayIterator(qs), getSnoozedCount(), maxQueuesPerReportCategory);
-
+        
         writer.print("\n -----===== INACTIVE QUEUES =====-----\n");
         SortedMap<Integer,Queue<String>> sortedInactives = getInactiveQueuesByPrecedence();
         for(Integer prec : sortedInactives.keySet()) {
@@ -1446,11 +1446,11 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             appendQueueReports(writer, "INACTIVE-p"+prec, inactiveQueues.iterator(),
                     inactiveQueues.size(), maxQueuesPerReportCategory);
         }
-
+        
         writer.print("\n -----===== RETIRED QUEUES =====-----\n");
         appendQueueReports(writer, "RETIRED", getRetiredQueues().iterator(),
-                getRetiredQueues().size(), maxQueuesPerReportCategory);
-
+            getRetiredQueues().size(), maxQueuesPerReportCategory);
+        
         appendQueueGroupReport(writer);
 
         writer.flush();
@@ -1506,15 +1506,15 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             writer.print("\n");
         }
     }
-
+    
     /** Compact report of all nonempty queues (one queue per line)
-     *
+     * 
      * @param writer
      */
     public void allNonemptyReportTo(PrintWriter writer) {
         ArrayList<WorkQueue> inProcessQueuesCopy;
         synchronized(this.inProcessQueues) {
-            // grab a copy that will be stable against mods for report duration
+            // grab a copy that will be stable against mods for report duration 
             Collection<WorkQueue> inProcess = this.inProcessQueues;
             inProcessQueuesCopy = new ArrayList<WorkQueue>(inProcess);
         }
@@ -1527,28 +1527,28 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         writer.print("\n -----===== SNOOZED QUEUES =====-----\n");
         queueSingleLinesTo(writer, this.snoozedClassQueues.iterator());
         queueSingleLinesTo(writer, this.snoozedOverflow.values().iterator());
-
+        
         writer.print("\n -----===== INACTIVE QUEUES =====-----\n");
         for(Queue<String> inactiveQueues : getInactiveQueuesByPrecedence().values()) {
             queueSingleLinesTo(writer, inactiveQueues.iterator());
         }
-
+        
         writer.print("\n -----===== RETIRED QUEUES =====-----\n");
         queueSingleLinesTo(writer, getRetiredQueues().iterator());
     }
 
     /** Compact report of all nonempty queues (one queue per line)
-     *
+     * 
      * @param writer
      */
     public void allQueuesReportTo(PrintWriter writer) {
         queueSingleLinesTo(writer, allQueues.keySet().iterator());
     }
-
+    
     /**
      * Writer the single-line reports of all queues in the
-     * iterator to the writer
-     *
+     * iterator to the writer 
+     * 
      * @param writer to receive report
      * @param iterator over queues of interest.
      */
@@ -1570,7 +1570,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                     q = this.allQueues.get((String)obj);
                 } catch (ClassCastException cce) {
                     logger.log(Level.SEVERE,"not convertible to workqueue:"+obj,cce);
-                    q = null;
+                    q = null; 
                 }
             }
 
@@ -1583,7 +1583,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
             } else {
                 writer.print(" ERROR: "+obj);
             }
-        }
+        }       
     }
 
     /**
@@ -1591,7 +1591,7 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
      * ArrayList.  This method synchronizes on the given collection's
      * monitor.  The returned list will never contain more than the
      * specified maximum number of elements.
-     *
+     * 
      * @param c    the collection whose elements to extract
      * @param max  the maximum number of elements to extract
      * @return  the extraction
@@ -1616,13 +1616,13 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     /**
      * Append queue report to general Frontier report.
      * @param w StringBuffer to append to.
-     * @param iterator An iterator over
+     * @param iterator An iterator over 
      * @param total
      * @param max
      */
     @SuppressWarnings("rawtypes")
     protected void appendQueueReports(PrintWriter w, String label, Iterator<?> iterator,
-                                      int total, int max) {
+            int total, int max) {
         Object obj;
         WorkQueue q;
         int count;
@@ -1656,13 +1656,13 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
 
     /**
      * Force logging, etc. of operator- deleted CrawlURIs
-     *
+     * 
      * @see org.archive.crawler.framework.Frontier#deleted(org.archive.modules.CrawlURI)
      */
     public void deleted(CrawlURI curi) {
         //treat as disregarded
         appCtx.publishEvent(
-                new CrawlURIDispositionEvent(this,curi,DISREGARDED));
+            new CrawlURIDispositionEvent(this,curi,DISREGARDED));
         log(curi);
         incrementDisregardedUriCount();
         curi.stripToMinimal();
@@ -1696,25 +1696,25 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
                 wq.makeDirty();
             }
         } finally {
-            KeyedProperties.clearOverridesFrom(curi);
+            KeyedProperties.clearOverridesFrom(curi); 
         }
     }
-
+    
     /**
      * Returns <code>true</code> if the WorkQueue implementation of this
      * Frontier stores its workload on disk instead of relying
      * on serialization mechanisms.
-     *
+     * 
      * TODO: rename! (this is a very misleading name) or kill (don't
      * see any implementations that return false)
-     *
+     * 
      * @return a constant boolean value for this class/instance
      */
     protected abstract boolean workQueueDataOnDisk();
 
     public long averageDepth() {
         if(inProcessQueues==null || readyClassQueues==null || snoozedClassQueues==null) {
-            return 0;
+            return 0; 
         }
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1724,14 +1724,14 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
         int totalQueueCount = (activeCount+inactiveCount);
         return (totalQueueCount == 0) ? 0 : queuedUriCount.get() / totalQueueCount;
     }
-
+    
     protected int getSnoozedCount() {
         return snoozedClassQueues.size() + snoozedOverflowCount.get();
     }
-
+    
     public float congestionRatio() {
         if(inProcessQueues==null || readyClassQueues==null || snoozedClassQueues==null) {
-            return 0;
+            return 0; 
         }
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1743,17 +1743,17 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     public long deepestUri() {
         return largestQueues.getTopSet().size()==0 ? -1 : largestQueues.getTopSet().get(largestQueues.getLargest());
     }
-
-    /**
+    
+    /** 
      * Return whether frontier is exhausted: all crawlable URIs done (none
      * waiting or pending). Only gives precise answer inside managerThread.
-     *
+     * 
      * @see org.archive.crawler.framework.Frontier#isEmpty()
      */
     public boolean isEmpty() {
-        return queuedUriCount.get() == 0
-                && (uriUniqFilter == null || uriUniqFilter.pending() == 0)
-                && futureUriCount.get() == 0;
+        return queuedUriCount.get() == 0 
+            && (uriUniqFilter == null || uriUniqFilter.pending() == 0)
+            && futureUriCount.get() == 0;
     }
 
     /* (non-Javadoc)
@@ -1763,5 +1763,5 @@ public abstract class WorkQueueFrontier extends AbstractFrontier
     protected int getInProcessCount() {
         return inProcessQueues.size();
     }
-
+    
 } // TODO: slim class! Suspect it should be < 800 lines, shedding budgeting/reporting

--- a/engine/src/main/java/org/archive/crawler/frontier/WorkQueueFrontier.java
+++ b/engine/src/main/java/org/archive/crawler/frontier/WorkQueueFrontier.java
@@ -1,8 +1,8 @@
 /*
  *  This file is part of the Heritrix web crawler (crawler.archive.org).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual 
- *  contributors. 
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
@@ -72,8 +73,8 @@ import com.sleepycat.collections.StoredSortedMap;
 import com.sleepycat.je.DatabaseException;
 
 /**
- * A common Frontier base using several queues to hold pending URIs. 
- * 
+ * A common Frontier base using several queues to hold pending URIs.
+ *
  * Uses in-memory map of all known 'queues' inside a single database.
  * Round-robins between all queues.
  *
@@ -81,8 +82,8 @@ import com.sleepycat.je.DatabaseException;
  * @author Christian Kohlschuetter
  */
 public abstract class WorkQueueFrontier extends AbstractFrontier
-implements Closeable, 
-           ApplicationContextAware {
+        implements Closeable,
+        ApplicationContextAware {
     @SuppressWarnings("unused")
     private static final long serialVersionUID = 570384305871965843L;
 
@@ -91,29 +92,80 @@ implements Closeable,
      * we can avoid using a disk-based BigMap.
      * This only works efficiently if the WorkQueue does not hold its
      * entries in memory as well.
-     */ 
+     */
     private static final int MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY = 3000;
 
     /**
      * When a snooze target for a queue is longer than this amount, the queue
      * will be "long snoozed" instead of "short snoozed".  A "long snoozed"
-     * queue may be swapped to disk because it's not needed soon.  
+     * queue may be swapped to disk because it's not needed soon.
      */
-    protected long snoozeLongMs = 5L*60L*1000L; 
+    protected long snoozeLongMs = 5L*60L*1000L;
     public long getSnoozeLongMs() {
         return snoozeLongMs;
     }
     public void setSnoozeLongMs(long snooze) {
         this.snoozeLongMs = snooze;
     }
-    
+
     private static final Logger logger =
-        Logger.getLogger(WorkQueueFrontier.class.getName());
-    
+            Logger.getLogger(WorkQueueFrontier.class.getName());
+
     // ApplicationContextAware implementation, for eventing
     protected AbstractApplicationContext appCtx;
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.appCtx = (AbstractApplicationContext)applicationContext;
+    }
+
+    /**
+     * Optional queue-group manager (issue #754). Entirely opt-in: if no
+     * {@code queueGroups} bean is declared in the crawl beans, this stays
+     * {@code null} and the frontier behaves exactly as before.
+     */
+    @Autowired(required=false)
+    protected QueueGroupManager queueGroupManager;
+
+    public QueueGroupManager getQueueGroupManager() {
+        return queueGroupManager;
+    }
+    public void setQueueGroupManager(QueueGroupManager queueGroupManager) {
+        this.queueGroupManager = queueGroupManager;
+    }
+
+    /**
+     * @return the {@link QueueGroup} the given queue belongs to, or
+     *         {@code null} if there is no manager or the queue is ungrouped.
+     */
+    protected QueueGroup groupFor(WorkQueue wq) {
+        if (queueGroupManager == null || wq == null) {
+            return null;
+        }
+        return queueGroupManager.groupFor(wq.getClassKey());
+    }
+
+    /**
+     * @return true if the given member classKey is currently ready to be
+     *         emitted, i.e. actually present in {@link #readyClassQueues}. This
+     *         guarantees the round-robin never waits forever for a member that
+     *         is snoozed/empty/in-process.
+     */
+    protected boolean isMemberReady(String classKey) {
+        return classKey != null && readyClassQueues.contains(classKey);
+    }
+
+    /**
+     * Release the shared group slot held by the given queue and arm the shared
+     * cool-down. No-op when the queue is not grouped or there is no manager.
+     *
+     * @param wq       the finished queue
+     * @param now      current epoch-ms
+     * @param delay_ms the per-URI politeness delay just computed
+     */
+    protected void releaseGroup(WorkQueue wq, long now, long delay_ms) {
+        QueueGroup group = groupFor(wq);
+        if (group != null) {
+            group.release(now, delay_ms);
+        }
     }
 
     {
@@ -149,7 +201,7 @@ implements Closeable,
     public void setQueueTotalBudget(long budget) {
         kp.put("queueTotalBudget",budget);
     }
-    
+
     {
         setQueuePrecedencePolicy(new BaseQueuePrecedencePolicy());
     }
@@ -162,7 +214,7 @@ implements Closeable,
     }
 
     /** precedence rank at or below which queues are not crawled */
-    protected int precedenceFloor = 255; 
+    protected int precedenceFloor = 255;
     public int getPrecedenceFloor() {
         return this.precedenceFloor;
     }
@@ -171,7 +223,7 @@ implements Closeable,
     }
 
     /** truncate reporting of queues at this large but not unbounded number */
-    protected int maxQueuesPerReportCategory = 2000; 
+    protected int maxQueuesPerReportCategory = 2000;
     public int getMaxQueuesPerReportCategory() {
         return this.maxQueuesPerReportCategory;
     }
@@ -181,7 +233,7 @@ implements Closeable,
 
     /** All known queues.
      */
-    protected ObjectIdentityCache<WorkQueue> allQueues = null; 
+    protected ObjectIdentityCache<WorkQueue> allQueues = null;
     // of classKey -> ClassKeyQueue
 
     /**
@@ -189,26 +241,26 @@ implements Closeable,
      * Linked-list of keys for the queues.
      */
     protected BlockingQueue<String> readyClassQueues;
-    
+
     /** all per-class queues from whom a URI is outstanding */
-    protected Set<WorkQueue> inProcessQueues = 
-        Collections.newSetFromMap(new ConcurrentHashMap<WorkQueue, Boolean>()); // of ClassKeyQueue
-    
+    protected Set<WorkQueue> inProcessQueues =
+            Collections.newSetFromMap(new ConcurrentHashMap<WorkQueue, Boolean>()); // of ClassKeyQueue
+
     /**
      * All per-class queues held in snoozed state, sorted by wake time.
      */
     transient protected DelayQueue<DelayedWorkQueue> snoozedClassQueues;
-    protected StoredSortedMap<Long,DelayedWorkQueue> snoozedOverflow; 
-    protected AtomicInteger snoozedOverflowCount = new AtomicInteger(0); 
-    protected static int MAX_SNOOZED_IN_MEMORY = 10000; 
-    
+    protected StoredSortedMap<Long,DelayedWorkQueue> snoozedOverflow;
+    protected AtomicInteger snoozedOverflowCount = new AtomicInteger(0);
+    protected static int MAX_SNOOZED_IN_MEMORY = 10000;
+
     /** URIs scheduled to be re-enqueued at future date */
-    protected StoredSortedMap<Long, CrawlURI> futureUris; 
-    
+    protected StoredSortedMap<Long, CrawlURI> futureUris;
+
     /** remember keys of small number of largest queues for reporting */
     transient protected TopNSet largestQueues = new TopNSet(20);
     /** remember this many largest queues for reporting's sake; actual tracking
-     *  can be somewhat approximate when some queues shrink before others' 
+     *  can be somewhat approximate when some queues shrink before others'
      *  sizes are again noted, or if the size is adjusted mid-crawl. */
     public int getLargestQueuesCount() {
         return largestQueues.getMaxSize();
@@ -216,11 +268,11 @@ implements Closeable,
     public void setLargestQueuesCount(int count) {
         largestQueues.setMaxSize(count);
     }
-    
+
     protected int highestPrecedenceWaiting = Integer.MAX_VALUE;
 
-    /** The UriUniqFilter to use, tracking those UURIs which are 
-     * already in-process (or processed), and thus should not be 
+    /** The UriUniqFilter to use, tracking those UURIs which are
+     * already in-process (or processed), and thus should not be
      * rescheduled. Also known as the 'alreadyIncluded' or
      * 'alreadySeen' structure */
     protected UriUniqFilter uriUniqFilter;
@@ -238,10 +290,10 @@ implements Closeable,
     public WorkQueueFrontier() {
         super();
     }
-    
+
     public void start() {
         if(isRunning()) {
-            return; 
+            return;
         }
         uriUniqFilter.setDestination(this);
         super.start();
@@ -257,34 +309,34 @@ implements Closeable,
      * Initializes internal queues.  May decide to keep all queues in memory based on
      * {@link QueueAssignmentPolicy#maximumNumberOfKeys}.  Otherwise invokes
      * {@link #initAllQueues()} to actually set up the queues.
-     * 
-     * Subclasses should invoke this method with recycle set to "true" in 
+     *
+     * Subclasses should invoke this method with recycle set to "true" in
      * a private readObject method, to restore queues after a checkpoint.
-     * 
+     *
      * @throws IOException
      * @throws DatabaseException
      */
-    protected void initInternalQueues() 
-    throws IOException, DatabaseException {
+    protected void initInternalQueues()
+            throws IOException, DatabaseException {
         this.initOtherQueues();
         if (workQueueDataOnDisk()
                 && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() >= 0
-                && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() <= 
-                    MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY) {
-            this.allQueues = 
-                new ObjectIdentityMemCache<WorkQueue>(701, .9f, 100);
+                && preparer.getQueueAssignmentPolicy().maximumNumberOfKeys() <=
+                MAX_QUEUES_TO_HOLD_ALLQUEUES_IN_MEMORY) {
+            this.allQueues =
+                    new ObjectIdentityMemCache<WorkQueue>(701, .9f, 100);
         } else {
             this.initAllQueues();
         }
     }
-    
+
     /**
      * Initialize the allQueues field in an implementation-appropriate
      * way.
      * @throws DatabaseException
      */
     protected abstract void initAllQueues() throws DatabaseException;
-    
+
     /**
      * Initialize all other internal queues in an implementation-appropriate
      * way.
@@ -292,8 +344,8 @@ implements Closeable,
      */
     protected abstract void initOtherQueues() throws DatabaseException;
 
-    
-    
+
+
     /* (non-Javadoc)
      * @see org.archive.crawler.frontier.AbstractFrontier#stop()
      */
@@ -301,45 +353,45 @@ implements Closeable,
     public void stop() {
         super.stop();
     }
-    
+
     public void destroy() {
         // release resources and trigger end-of-frontier actions
         close();
     }
-    
+
     /**
      * Release resources only needed when running
      */
     public void close() {
-        ArchiveUtils.closeQuietly(uriUniqFilter);     
+        ArchiveUtils.closeQuietly(uriUniqFilter);
         ArchiveUtils.closeQuietly(allQueues);
     }
-    
+
     /**
      * Accept the given CrawlURI for scheduling, as it has
-     * passed the alreadyIncluded filter. 
-     * 
+     * passed the alreadyIncluded filter.
+     *
      * Choose a per-classKey queue and enqueue it. If this
-     * item has made an unready queue ready, place that 
-     * queue on the readyClassQueues queue. 
+     * item has made an unready queue ready, place that
+     * queue on the readyClassQueues queue.
      * @param curi CrawlURI.
      */
     protected void processScheduleAlways(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        assert KeyedProperties.overridesActiveFrom(curi); 
-        
+        assert KeyedProperties.overridesActiveFrom(curi);
+
         prepForFrontier(curi);
         sendToQueue(curi);
     }
-    
-    
+
+
     /**
      * Arrange for the given CrawlURI to be visited, if it is not
-     * already enqueued/completed. 
-     * 
-     * Differs from superclass in that it operates in calling thread, rather 
+     * already enqueued/completed.
+     *
+     * Differs from superclass in that it operates in calling thread, rather
      * than deferring operations via in-queue to managerThread. TODO: settle
-     * on either defer or in-thread approach after testing. 
+     * on either defer or in-thread approach after testing.
      *
      * @see org.archive.crawler.framework.Frontier#schedule(org.archive.modules.CrawlURI)
      */
@@ -354,7 +406,7 @@ implements Closeable,
             }
             processScheduleIfUnique(curi);
         } finally {
-            KeyedProperties.clearOverridesFrom(curi); 
+            KeyedProperties.clearOverridesFrom(curi);
         }
     }
 
@@ -366,8 +418,8 @@ implements Closeable,
      */
     protected void processScheduleIfUnique(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        assert KeyedProperties.overridesActiveFrom(curi); 
-        
+        assert KeyedProperties.overridesActiveFrom(curi);
+
         // Canonicalization may set forceFetch flag.  See
         // #canonicalization(CrawlURI) javadoc for circumstance.
         String canon = curi.getCanonicalString();
@@ -380,12 +432,12 @@ implements Closeable,
 
     /**
      * Send a CrawlURI to the appropriate subqueue.
-     * 
+     *
      * @param curi
      */
     protected void sendToQueue(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        
+
         WorkQueue wq = getQueueFor(curi.getClassKey());
         synchronized(wq) {
             int originalPrecedence = wq.getPrecedence();
@@ -394,7 +446,7 @@ implements Closeable,
             // (whose overlay settings should be active here)
             wq.setSessionBudget(getBalanceReplenishAmount());
             wq.setTotalBudget(getQueueTotalBudget());
-            
+
             if(!wq.isRetired()) {
                 incrementQueuedUriCount();
                 int currentPrecedence = wq.getPrecedence();
@@ -427,7 +479,7 @@ implements Closeable,
         } catch (InterruptedException e) {
             e.printStackTrace();
             System.err.println("unable to ready queue "+wq);
-            // propagate interrupt up 
+            // propagate interrupt up
             throw new RuntimeException(e);
         }
     }
@@ -455,21 +507,21 @@ implements Closeable,
 
             if(logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE,
-                        "queue deactivated to p" + precedence 
-                        + ": " + wq.getClassKey());
+                        "queue deactivated to p" + precedence
+                                + ": " + wq.getClassKey());
             }
         }
     }
-    
+
     /**
-     * Get the queue of inactive uri-queue names at the given precedence. 
-     * 
+     * Get the queue of inactive uri-queue names at the given precedence.
+     *
      * @param precedence
      * @return queue of inacti
      */
     protected Queue<String> getInactiveQueuesForPrecedence(int precedence) {
-        Map<Integer,Queue<String>> inactiveQueuesByPrecedence = 
-            getInactiveQueuesByPrecedence();
+        Map<Integer,Queue<String>> inactiveQueuesByPrecedence =
+                getInactiveQueuesByPrecedence();
         Queue<String> candidate = inactiveQueuesByPrecedence.get(precedence);
         if(candidate==null) {
             candidate = createInactiveQueueForPrecedence(precedence);
@@ -507,19 +559,19 @@ implements Closeable,
                     "queue retired: " + wq.getClassKey());
         }
     }
-    
+
     /**
      * Return queue of all retired queue names.
-     * 
+     *
      * @return Queue&lt;String&gt; of retired queue names
      */
     protected abstract Queue<String> getRetiredQueues();
 
-    /** 
+    /**
      * Accommodate any changes in retirement-determining settings (like
-     * total-budget or force-retire changes/overlays. 
-     * 
-     * (Essentially, exists to be called from tools like the UI 
+     * total-budget or force-retire changes/overlays.
+     *
+     * (Essentially, exists to be called from tools like the UI
      * Scripting Console when the operator knows it's necessary.)
      */
     public void reconsiderRetiredQueues() {
@@ -529,9 +581,9 @@ implements Closeable,
         // as retired/overbudget next time they come up, they'll
         // be re-retired; if not, they'll get a chance to become
         // active under the new rules.
-        
+
         // TODO: Do this automatically, only when necessary.
-        
+
         String key = getRetiredQueues().poll();
         while (key != null) {
             WorkQueue q = (WorkQueue)this.allQueues.get(key);
@@ -545,69 +597,69 @@ implements Closeable,
         }
     }
     /**
-     * Restore a retired queue to the 'inactive' state. 
-     * 
+     * Restore a retired queue to the 'inactive' state.
+     *
      * @param q
      */
     private void unretireQueue(WorkQueue q) {
 //        assert Thread.currentThread() == managerThread;
 
         deactivateQueue(q);
-        q.setRetired(false); 
+        q.setRetired(false);
         incrementQueuedUriCount(q.getCount());
     }
 
     /**
      * Return the work queue for the given classKey, or null
      * if no such queue exists.
-     * 
+     *
      * @param classKey key to look for
      * @return the found WorkQueue
      */
     protected abstract WorkQueue getQueueFor(String classKey);
-    
- 
+
+
     /**
      * Return the next CrawlURI eligible to be processed (and presumably
      * visited/fetched) by a a worker thread.
      *
      * Relies on the readyClassQueues having been loaded with
-     * any work queues that are eligible to provide a URI. 
+     * any work queues that are eligible to provide a URI.
      *
      * @return next CrawlURI eligible to be processed, or null if none available
      *
      * @see org.archive.crawler.framework.Frontier#next()
      */
     protected CrawlURI findEligibleURI() {
-            // wake any snoozed queues
-            wakeQueues();
-            // consider rescheduled URIS
-            checkFutures();
-                   
-            // find a non-empty ready queue, if any 
-            // TODO: refactor to untangle these loops, early-exits, etc!
-            WorkQueue readyQ = null;
-            findauri: while(true) {
-                findaqueue: do {
-                    String key = readyClassQueues.poll();
-                    if(key==null) {
-                        // no ready queues; try to activate one
-                        if(!getInactiveQueuesByPrecedence().isEmpty() 
+        // wake any snoozed queues
+        wakeQueues();
+        // consider rescheduled URIS
+        checkFutures();
+
+        // find a non-empty ready queue, if any
+        // TODO: refactor to untangle these loops, early-exits, etc!
+        WorkQueue readyQ = null;
+        findauri: while(true) {
+            findaqueue: do {
+                String key = readyClassQueues.poll();
+                if(key==null) {
+                    // no ready queues; try to activate one
+                    if(!getInactiveQueuesByPrecedence().isEmpty()
                             && highestPrecedenceWaiting < getPrecedenceFloor()) {
-                            activateInactiveQueue();
-                            continue findaqueue;
-                        } else {
-                            // nothing ready or readyable
-                            break findaqueue;
-                        }
-                    }
-                    readyQ = getQueueFor(key);
-                    if (readyQ == null) {
-                        // readyQ key wasn't in all queues: unexpected
-                        logger.severe("Key " + key
-                                + " in readyClassQueues but not allQueues");
+                        activateInactiveQueue();
+                        continue findaqueue;
+                    } else {
+                        // nothing ready or readyable
                         break findaqueue;
                     }
+                }
+                readyQ = getQueueFor(key);
+                if (readyQ == null) {
+                    // readyQ key wasn't in all queues: unexpected
+                    logger.severe("Key " + key
+                            + " in readyClassQueues but not allQueues");
+                    break findaqueue;
+                }
                 synchronized (readyQ) {
                     if (readyQ.getCount() == 0) {
                         // readyQ is empty and ready: it's exhausted
@@ -652,89 +704,123 @@ implements Closeable,
                         readyQ.makeDirty();
                         readyQ = null;
                         continue;
+                    }
+                }
+            } while (readyQ == null);
+
+            if (readyQ == null) {
+                // no queues left in ready or readiable
+                break findauri;
+            }
+
+            returnauri: while(true) { // loop left by explicit return or break on empty
+                CrawlURI curi = null;
+                curi = readyQ.peek(this);
+                if(curi == null) {
+                    // should not reach
+                    logger.severe("No CrawlURI from ready non-empty queue "
+                            + readyQ.classKey + "\n"
+                            + readyQ.shortReportLegend() + "\n"
+                            + readyQ.shortReportLine() + "\n");
+                    break returnauri;
+                }
+
+                // from queues, override names persist but not map source
+                curi.setOverlayMapsSource(sheetOverlaysManager);
+                // TODO: consider optimizations avoiding this recalc of
+                // overrides when not necessary
+                sheetOverlaysManager.applyOverlaysTo(curi);
+                // check if curi belongs in different queue
+                String currentQueueKey;
+                try {
+                    KeyedProperties.loadOverridesFrom(curi);
+                    currentQueueKey = getClassKey(curi);
+                } finally {
+                    KeyedProperties.clearOverridesFrom(curi);
+                }
+                if (currentQueueKey.equals(curi.getClassKey())) {
+                    // curi was in right queue; apply queue-group gating and
+                    // round-robin (issue #754) if it belongs to a group,
+                    // otherwise emit exactly as before.
+                    QueueGroup group = groupFor(readyQ);
+                    if (group != null) {
+                        String memberKey = readyQ.getClassKey();
+                        long now = System.currentTimeMillis();
+                        synchronized (group) {
+                            // (a) shared gate closed: at concurrency ceiling
+                            // or in cool-down. Park the queue (snooze until
+                            // the group re-opens) and serve another queue.
+                            if (!group.canProceed(now)) {
+                                inProcessQueues.remove(readyQ);
+                                long until = Math.max(group.getWakeTime(), now + 1);
+                                snoozeQueue(readyQ, now, until - now);
+                                readyQ.makeDirty();
+                                readyQ = null;
+                                continue findauri;
+                            }
+                            // (b) not this member's turn: another member is
+                            // ahead in the rotation and ready. Requeue and
+                            // retry so the expected member gets served next.
+                            if (!group.isTurn(this::isMemberReady, memberKey)) {
+                                inProcessQueues.remove(readyQ);
+                                readyQueue(readyQ);
+                                readyQ.makeDirty();
+                                readyQ = null;
+                                continue findauri;
+                            }
+                            // (c) its turn and gate open: reserve a shared
+                            // slot, advance the rotation, and emit.
+                            group.acquire();
+                            group.advanceRotation(memberKey);
                         }
                     }
-                } while (readyQ == null);
-                
-                if (readyQ == null) {
-                    // no queues left in ready or readiable
-                    break findauri; 
+                    noteAboutToEmit(curi, readyQ);
+                    return curi;
                 }
-           
-                returnauri: while(true) { // loop left by explicit return or break on empty
-                    CrawlURI curi = null;
-                    curi = readyQ.peek(this);   
-                    if(curi == null) {
-                        // should not reach
-                        logger.severe("No CrawlURI from ready non-empty queue "
-                                + readyQ.classKey + "\n" 
-                                + readyQ.shortReportLegend() + "\n"
-                                + readyQ.shortReportLine() + "\n");
-                        break returnauri;
-                    }
-                    
-                    // from queues, override names persist but not map source
-                    curi.setOverlayMapsSource(sheetOverlaysManager);
-                    // TODO: consider optimizations avoiding this recalc of
-                    // overrides when not necessary
-                    sheetOverlaysManager.applyOverlaysTo(curi);
-                    // check if curi belongs in different queue
-                    String currentQueueKey;
-                    try {
-                        KeyedProperties.loadOverridesFrom(curi);
-                        currentQueueKey = getClassKey(curi);
-                    } finally {
-                        KeyedProperties.clearOverridesFrom(curi); 
-                    }
-                    if (currentQueueKey.equals(curi.getClassKey())) {
-                        // curi was in right queue, emit
-                        noteAboutToEmit(curi, readyQ);
-                        return curi;
-                    }
-                    // URI's assigned queue has changed since it
-                    // was queued (eg because its IP has become
-                    // known). Requeue to new queue.
-                    // TODO: consider synchronization on readyQ
-                    readyQ.dequeue(this,curi);
-                    doJournalRelocated(curi);
-                    curi.setClassKey(currentQueueKey);
-                    decrementQueuedCount(1);
-                    curi.setHolderKey(null);
-                    sendToQueue(curi);
-                    if(readyQ.getCount()==0) {
-                        // readyQ is empty and ready: it's exhausted
-                        // release held status, allowing any subsequent 
-                        // enqueues to again put queue in ready
-                        // FIXME: tiny window here where queue could 
-                        // receive new URI, be readied, fail not-in-process?
-                        inProcessQueues.remove(readyQ);
-                        readyQ.noteExhausted();
-                        readyQ.makeDirty();
-                        readyQ = null;
-                        continue findauri;
-                    }
+                // URI's assigned queue has changed since it
+                // was queued (eg because its IP has become
+                // known). Requeue to new queue.
+                // TODO: consider synchronization on readyQ
+                readyQ.dequeue(this,curi);
+                doJournalRelocated(curi);
+                curi.setClassKey(currentQueueKey);
+                decrementQueuedCount(1);
+                curi.setHolderKey(null);
+                sendToQueue(curi);
+                if(readyQ.getCount()==0) {
+                    // readyQ is empty and ready: it's exhausted
+                    // release held status, allowing any subsequent
+                    // enqueues to again put queue in ready
+                    // FIXME: tiny window here where queue could
+                    // receive new URI, be readied, fail not-in-process?
+                    inProcessQueues.remove(readyQ);
+                    readyQ.noteExhausted();
+                    readyQ.makeDirty();
+                    readyQ = null;
+                    continue findauri;
                 }
             }
-                
-            if(inProcessQueues.size()==0) {
-                // Nothing was ready or in progress or imminent to wake; ensure 
-                // any piled-up pending-scheduled URIs are considered
-                uriUniqFilter.requestFlush();
+        }
+
+        if(inProcessQueues.size()==0) {
+            // Nothing was ready or in progress or imminent to wake; ensure
+            // any piled-up pending-scheduled URIs are considered
+            uriUniqFilter.requestFlush();
+        }
+
+        // if truly nothing ready, wait a moment before returning null
+        // so that loop in surrounding next() has a chance of getting something
+        // next time
+        if(getTotalEligibleInactiveQueues()==0) {
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                //
             }
-            
-            // if truly nothing ready, wait a moment before returning null
-            // so that loop in surrounding next() has a chance of getting something
-            // next time
-            if(getTotalEligibleInactiveQueues()==0) {
-                try {
-                    Thread.sleep(250);
-                } catch (InterruptedException e) {
-                    // 
-                } 
-            }
-            
-            // nothing eligible
-            return null; 
+        }
+
+        // nothing eligible
+        return null;
     }
 
     /**
@@ -745,9 +831,9 @@ implements Closeable,
         // TODO: consider only checking this every set interval
         if(!futureUris.isEmpty()) {
             synchronized(futureUris) {
-                Iterator<CrawlURI> iter = 
-                    futureUris.headMap(System.currentTimeMillis())
-                        .values().iterator();
+                Iterator<CrawlURI> iter =
+                        futureUris.headMap(System.currentTimeMillis())
+                                .values().iterator();
                 while(iter.hasNext()) {
                     CrawlURI curi = iter.next();
                     curi.setRescheduleTime(-1); // unless again set elsewhere
@@ -758,9 +844,9 @@ implements Closeable,
             }
         }
     }
-    
+
     /**
-     * Activate an inactive queue, if any are available. 
+     * Activate an inactive queue, if any are available.
      */
     protected boolean activateInactiveQueue() {
         for (Entry<Integer, Queue<String>> entry: getInactiveQueuesByPrecedence().entrySet()) {
@@ -802,8 +888,8 @@ implements Closeable,
 
     /**
      * Recalculate the value of thehighest-precedence queue waiting
-     * among inactive queues. 
-     * 
+     * among inactive queues.
+     *
      * @param startFrom start looking at this precedence value
      */
     protected void updateHighestWaiting(int startFrom) {
@@ -821,23 +907,23 @@ implements Closeable,
     /**
      * Enqueue the given queue to either readyClassQueues or inactiveQueues,
      * as appropriate.
-     * 
+     *
      * @param wq
      */
-    protected void reenqueueQueue(WorkQueue wq) { 
+    protected void reenqueueQueue(WorkQueue wq) {
         if (logger.isLoggable(Level.FINE)) {
             logger.fine("queue reenqueued: " +
-                wq.getClassKey());
+                    wq.getClassKey());
         }
-        if(highestPrecedenceWaiting < wq.getPrecedence() 
-            || wq.getPrecedence() >= getPrecedenceFloor()) {
+        if(highestPrecedenceWaiting < wq.getPrecedence()
+                || wq.getPrecedence() >= getPrecedenceFloor()) {
             // if still over budget, deactivate
             deactivateQueue(wq);
         } else {
             readyQueue(wq);
         }
     }
-    
+
     /* (non-Javadoc)
      * @see org.archive.crawler.frontier.AbstractFrontier#getMaxInWait()
      */
@@ -850,7 +936,7 @@ implements Closeable,
     /**
      * Utility method for advanced users/experimentation: force wake all snoozed
      * queues -- for example to kick a crawl where connectivity problems have
-     * put all queues in slow-retry-snoozes back to busy-ness. 
+     * put all queues in slow-retry-snoozes back to busy-ness.
      */
     public void forceWakeQueues() {
         Iterator<DelayedWorkQueue> iterSnoozed = snoozedClassQueues.iterator();
@@ -861,7 +947,7 @@ implements Closeable,
                 reenqueueQueue(queue);
                 queue.makeDirty();
             }
-            iterSnoozed.remove(); 
+            iterSnoozed.remove();
         }
         Iterator<DelayedWorkQueue> iterOverflow = snoozedOverflow.values().iterator();
         while(iterOverflow.hasNext()) {
@@ -871,16 +957,16 @@ implements Closeable,
                 reenqueueQueue(queue);
                 queue.makeDirty();
             }
-            iterOverflow.remove(); 
+            iterOverflow.remove();
             snoozedOverflowCount.decrementAndGet();
         }
     }
-    
+
     /**
      * Wake any queues sitting in the snoozed queue whose time has come.
      */
     protected void wakeQueues() {
-        DelayedWorkQueue waked; 
+        DelayedWorkQueue waked;
         while((waked = snoozedClassQueues.poll())!=null) {
             WorkQueue queue = waked.getWorkQueue(this);
             synchronized(queue) {
@@ -892,8 +978,8 @@ implements Closeable,
         // also consider overflow (usually empty)
         if(!snoozedOverflow.isEmpty()) {
             synchronized(snoozedOverflow) {
-                Iterator<DelayedWorkQueue> iter = 
-                    snoozedOverflow.headMap(System.currentTimeMillis()).values().iterator();
+                Iterator<DelayedWorkQueue> iter =
+                        snoozedOverflow.headMap(System.currentTimeMillis()).values().iterator();
                 while(iter.hasNext()) {
                     DelayedWorkQueue dq = iter.next();
                     iter.remove();
@@ -908,7 +994,7 @@ implements Closeable,
             }
         }
     }
-    
+
     /**
      * Note that the previously emitted CrawlURI has completed
      * its processing (for now).
@@ -918,20 +1004,20 @@ implements Closeable,
      * via the next next() call, as a result of finished().
      *
      * TODO: make as many decisions about what happens to the CrawlURI
-     * (success, failure, retry) and queue (retire, snooze, ready) as 
+     * (success, failure, retry) and queue (retire, snooze, ready) as
      * possible elsewhere, such as in DispositionProcessor. Then, break
-     * this into simple branches or focused methods for each case. 
-     *  
+     * this into simple branches or focused methods for each case.
+     *
      * @see org.archive.crawler.framework.Frontier#finished(org.archive.modules.CrawlURI)
      */
     protected void processFinish(CrawlURI curi) {
 //        assert Thread.currentThread() == managerThread;
-        
+
         long now = System.currentTimeMillis();
 
         curi.incrementFetchAttempts();
         logNonfatalErrors(curi);
-        
+
         WorkQueue wq = (WorkQueue) curi.getHolder();
         synchronized (wq) {
 
@@ -952,9 +1038,10 @@ implements Closeable,
                 }
                 long delay_ms = retryDelayFor(curi) * 1000;
                 curi.processingCleanup(); // lose state that shouldn't burden
-                                          // retry
+                // retry
                 wq.unpeek(curi);
                 wq.update(this, curi); // rewrite any changes
+                releaseGroup(wq, now, delay_ms);
                 handleQueue(wq, curi.includesRetireDirective(), now, delay_ms);
                 appCtx.publishEvent(new CrawlURIDispositionEvent(this, curi,
                         DEFERRED_FOR_RETRY));
@@ -1012,26 +1099,27 @@ implements Closeable,
             wq.expend(holderCost); // successes & failures charge cost to queue
 
             long delay_ms = curi.getPolitenessDelay();
+            releaseGroup(wq, now, delay_ms);
             handleQueue(wq,curi.includesRetireDirective(),now,delay_ms);
             wq.makeDirty();
         }
-        
+
         if(curi.getRescheduleTime()>0) {
             // marked up for forced-revisit at a set time
             curi.processingCleanup();
-            curi.resetForRescheduling(); 
+            curi.resetForRescheduling();
             futureUris.put(curi.getRescheduleTime(),curi);
-            futureUriCount.incrementAndGet(); 
+            futureUriCount.incrementAndGet();
         } else {
             curi.stripToMinimal();
             curi.processingCleanup();
         }
     }
-    
+
     /**
-     * Send an active queue to its next state, based on the supplied 
+     * Send an active queue to its next state, based on the supplied
      * parameters.
-     * 
+     *
      * @param wq
      * @param forceRetire
      * @param now
@@ -1051,10 +1139,10 @@ implements Closeable,
 
     /**
      * Place the given queue into 'snoozed' state, ineligible to
-     * supply any URIs for crawling, for the given amount of time. 
-     * 
-     * @param wq queue to snooze 
-     * @param now time now in ms 
+     * supply any URIs for crawling, for the given amount of time.
+     *
+     * @param wq queue to snooze
+     * @param now time now in ms
      * @param delay_ms time to snooze in ms
      */
     protected void snoozeQueue(WorkQueue wq, long now, long delay_ms) {
@@ -1120,14 +1208,14 @@ implements Closeable,
     //
     // Reporter implementation
     //
-    
-    
+
+
     @Override
     public Map<String, Object> shortReportMap() {
         if (this.allQueues == null) {
             return null;
         }
-        
+
         int allCount = allQueues.size();
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1160,7 +1248,7 @@ implements Closeable,
     @Override
     public void shortReportLineTo(PrintWriter w) {
         if (!isRunning()) return; //???
-        
+
         if (this.allQueues == null) {
             return;
         }
@@ -1172,8 +1260,8 @@ implements Closeable,
         int inactiveCount = getTotalEligibleInactiveQueues();
         int ineligibleCount = getTotalIneligibleInactiveQueues();
         int retiredCount = getRetiredQueues().size();
-        int exhaustedCount = 
-            allCount - activeCount - inactiveCount - retiredCount;
+        int exhaustedCount =
+                allCount - activeCount - inactiveCount - retiredCount;
         State last = lastReachedState;
         w.print(last);
         w.print(" - ");
@@ -1194,30 +1282,30 @@ implements Closeable,
         w.print(retiredCount);
         w.print(" retired; ");
         w.print(exhaustedCount);
-        w.print(" exhausted");        
+        w.print(" exhausted");
         w.flush();
     }
 
     /**
      * Total of all URIs in inactive queues at all precedences
-     * @return int total 
+     * @return int total
      */
     protected int getTotalInactiveQueues() {
         return tallyInactiveTotals(getInactiveQueuesByPrecedence());
     }
-    
+
     /**
      * Total of all URIs in inactive queues at precedences above the floor
-     * @return int total 
+     * @return int total
      */
     protected int getTotalEligibleInactiveQueues() {
         return tallyInactiveTotals(
                 getInactiveQueuesByPrecedence().headMap(getPrecedenceFloor()));
     }
-    
+
     /**
      * Total of all URIs in inactive queues at precedences at or below the floor
-     * @return int total 
+     * @return int total
      */
     protected int getTotalIneligibleInactiveQueues() {
         return tallyInactiveTotals(
@@ -1225,13 +1313,13 @@ implements Closeable,
     }
 
     private int tallyInactiveTotals(SortedMap<Integer,Queue<String>> iqueues) {
-        int inactiveCount = 0; 
+        int inactiveCount = 0;
         for(Queue<String> q : iqueues.values()) {
             inactiveCount += q.size();
         }
         return inactiveCount;
     }
-    
+
     /* (non-Javadoc)
      * @see org.archive.util.Reporter#singleLineLegend()
      */
@@ -1254,9 +1342,9 @@ implements Closeable,
         int activeCount = inProcessCount + readyCount + snoozedCount;
         int inactiveCount = getTotalInactiveQueues();
         int retiredCount = getRetiredQueues().size();
-        int exhaustedCount = 
-            allCount - activeCount - inactiveCount - retiredCount;
-        
+        int exhaustedCount =
+                allCount - activeCount - inactiveCount - retiredCount;
+
         writer.print("Frontier report - ");
         writer.print(ArchiveUtils.get12DigitDate());
         writer.print("\n");
@@ -1308,7 +1396,7 @@ implements Closeable,
         writer.print(inactiveCount);
         writer.print(" (");
         Map<Integer,Queue<String>> inactives = getInactiveQueuesByPrecedence();
-        boolean betwixt = false; 
+        boolean betwixt = false;
         for(Integer k : inactives.keySet()) {
             if(betwixt) {
                 writer.print("; ");
@@ -1317,7 +1405,7 @@ implements Closeable,
             writer.print(k);
             writer.print(": ");
             writer.print(inactives.get(k).size());
-            betwixt = true; 
+            betwixt = true;
         }
         writer.print(")\n");
         writer.print("            Retired queues: ");
@@ -1326,31 +1414,31 @@ implements Closeable,
         writer.print("          Exhausted queues: ");
         writer.print(exhaustedCount);
         writer.print("\n");
-        
+
         State last = lastReachedState;
-        writer.print("\n             Last state: "+last);        
-        
+        writer.print("\n             Last state: "+last);
+
         writer.print("\n -----===== MANAGER THREAD =====-----\n");
         ToeThread.reportThread(managerThread, writer);
-        
+
         writer.print("\n -----===== "+largestQueues.size()+" LONGEST QUEUES =====-----\n");
         appendQueueReports(writer, "LONGEST", largestQueues.getEntriesDescending().iterator(), largestQueues.size(), largestQueues.size());
-        
+
         writer.print("\n -----===== IN-PROCESS QUEUES =====-----\n");
         Collection<WorkQueue> inProcess = inProcessQueues;
         ArrayList<WorkQueue> copy = extractSome(inProcess, maxQueuesPerReportCategory);
         appendQueueReports(writer, "IN-PROCESS", copy.iterator(), copy.size(), maxQueuesPerReportCategory);
-        
+
         writer.print("\n -----===== READY QUEUES =====-----\n");
         appendQueueReports(writer, "READY", this.readyClassQueues.iterator(),
-            this.readyClassQueues.size(), maxQueuesPerReportCategory);
-        
+                this.readyClassQueues.size(), maxQueuesPerReportCategory);
+
         writer.print("\n -----===== SNOOZED QUEUES =====-----\n");
         Object[] objs = snoozedClassQueues.toArray();
         DelayedWorkQueue[] qs = Arrays.copyOf(objs,objs.length,DelayedWorkQueue[].class);
         Arrays.sort(qs);
         appendQueueReports(writer, "SNOOZED", new ObjectArrayIterator(qs), getSnoozedCount(), maxQueuesPerReportCategory);
-        
+
         writer.print("\n -----===== INACTIVE QUEUES =====-----\n");
         SortedMap<Integer,Queue<String>> sortedInactives = getInactiveQueuesByPrecedence();
         for(Integer prec : sortedInactives.keySet()) {
@@ -1358,22 +1446,75 @@ implements Closeable,
             appendQueueReports(writer, "INACTIVE-p"+prec, inactiveQueues.iterator(),
                     inactiveQueues.size(), maxQueuesPerReportCategory);
         }
-        
+
         writer.print("\n -----===== RETIRED QUEUES =====-----\n");
         appendQueueReports(writer, "RETIRED", getRetiredQueues().iterator(),
-            getRetiredQueues().size(), maxQueuesPerReportCategory);
-        
+                getRetiredQueues().size(), maxQueuesPerReportCategory);
+
+        appendQueueGroupReport(writer);
+
         writer.flush();
     }
-    
+
+    /**
+     * Append a QUEUE GROUPS section describing the state of each configured
+     * {@link QueueGroup} (issue #754). Returns immediately (leaving the report
+     * byte-for-byte unchanged) when no {@link QueueGroupManager} is declared or
+     * it holds no groups, preserving the opt-in guarantee.
+     *
+     * @param writer report writer
+     */
+    protected void appendQueueGroupReport(PrintWriter writer) {
+        if (queueGroupManager == null) {
+            return;
+        }
+        List<QueueGroup> groups = queueGroupManager.getGroups();
+        if (groups == null || groups.isEmpty()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        writer.print("\n -----===== QUEUE GROUPS =====-----\n");
+        for (QueueGroup group : groups) {
+            writer.print(" Group: ");
+            writer.print(group.getName());
+            writer.print("\n");
+            writer.print("   maxParallelInGroup: ");
+            writer.print(group.getMaxParallelInGroup());
+            writer.print("   groupMinDelayMs: ");
+            writer.print(group.getGroupMinDelayMs());
+            writer.print("\n");
+            long cooldownRemaining = Math.max(0, group.getWakeTime() - now);
+            writer.print("   active (in-process): ");
+            writer.print(group.getActiveCount());
+            writer.print("   cooldown remaining (ms): ");
+            writer.print(cooldownRemaining);
+            writer.print("\n");
+            writer.print("   configured members by host: ");
+            writer.print(group.getGroupMembersByHost());
+            writer.print("\n");
+            writer.print("   configured members by regex: ");
+            writer.print(group.getGroupMembersByRegex());
+            writer.print("\n");
+            writer.print("   configured members by surt: ");
+            writer.print(group.getGroupMembersBySurt());
+            writer.print("\n");
+            List<String> discovered = group.memberKeys();
+            writer.print("   discovered queues (");
+            writer.print(discovered.size());
+            writer.print("): ");
+            writer.print(discovered);
+            writer.print("\n");
+        }
+    }
+
     /** Compact report of all nonempty queues (one queue per line)
-     * 
+     *
      * @param writer
      */
     public void allNonemptyReportTo(PrintWriter writer) {
         ArrayList<WorkQueue> inProcessQueuesCopy;
         synchronized(this.inProcessQueues) {
-            // grab a copy that will be stable against mods for report duration 
+            // grab a copy that will be stable against mods for report duration
             Collection<WorkQueue> inProcess = this.inProcessQueues;
             inProcessQueuesCopy = new ArrayList<WorkQueue>(inProcess);
         }
@@ -1386,28 +1527,28 @@ implements Closeable,
         writer.print("\n -----===== SNOOZED QUEUES =====-----\n");
         queueSingleLinesTo(writer, this.snoozedClassQueues.iterator());
         queueSingleLinesTo(writer, this.snoozedOverflow.values().iterator());
-        
+
         writer.print("\n -----===== INACTIVE QUEUES =====-----\n");
         for(Queue<String> inactiveQueues : getInactiveQueuesByPrecedence().values()) {
             queueSingleLinesTo(writer, inactiveQueues.iterator());
         }
-        
+
         writer.print("\n -----===== RETIRED QUEUES =====-----\n");
         queueSingleLinesTo(writer, getRetiredQueues().iterator());
     }
 
     /** Compact report of all nonempty queues (one queue per line)
-     * 
+     *
      * @param writer
      */
     public void allQueuesReportTo(PrintWriter writer) {
         queueSingleLinesTo(writer, allQueues.keySet().iterator());
     }
-    
+
     /**
      * Writer the single-line reports of all queues in the
-     * iterator to the writer 
-     * 
+     * iterator to the writer
+     *
      * @param writer to receive report
      * @param iterator over queues of interest.
      */
@@ -1429,7 +1570,7 @@ implements Closeable,
                     q = this.allQueues.get((String)obj);
                 } catch (ClassCastException cce) {
                     logger.log(Level.SEVERE,"not convertible to workqueue:"+obj,cce);
-                    q = null; 
+                    q = null;
                 }
             }
 
@@ -1442,7 +1583,7 @@ implements Closeable,
             } else {
                 writer.print(" ERROR: "+obj);
             }
-        }       
+        }
     }
 
     /**
@@ -1450,7 +1591,7 @@ implements Closeable,
      * ArrayList.  This method synchronizes on the given collection's
      * monitor.  The returned list will never contain more than the
      * specified maximum number of elements.
-     * 
+     *
      * @param c    the collection whose elements to extract
      * @param max  the maximum number of elements to extract
      * @return  the extraction
@@ -1475,13 +1616,13 @@ implements Closeable,
     /**
      * Append queue report to general Frontier report.
      * @param w StringBuffer to append to.
-     * @param iterator An iterator over 
+     * @param iterator An iterator over
      * @param total
      * @param max
      */
     @SuppressWarnings("rawtypes")
     protected void appendQueueReports(PrintWriter w, String label, Iterator<?> iterator,
-            int total, int max) {
+                                      int total, int max) {
         Object obj;
         WorkQueue q;
         int count;
@@ -1501,7 +1642,8 @@ implements Closeable,
             }
             if(q != null) {
                 w.println(label+"#"+count+":");
-                q.reportTo(w);
+                QueueGroup group = groupFor(q);
+                q.reportTo(group != null ? group.getName() : null, w);
             } else {
                 w.print("WARNING: No report for queue "+obj);
             }
@@ -1514,17 +1656,28 @@ implements Closeable,
 
     /**
      * Force logging, etc. of operator- deleted CrawlURIs
-     * 
+     *
      * @see org.archive.crawler.framework.Frontier#deleted(org.archive.modules.CrawlURI)
      */
     public void deleted(CrawlURI curi) {
         //treat as disregarded
         appCtx.publishEvent(
-            new CrawlURIDispositionEvent(this,curi,DISREGARDED));
+                new CrawlURIDispositionEvent(this,curi,DISREGARDED));
         log(curi);
         incrementDisregardedUriCount();
         curi.stripToMinimal();
         curi.processingCleanup();
+    }
+
+    @Override
+    protected void log(CrawlURI curi) {
+        if (queueGroupManager != null) {
+            QueueGroup group = queueGroupManager.groupFor(curi.getClassKey());
+            if (group != null) {
+                curi.getAnnotations().add("queueGroup:" + group.getName());
+            }
+        }
+        super.log(curi);
     }
 
     public void considerIncluded(CrawlURI curi) {
@@ -1543,25 +1696,25 @@ implements Closeable,
                 wq.makeDirty();
             }
         } finally {
-            KeyedProperties.clearOverridesFrom(curi); 
+            KeyedProperties.clearOverridesFrom(curi);
         }
     }
-    
+
     /**
      * Returns <code>true</code> if the WorkQueue implementation of this
      * Frontier stores its workload on disk instead of relying
      * on serialization mechanisms.
-     * 
+     *
      * TODO: rename! (this is a very misleading name) or kill (don't
      * see any implementations that return false)
-     * 
+     *
      * @return a constant boolean value for this class/instance
      */
     protected abstract boolean workQueueDataOnDisk();
 
     public long averageDepth() {
         if(inProcessQueues==null || readyClassQueues==null || snoozedClassQueues==null) {
-            return 0; 
+            return 0;
         }
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1571,14 +1724,14 @@ implements Closeable,
         int totalQueueCount = (activeCount+inactiveCount);
         return (totalQueueCount == 0) ? 0 : queuedUriCount.get() / totalQueueCount;
     }
-    
+
     protected int getSnoozedCount() {
         return snoozedClassQueues.size() + snoozedOverflowCount.get();
     }
-    
+
     public float congestionRatio() {
         if(inProcessQueues==null || readyClassQueues==null || snoozedClassQueues==null) {
-            return 0; 
+            return 0;
         }
         int inProcessCount = inProcessQueues.size();
         int readyCount = readyClassQueues.size();
@@ -1590,17 +1743,17 @@ implements Closeable,
     public long deepestUri() {
         return largestQueues.getTopSet().size()==0 ? -1 : largestQueues.getTopSet().get(largestQueues.getLargest());
     }
-    
-    /** 
+
+    /**
      * Return whether frontier is exhausted: all crawlable URIs done (none
      * waiting or pending). Only gives precise answer inside managerThread.
-     * 
+     *
      * @see org.archive.crawler.framework.Frontier#isEmpty()
      */
     public boolean isEmpty() {
-        return queuedUriCount.get() == 0 
-            && (uriUniqFilter == null || uriUniqFilter.pending() == 0)
-            && futureUriCount.get() == 0;
+        return queuedUriCount.get() == 0
+                && (uriUniqFilter == null || uriUniqFilter.pending() == 0)
+                && futureUriCount.get() == 0;
     }
 
     /* (non-Javadoc)
@@ -1610,5 +1763,5 @@ implements Closeable,
     protected int getInProcessCount() {
         return inProcessQueues.size();
     }
-    
+
 } // TODO: slim class! Suspect it should be < 800 lines, shedding budgeting/reporting

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -469,7 +469,45 @@ http://example.example/example
   <!-- <property name="dumpPendingAtClose" value="false" /> -->
  </bean>
  
- <!-- URI UNIQ FILTER: Used by frontier to remember already-included URIs --> 
+ <!-- QUEUE GROUPS (issue #754): OPTIONAL, opt-in. When this bean is absent
+      (as by default, being commented out below), the frontier behaves
+      exactly as before. Uncomment and adapt to group several per-host queues
+      so they share a single politeness gate (shared concurrency + shared
+      cool-down) and are served round-robin, like a single visitor toward one
+      web server. See docs/QUEUE_GROUPS.md. -->
+ <!--
+ <bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
+  <property name="groups">
+   <list>
+    <bean class="org.archive.crawler.frontier.QueueGroup">
+     <property name="name" value="europa_eu" />
+     <property name="maxParallelInGroup" value="1" />
+     <property name="groupMinDelayMs" value="4000" />
+     <property name="groupMembersByHost">
+      <list>
+       <value>european-union.europa.eu</value>
+       <value>commission.europa.eu</value>
+       <value>data.europa.eu</value>
+       <value>op.europa.eu</value>
+      </list>
+     </property>
+     <property name="groupMembersByRegex">
+      <list>
+       <value>.*\.europa\.eu</value>
+      </list>
+     </property>
+     <property name="groupMembersBySurt">
+      <list>
+       <value>http://(eu,europa,</value>
+      </list>
+     </property>
+    </bean>
+   </list>
+  </property>
+ </bean>
+ -->
+
+ <!-- URI UNIQ FILTER: Used by frontier to remember already-included URIs -->
  <bean id="uriUniqFilter" 
    class="org.archive.crawler.util.BdbUriUniqFilter">
  </bean>

--- a/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
+++ b/engine/src/main/resources/org/archive/crawler/restlet/profile-crawler-beans.cxml
@@ -469,36 +469,32 @@ http://example.example/example
   <!-- <property name="dumpPendingAtClose" value="false" /> -->
  </bean>
  
- <!-- QUEUE GROUPS (issue #754): OPTIONAL, opt-in. When this bean is absent
+ <!-- QUEUE GROUPS : OPTIONAL. When this bean is absent
       (as by default, being commented out below), the frontier behaves
       exactly as before. Uncomment and adapt to group several per-host queues
       so they share a single politeness gate (shared concurrency + shared
       cool-down) and are served round-robin, like a single visitor toward one
-      web server. See docs/QUEUE_GROUPS.md. -->
+      web server. See docs/QUEUE_GROUPS.md.
+
+      IMPORTANT: group members are matched against the frontier's queue
+      classKey, whose format depends on the configured queueAssignmentPolicy
+      (see below). The default is SurtAuthorityQueueAssignmentPolicy, which
+      produces SURT-form authority classKeys such as "eu,europa,commission,".
+      Therefore, with the default policy, use groupMembersBySurt with a
+      SURT-authority prefix. The groupMembersByHost and groupMembersByRegex
+      forms match plain hostnames and are only appropriate when a host-based
+      queueAssignmentPolicy (e.g. HostnameQueueAssignmentPolicy) is used. -->
  <!--
  <bean id="queueGroups" class="org.archive.crawler.frontier.QueueGroupManager">
   <property name="groups">
    <list>
     <bean class="org.archive.crawler.frontier.QueueGroup">
-     <property name="name" value="europa_eu" />
+     <property name="name" value="example_com" />
      <property name="maxParallelInGroup" value="1" />
      <property name="groupMinDelayMs" value="4000" />
-     <property name="groupMembersByHost">
-      <list>
-       <value>european-union.europa.eu</value>
-       <value>commission.europa.eu</value>
-       <value>data.europa.eu</value>
-       <value>op.europa.eu</value>
-      </list>
-     </property>
-     <property name="groupMembersByRegex">
-      <list>
-       <value>.*\.europa\.eu</value>
-      </list>
-     </property>
      <property name="groupMembersBySurt">
       <list>
-       <value>http://(eu,europa,</value>
+       <value>com,example,</value>
       </list>
      </property>
     </bean>

--- a/engine/src/test/java/org/archive/crawler/frontier/QueueGroupTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/QueueGroupTest.java
@@ -1,0 +1,207 @@
+/*
+ *  This file is part of the Heritrix web crawler (crawler.archive.org).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.crawler.frontier;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the queue-group feature (issue #754): member matching,
+ * shared politeness gate, and round-robin rotation.
+ */
+public class QueueGroupTest {
+
+    private QueueGroup europa() {
+        QueueGroup g = new QueueGroup("europa_eu");
+        g.setMaxParallelInGroup(1);
+        g.setGroupMinDelayMs(4000);
+        g.setGroupMembersByHost(Arrays.asList(
+                "european-union.europa.eu",           // exact host
+                "commission.europa.eu"));             // exact host
+        g.setGroupMembersByRegex(Arrays.asList(
+                ".*\\.example\\.org"));                // regex on host part
+        g.setGroupMembersBySurt(Arrays.asList(
+                "http://(eu,europa,"));                // surt prefix
+        return g;
+    }
+
+    // ---- member matching ----
+
+    @Test
+    public void testExactHostMatch() {
+        QueueGroup g = europa();
+        assertTrue(g.matches("european-union.europa.eu"));
+        assertTrue(g.matches("commission.europa.eu"));
+        // hostname-policy suffixes
+        assertTrue(g.matches("european-union.europa.eu#8080"));
+        assertTrue(g.matches("european-union.europa.eu+2"));
+        assertFalse(g.matches("evil-european-union.europa.eu"));
+    }
+
+    @Test
+    public void testRegexMatchOnHostPart() {
+        QueueGroup g = europa();
+        assertTrue(g.matches("www.example.org"));
+        assertTrue(g.matches("www.example.org#80"));
+        assertFalse(g.matches("www.example.com"));
+    }
+
+    @Test
+    public void testSurtPrefixMatch() {
+        QueueGroup g = europa();
+        assertTrue(g.matches("http://(eu,europa,commission,"));
+        assertFalse(g.matches("http://(com,example,"));
+    }
+
+    @Test
+    public void testInvalidRegexIsIgnored() {
+        QueueGroup g = new QueueGroup("bad");
+        g.setGroupMembersByRegex(Arrays.asList("[unclosed"));
+        g.setGroupMembersByHost(Arrays.asList("good.host"));
+        // invalid regex never throws, and does not match
+        assertFalse(g.matches("anything"));
+        assertTrue(g.matches("good.host"));
+    }
+
+    // ---- shared politeness gate ----
+
+    @Test
+    public void testGateConcurrencyCeiling() {
+        QueueGroup g = new QueueGroup("g");
+        g.setMaxParallelInGroup(1);
+        g.setGroupMinDelayMs(0);
+        long now = 1000L;
+        assertTrue(g.canProceed(now));
+        g.acquire();
+        assertFalse(g.canProceed(now)); // ceiling reached
+        g.release(now, 0);
+        assertTrue(g.canProceed(now));  // slot freed, no cool-down
+    }
+
+    @Test
+    public void testGateCoolDownUsesMaxOfDelays() {
+        QueueGroup g = new QueueGroup("g");
+        g.setMaxParallelInGroup(1);
+        g.setGroupMinDelayMs(4000);
+        long now = 1000L;
+        g.acquire();
+        // per-URI delay smaller than group min -> group min wins
+        g.release(now, 500);
+        assertEquals(now + 4000, g.getWakeTime());
+        assertFalse(g.canProceed(now + 3999));
+        assertTrue(g.canProceed(now + 4000));
+    }
+
+    @Test
+    public void testGateCoolDownUsesPerUriDelayWhenLarger() {
+        QueueGroup g = new QueueGroup("g");
+        g.setMaxParallelInGroup(1);
+        g.setGroupMinDelayMs(1000);
+        long now = 1000L;
+        g.acquire();
+        g.release(now, 8000); // per-URI delay larger than group min
+        assertEquals(now + 8000, g.getWakeTime());
+    }
+
+    // ---- round-robin rotation ----
+
+    @Test
+    public void testRoundRobinRotation() {
+        QueueGroup g = new QueueGroup("g");
+        g.noteMember("a");
+        g.noteMember("b");
+        g.noteMember("c");
+        Predicate<String> allReady = k -> true;
+
+        // initially it's a's turn
+        assertTrue(g.isTurn(allReady, "a"));
+        assertFalse(g.isTurn(allReady, "b"));
+        g.advanceRotation("a");
+
+        // now b's turn
+        assertTrue(g.isTurn(allReady, "b"));
+        assertFalse(g.isTurn(allReady, "c"));
+        g.advanceRotation("b");
+
+        // now c's turn
+        assertTrue(g.isTurn(allReady, "c"));
+        g.advanceRotation("c");
+
+        // wraps back to a
+        assertTrue(g.isTurn(allReady, "a"));
+    }
+
+    @Test
+    public void testRotationSkipsNotReadyMembers() {
+        QueueGroup g = new QueueGroup("g");
+        g.noteMember("a");
+        g.noteMember("b");
+        g.noteMember("c");
+        // only "c" is ready; a and b are snoozed/empty
+        Set<String> ready = new HashSet<String>(Arrays.asList("c"));
+        Predicate<String> readyChecker = ready::contains;
+
+        // a is at the pointer but not ready -> skipped, so c gets the turn
+        assertTrue(g.isTurn(readyChecker, "c"));
+    }
+
+    // ---- manager resolution and caching ----
+
+    @Test
+    public void testManagerGroupForAndDiscovery() {
+        QueueGroupManager mgr = new QueueGroupManager();
+        QueueGroup g = europa();
+        mgr.setGroups(Arrays.asList(g));
+
+        assertSame(g, mgr.groupFor("european-union.europa.eu"));
+        assertSame(g, mgr.groupFor("commission.europa.eu"));
+        assertNull(mgr.groupFor("unrelated.example.net"));
+
+        // discovered members registered for rotation
+        assertTrue(g.memberKeys().contains("european-union.europa.eu"));
+        assertTrue(g.memberKeys().contains("commission.europa.eu"));
+    }
+
+    @Test
+    public void testManagerNoGroupsAlwaysNull() {
+        QueueGroupManager mgr = new QueueGroupManager();
+        assertNull(mgr.groupFor("anything.example.com"));
+    }
+
+    @Test
+    public void testManagerCrud() {
+        QueueGroupManager mgr = new QueueGroupManager();
+        QueueGroup g = new QueueGroup("g1");
+        g.setGroupMembersByHost(Arrays.asList("a.example.com"));
+        mgr.addGroup(g);
+        assertSame(g, mgr.groupFor("a.example.com"));
+
+        assertTrue(mgr.addMember("g1", "b.example.com"));
+        assertSame(g, mgr.groupFor("b.example.com"));
+
+        assertTrue(mgr.removeGroup("g1"));
+        assertNull(mgr.groupFor("a.example.com"));
+    }
+}

--- a/engine/src/test/java/org/archive/crawler/frontier/QueueGroupTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/QueueGroupTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,7 +42,7 @@ public class QueueGroupTest {
                 "european-union.europa.eu",           // exact host
                 "commission.europa.eu"));             // exact host
         g.setGroupMembersByRegex(Arrays.asList(
-                ".*\\.example\\.org"));                // regex on host part
+                Pattern.compile(".*\\.example\\.org")));  // regex on host part
         g.setGroupMembersBySurt(Arrays.asList(
                 "http://(eu,europa,"));                // surt prefix
         return g;
@@ -76,11 +77,10 @@ public class QueueGroupTest {
     }
 
     @Test
-    public void testInvalidRegexIsIgnored() {
+    public void testRegexOnlyMatchesConfiguredPattern() {
         QueueGroup g = new QueueGroup("bad");
-        g.setGroupMembersByRegex(Arrays.asList("[unclosed"));
+        g.setGroupMembersByRegex(Arrays.asList(Pattern.compile("good\\..*")));
         g.setGroupMembersByHost(Arrays.asList("good.host"));
-        // invalid regex never throws, and does not match
         assertFalse(g.matches("anything"));
         assertTrue(g.matches("good.host"));
     }

--- a/engine/src/test/java/org/archive/crawler/frontier/WorkQueueFrontierLogTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/WorkQueueFrontierLogTest.java
@@ -1,0 +1,114 @@
+package org.archive.crawler.frontier;
+
+import com.sleepycat.je.DatabaseException;
+import org.archive.modules.CrawlURI;
+import org.archive.net.UURIFactory;
+import org.archive.util.ObjectIdentityCache;
+import org.junit.jupiter.api.Test;
+
+import javax.management.openmbean.CompositeData;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WorkQueueFrontierLogTest {
+
+    @Test
+    public void testLogAddsQueueGroupAnnotation() throws Exception {
+        WorkQueueFrontier frontier = new WorkQueueFrontier() {
+            @Override
+            public CompositeData getURIsList(String marker, int numberOfMatches, String regex, boolean verbose) {
+                return null;
+            }
+
+            @Override
+            public FrontierGroup getGroup(CrawlURI curi) {
+                return null;
+            }
+
+            @Override
+            public long exportPendingUris(PrintWriter writer) {
+                return 0;
+            }
+
+            @Override
+            public ObjectIdentityCache<WorkQueue> getAllQueues() {
+                return null;
+            }
+
+            @Override
+            public BlockingQueue<String> getReadyClassQueues() {
+                return null;
+            }
+
+            @Override
+            public Set<WorkQueue> getInProcessQueues() {
+                return Set.of();
+            }
+
+            @Override
+            protected boolean workQueueDataOnDisk() {
+                return false;
+            }
+            @Override
+            public void initAllQueues() {
+            }
+
+            @Override
+            protected void initOtherQueues() throws DatabaseException {
+
+            }
+
+            @Override
+            protected SortedMap<Integer, Queue<String>> getInactiveQueuesByPrecedence() {
+                return null;
+            }
+
+            @Override
+            protected Queue<String> createInactiveQueueForPrecedence(int precedence) {
+                return null;
+            }
+
+            @Override
+            protected Queue<String> getRetiredQueues() {
+                return null;
+            }
+
+            @Override
+            protected WorkQueue getQueueFor(String classKey) {
+                return null;
+            }
+
+            @Override
+            protected void initInternalQueues() {
+            }
+        };
+
+        QueueGroupManager qgm = new QueueGroupManager();
+        QueueGroup g = new QueueGroup("testGroup");
+        g.setGroupMembersByHost(Arrays.asList("example.com"));
+        qgm.setGroups(Arrays.asList(g));
+        frontier.setQueueGroupManager(qgm);
+
+        CrawlURI curi = new CrawlURI(UURIFactory.getInstance("http://example.com/"));
+        curi.setClassKey("example.com");
+
+        // We need a dummy logger module to avoid NullPointerException in super.log(curi)
+        // However, we only care if the annotation is added before super.log(curi) is called.
+        // Let's use a simpler approach: check annotations after calling our log method.
+        
+        try {
+            frontier.log(curi);
+        } catch (NullPointerException e) {
+            // Expected because loggerModule is not set, but annotation should be added already
+        }
+
+        assertTrue(curi.getAnnotations().contains("queueGroup:testGroup"), 
+            "Annotations should contain queueGroup:testGroup. Found: " + curi.getAnnotations());
+    }
+}

--- a/engine/src/test/java/org/archive/crawler/frontier/WorkQueueReportTest.java
+++ b/engine/src/test/java/org/archive/crawler/frontier/WorkQueueReportTest.java
@@ -1,0 +1,45 @@
+package org.archive.crawler.frontier;
+
+import org.archive.modules.CrawlURI;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WorkQueueReportTest {
+
+    @Test
+    public void testReportToWithGroup() {
+        WorkQueue wq = new WorkQueue("testKey") {
+            private static final long serialVersionUID = 1L;
+            @Override
+            protected void insertItem(WorkQueueFrontier frontier, CrawlURI curi, boolean overwriteIfPresent) {}
+            @Override
+            protected long deleteMatchingFromQueue(WorkQueueFrontier frontier, String match) { return 0; }
+            @Override
+            protected void deleteItem(WorkQueueFrontier frontier, CrawlURI item) {}
+            @Override
+            protected CrawlURI peekItem(WorkQueueFrontier frontier) { return null; }
+        };
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        
+        // Test without group
+        wq.reportTo(pw);
+        pw.flush();
+        String report = sw.toString();
+        assertTrue(report.contains("Queue testKey (p1)"));
+        assertTrue(!report.contains("in queueGroup"));
+
+        // Test with group
+        sw = new StringWriter();
+        pw = new PrintWriter(sw);
+        wq.reportTo("testGroup", pw);
+        pw.flush();
+        report = sw.toString();
+        assertTrue(report.contains("Queue testKey (p1) in queueGroup testGroup"));
+    }
+}


### PR DESCRIPTION
Added `QueueGroup` and `QueueGroupManager` to implement queue-grouping for shared resource management, politeness gating, and round-robin scheduling. Introduced test cases to validate functionality and integration.

The implementation adds three main pieces:
- **QueueGroup:** represents the configuration and runtime state of one group. It stores the group name, the member matchers, the maximum allowed parallelism, and the shared minimum delay. It also manages the group-level scheduling state, including the shared gate and the round-robin rotation between discovered member queues.
- **QueueGroupManager:** acts as the optional registry for all configured groups. It resolves which group, if any, a given queue belongs to, caches those lookups, and records the concrete queues discovered at runtime. It also allows groups or members to be added or removed dynamically, which can be useful from the scripting console.
- **WorkQueueFrontier integration:** the frontier remains responsible for selecting the next eligible queue, but now checks whether a queue belongs to a group before emitting its next URI. If the queue is not grouped, the original behavior is preserved. If it is grouped, the frontier applies the group gate and the group round-robin rules before allowing the URI to be fetched.

A key part of the design is the group gate.
The group gate is the shared politeness mechanism for all queues in the same group. It decides whether the group is currently allowed to emit another URI. The gate can be closed for two reasons:
- Shared concurrency is already full
	If the number of active queues in the group has reached queueGroup.getMaxParallelInGroup(), no other member of the group may start a fetch until one of the active fetches finishes.
- The group is still in shared cooldown
After a fetch finishes, the group arms a shared cooldown. The next fetch from any member of the group must wait until this cooldown expires. The effective delay is based on the normal per-URI politeness delay, but can be raised by groupMinDelayMs. _**effective delay** : max(curi.getPolitenessDelay(), groupMinDelayMs)_

When the gate is closed, the queue is not emitted. Instead, it is put aside until the group becomes eligible again, allowing the frontier to continue serving other queues outside the group, or other groups that are ready.
When the gate is open, the frontier still checks the group round-robin order. This ensures that the next URI comes from the member whose turn it is, rather than always selecting the first ready queue. Once a member is allowed through, the group acquires a shared slot. When the fetch completes, that slot is released and the group cooldown is updated.
In other words, the group gate makes the group behave like a single polite communication channel toward the target server, while the round-robin logic keeps distribution fair between the individual host queues inside that channel.


We add observability in the frontier summary report, so that configured groups expose their current state: configured members, discovered queues, active in-process count, and remaining cooldown time.
Example:
<img width="604" height="153" alt="frontierSummary" src="https://github.com/user-attachments/assets/0da74f54-8fea-499e-80a4-40575d70107c" />


We  add **queueGroup** annotation in CrawlUri to display it in Crawl Report (crawl.log). 
