### PR TITLE
New Heritrix status for SSLHandshakeException

### DIFF
--- a/modules/src/main/java/org/archive/modules/CrawlURI.java
+++ b/modules/src/main/java/org/archive/modules/CrawlURI.java
@@ -396,6 +396,8 @@ implements Reporter, Serializable, OverlayContext, Comparable<CrawlURI> {
             case S_PROCESSING_THREAD_KILLED:
                 return "Heritrix(" + S_PROCESSING_THREAD_KILLED + ")-" +
                     "Processing thread killed";
+            case S_SSL_ERROR:
+                return "Heritrix(" + S_SSL_ERROR + ")-SSL error";
             // Unknown return code
             default : return Integer.toString(code);
         }

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchHTTP.java
@@ -25,6 +25,7 @@ import static org.archive.modules.fetcher.FetchStatusCodes.S_CONNECT_FAILED;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_CONNECT_LOST;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_DOMAIN_PREREQUISITE_FAILURE;
 import static org.archive.modules.fetcher.FetchStatusCodes.S_UNFETCHABLE_URI;
+import static org.archive.modules.fetcher.FetchStatusCodes.S_SSL_ERROR;
 import static org.archive.modules.recrawl.RecrawlAttributeConstants.A_REFERENCE_LENGTH;
 
 import java.io.IOException;
@@ -42,9 +43,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManager;
 
-import org.archive.url.URIException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -82,6 +83,7 @@ import org.archive.modules.deciderules.DecideRule;
 import org.archive.modules.net.CrawlHost;
 import org.archive.modules.net.CrawlServer;
 import org.archive.modules.net.ServerCache;
+import org.archive.url.URIException;
 import org.archive.util.Recorder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.Lifecycle;
@@ -680,6 +682,9 @@ public class FetchHTTP extends Processor implements Lifecycle {
             addResponseContent(response, curi);
         } catch (ClientProtocolException e) {
             failedExecuteCleanup(curi, e);
+            return;
+        } catch (SSLHandshakeException e) {
+            cleanup(curi, e, "executeMethod", S_SSL_ERROR);
             return;
         } catch (IOException e) {
             if ("handshake alert:  unrecognized_name".equals(e.getMessage())) {

--- a/modules/src/main/java/org/archive/modules/fetcher/FetchStatusCodes.java
+++ b/modules/src/main/java/org/archive/modules/fetcher/FetchStatusCodes.java
@@ -49,6 +49,8 @@ public interface FetchStatusCodes {
     public static final int S_UNFETCHABLE_URI = -7;      //
     /** multiple retries all failed */
     public static final int S_TOO_MANY_RETRIES = -8;     //
+    /** SSL error such as SSL handshake failure */
+    public static final int S_SSL_ERROR = -9;     //
 
     /** temporary status assigned URIs awaiting preconditions; appearance in
      *  logs is a bug */

--- a/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
+++ b/modules/src/test/java/org/archive/modules/fetcher/FetchHTTPTest.java
@@ -728,7 +728,7 @@ public class FetchHTTPTest {
         fetcher().process(curi);
         assertEquals(1, curi.getNonFatalFailures().size());
         assertTrue(curi.getNonFatalFailures().toArray()[0] instanceof SSLException);
-        assertEquals(FetchStatusCodes.S_CONNECT_FAILED, curi.getFetchStatus());
+        assertEquals(FetchStatusCodes.S_SSL_ERROR, curi.getFetchStatus());
         assertEquals(0, curi.getFetchCompletedTime());
     }
 


### PR DESCRIPTION
Related to issue #752 
To prevent Heritrix to retry uselessly crawling website that throws SSLHandshakeException, a new Heritrix status code has been created: -9 SSL_ERROR.

The documentation needs to be revised  (to add the -9 status code)  but I don't know were to add the changes: https://heritrix.readthedocs.io/en/latest/glossary.html#status-codes